### PR TITLE
Bloquer le passage pour les pros pour les signalements sur les logements sociaux

### DIFF
--- a/templates/front_suivi_usager/index.html.twig
+++ b/templates/front_suivi_usager/index.html.twig
@@ -55,7 +55,7 @@
                 </div>
 
                 <div class="fr-col fr-col-12 fr-col-lg-6 fr-mb-3v">
-                    {% if signalement.autotraitement and signalement.territoire.active %}
+                    {% if signalement.autotraitement and signalement.territoire.active and not signalement.logementSocial %}
                         <form action="{{ path('app_signalement_switch_pro', {'uuid': signalement.uuid }) }}" method="POST" class="fr-mb-3v">
                             <input type="hidden" name="_csrf_token" value="{{ csrf_token('signalement_switch_pro') }}">
                             <button class="fr-btn fr-btn--icon-left fr-icon-check-line color-check">Trouver une entreprise labellisée</button>


### PR DESCRIPTION
Fix for : https://github.com/MTES-MCT/stop-punaises/issues/289

### Test

- [ ] Créer un signalement qui est dans un logement social et vérifier que le bouton pour passer avec un pro n'apparait pas pour les usagers