### PR TITLE
Correction parcours quand on saisit un territoire inactif

### DIFF
--- a/assets/controllers/form_signalement_front.js
+++ b/assets/controllers/form_signalement_front.js
@@ -277,6 +277,14 @@ class PunaisesFrontSignalementController {
       $('.search-address .fr-error-text').addClass('fr-hidden');
     }
     
+    // Re-vérification code postal
+    if (canGoNext) {
+      let inputContent = $('input#signalement_front_codePostal').val();
+      let zipCode = inputContent.substring(0, 2);
+      self.isTerritoryOpen = (self.OPEN_TERRITORIES.indexOf(zipCode) > -1);
+      self.step = 1;
+    }
+    
     return canGoNext;
   }
 


### PR DESCRIPTION
### Test

- [ ] `npm run watch`
- [ ] Saisir un code postal du 13 dans le premier formulaire puis une adresse dans un autre département, et vérifier qu'on est redirigé vers l'écran qui dit que ça n'existe pas encore