### PR TITLE
Correction de l'erreur Sentry sur le niveau d'infestation null

### DIFF
--- a/src/Controller/Front/SuiviUsagerViewController.php
+++ b/src/Controller/Front/SuiviUsagerViewController.php
@@ -60,7 +60,7 @@ class SuiviUsagerViewController extends AbstractController
         return $this->render('front_suivi_usager/index.html.twig', [
             'signalement' => $signalement,
             'link_pdf' => $this->getParameter('base_url').'/build/'.$docFile,
-            'niveau_infestation' => InfestationLevel::from($signalement->getNiveauInfestation())->label(),
+            'niveau_infestation' => $signalement->getNiveauInfestation() ? InfestationLevel::from($signalement->getNiveauInfestation())->label() : 'Non déterminée',
             'events' => $events,
             'accepted_interventions' => $acceptedInterventions,
             'accepted_estimations' => $interventionsAcceptedByUsager,


### PR DESCRIPTION
## Ticket

#294    

## Description
Correction de l'erreur Sentry sur le niveau d'infestation null

## Tests
- [ ] Créer un signalement hors territoire accepté (donc avec un niveau d'infestation non défini) et vérifier que le signalement s'affiche toujours côté usager (et sans erreur Sentry)
- [ ] Créer un signalement dans le 13 et vérifier que le signalement s'affiche toujours côté usager avec le bon niveau d'infestation
