### PR TITLE
add event for admin when messages between usager and entreprise

### DIFF
--- a/src/DataFixtures/Files/Signalement.yml
+++ b/src/DataFixtures/Files/Signalement.yml
@@ -2,6 +2,7 @@ signalements:
 -
   entreprise: "00000001-0001-0000-0000-000000000000"
   uuid: "00000001-0001-0000-0000-000000000000"
+  uuid_public: "aaabbb111"
   adresse: "18 Avenue De La Republique"
   code_postal: "13002"
   ville: "Marseille"
@@ -18,6 +19,7 @@ signalements:
 -
   entreprise: "00000001-0001-0000-0000-000000000000"
   uuid: "00000001-0002-0000-0000-000000000000"
+  uuid_public: "aaabbb112"
   adresse: "19 Avenue De La Republique"
   code_postal: "13002"
   ville: "Marseille"
@@ -34,6 +36,7 @@ signalements:
 -
   entreprise: "00000001-0001-0000-0000-000000000000"
   uuid: "00000001-0003-0000-0000-000000000000"
+  uuid_public: "aaabbb113"
   adresse: "20 Avenue De La Republique"
   code_postal: "13002"
   ville: "Marseille"
@@ -50,6 +53,7 @@ signalements:
 -
   entreprise: "00000001-0002-0000-0000-000000000000"
   uuid: "00000001-0004-0000-0000-000000000000"
+  uuid_public: "aaabbb114"
   adresse: "21 Avenue De La Republique"
   code_postal: "13002"
   ville: "Marseille"
@@ -66,6 +70,7 @@ signalements:
 -
   entreprise: "00000001-0002-0000-0000-000000000000"
   uuid: "00000001-0005-0000-0000-000000000000"
+  uuid_public: "aaabbb115"
   adresse: "22 Avenue De La Republique"
   code_postal: "13002"
   ville: "Marseille"
@@ -82,6 +87,7 @@ signalements:
 -
   entreprise: "00000001-0003-0000-0000-000000000000"
   uuid: "00000001-0006-0000-0000-000000000000"
+  uuid_public: "aaabbb116"
   adresse: "23 Avenue De La Republique"
   code_postal: "13002"
   ville: "Marseille"
@@ -97,6 +103,7 @@ signalements:
   territoire: "13"
 -
   uuid: "00000001-0001-0001-0000-000000000000"
+  uuid_public: "aaaccc111"
   adresse: "24 Avenue De La Republique"
   code_postal: "13002"
   ville: "Marseille"
@@ -112,6 +119,7 @@ signalements:
   territoire: "13"
 -
   uuid: "00000001-0001-0001-0001-000000000000"
+  uuid_public: "aaaccc112"
   adresse: "24 Avenue De La Republique"
   code_postal: "44001"
   ville: "Nantes"

--- a/src/DataFixtures/Loader/LoadSignalementData.php
+++ b/src/DataFixtures/Loader/LoadSignalementData.php
@@ -37,6 +37,7 @@ class LoadSignalementData extends Fixture implements OrderedFixtureInterface
 
         $signalement = (new Signalement())
             ->setUuid($row['uuid'])
+            ->setUuidPublic($row['uuid_public'])
             ->setAdresse($row['adresse'])
             ->setCodePostal($row['code_postal'])
             ->setVille($row['ville'])

--- a/src/EventSubscriber/MessageAddedSubscriber.php
+++ b/src/EventSubscriber/MessageAddedSubscriber.php
@@ -35,6 +35,11 @@ class MessageAddedSubscriber implements EventSubscriberInterface
         $entrepriseName = $entreprise->getNom();
         $entrepriseEmail = $entreprise->getUser()->getEmail();
 
+        $link = $this->urlGenerator->generate('app_suivi_usager_view_messages_thread', [
+            'signalement_uuid' => $signalement->getUuid(),
+            'thread_uuid' => $messageThread->getUuid(),
+        ]);
+
         if (null === $messageAddedEvent->getUser()) {
             $this->mailerProvider->sendNotificationToEntreprise($signalement, $entrepriseEmail);
             $this->eventManager->createEventMessage(
@@ -42,6 +47,14 @@ class MessageAddedSubscriber implements EventSubscriberInterface
                 title: sprintf('Messages avec %s', $entrepriseName),
                 description: sprintf('L\'entreprise %s va vous contacter.', $entrepriseName),
                 recipient: $signalement->getEmailOccupant(),
+            );
+            $this->eventManager->createEventMessage(
+                messageThread: $messageThread,
+                title: sprintf('Messages avec %s', $entrepriseName),
+                description: sprintf('Echanges avec %s.', $entrepriseName),
+                recipient: $signalement->getEmailOccupant(),
+                userId: Event::USER_ADMIN,
+                actionLink: $link,
             );
             $this->eventManager->createEventMessage(
                 messageThread: $messageThread,
@@ -54,16 +67,19 @@ class MessageAddedSubscriber implements EventSubscriberInterface
         } else {
             $this->mailerProvider->sendNotificationToUsager($signalement, $entrepriseName);
 
-            $link = $this->urlGenerator->generate('app_suivi_usager_view_messages_thread', [
-                'signalement_uuid' => $signalement->getUuid(),
-                'thread_uuid' => $messageThread->getUuid(),
-            ]);
-
             $this->eventManager->createEventMessage(
                 messageThread: $messageThread,
                 title: sprintf('Messages avec %s', $entrepriseName),
                 description: sprintf('Vos échanges avec %s.', $entrepriseName),
                 recipient: $signalement->getEmailOccupant(),
+                actionLink: $link,
+            );
+            $this->eventManager->createEventMessage(
+                messageThread: $messageThread,
+                title: sprintf('Messages avec %s', $entrepriseName),
+                description: sprintf('Echanges avec %s.', $entrepriseName),
+                recipient: $signalement->getEmailOccupant(),
+                userId: Event::USER_ADMIN,
                 actionLink: $link,
             );
 

--- a/src/EventSubscriber/MessageAddedSubscriber.php
+++ b/src/EventSubscriber/MessageAddedSubscriber.php
@@ -52,7 +52,7 @@ class MessageAddedSubscriber implements EventSubscriberInterface
                 messageThread: $messageThread,
                 title: sprintf('Messages avec %s', $entrepriseName),
                 description: sprintf('Echanges avec %s.', $entrepriseName),
-                recipient: $signalement->getEmailOccupant(),
+                recipient: null,
                 userId: Event::USER_ADMIN,
                 actionLink: $link,
             );
@@ -78,7 +78,7 @@ class MessageAddedSubscriber implements EventSubscriberInterface
                 messageThread: $messageThread,
                 title: sprintf('Messages avec %s', $entrepriseName),
                 description: sprintf('Echanges avec %s.', $entrepriseName),
-                recipient: $signalement->getEmailOccupant(),
+                recipient: null,
                 userId: Event::USER_ADMIN,
                 actionLink: $link,
             );

--- a/src/Manager/EventManager.php
+++ b/src/Manager/EventManager.php
@@ -153,7 +153,7 @@ class EventManager extends AbstractManager
         MessageThread $messageThread,
         string $title,
         string $description,
-        string $recipient,
+        ?string $recipient,
         ?int $userId = null,
         ?string $actionLink = null
     ): Event {


### PR DESCRIPTION
Lié à https://github.com/MTES-MCT/stop-punaises/issues/262

Quand il y a des échanges de messages, il faut un événement pour l'usager, pour l'entreprise et pour l'admin