### PR TITLE
Correction des statuts de signalement dans la liste BO pour les admins

### DIFF
--- a/templates/common/components/signalement-procedure.html.twig
+++ b/templates/common/components/signalement-procedure.html.twig
@@ -9,28 +9,41 @@
 {% else %}
     {% set procedure = {'caption': 'Réception', 'percent': 5} %}
     {% if (signalement.interventions|length > 0) %}
+        {% set procedure = {'caption': 'Contact usager', 'percent': 20} %}
+
         {% if signalement.typeIntervention %}
             {% set procedure = {'caption': 'Intervention faite', 'percent': 80} %}
         {% elseif signalement.resolvedAt %}
             {% set procedure = {'caption': 'Confirmation usager', 'percent': 100} %}
 
         {% else %}
+            {% set isPendingEstimation = false %}
+            {% set isSentWithoutAnswer = false %}
             {% set isAccepted = false %}
+            {% set isRefused = false %}
             {% for intervention in signalement.interventions %}
-                {% if procedure.percent < 20 %}
-                    {% set procedure = {'caption': 'Contact usager', 'percent': 20} %}
-                {% endif %}
-                {% if intervention.estimationSentAt and procedure.percent < 40 %}
-                    {% set procedure = {'caption': 'Estimation envoyée', 'percent': 40} %}
-                {% endif %}
-                {% if intervention.acceptedByUsager %}
-                    {% set isAccepted = true %}
-                    {% set procedure = {'caption': 'Estimation acceptée', 'percent': 60} %}
-                {% endif %}
-                {% if intervention.acceptedByUsager is same as false and procedure.percent < 60 and not isAccepted %}
-                    {% set procedure = {'caption': 'Estimation refusée', 'percent': 100} %}
+                {% if intervention.estimationSentAt %}
+                    {% if intervention.acceptedByUsager is same as false %}
+                        {% set isRefused = true %}
+                    {% elseif intervention.acceptedByUsager is same as true %}
+                        {% set isAccepted = true %}
+                    {% else %}
+                        {% set isSentWithoutAnswer = true %}
+                    {% endif %}
+                {% else %}
+                    {% set isPendingEstimation = true %}
                 {% endif %}
             {% endfor %}
+
+            {% if isAccepted %}
+                {% set procedure = {'caption': 'Estimation acceptée', 'percent': 60} %}
+            {% elseif isSentWithoutAnswer %}
+                {% set procedure = {'caption': 'Estimation envoyée', 'percent': 40} %}
+            {% elseif isPendingEstimation %}
+                {% set procedure = {'caption': 'Contact usager', 'percent': 20} %}
+            {% elseif isRefused %}
+                {% set procedure = {'caption': 'Estimation refusée', 'percent': 100} %}
+            {% endif %}
         {% endif %}
     {% endif %}
 

--- a/templates/common/components/signalement-procedure.html.twig
+++ b/templates/common/components/signalement-procedure.html.twig
@@ -8,28 +8,30 @@
 
 {% else %}
     {% set procedure = {'caption': 'Réception', 'percent': 5} %}
-    {% if (signalement.interventions) %}
+    {% if (signalement.interventions|length > 0) %}
         {% if signalement.typeIntervention %}
             {% set procedure = {'caption': 'Intervention faite', 'percent': 80} %}
-        {% endif %}
-        {% if signalement.resolvedAt %}
+        {% elseif signalement.resolvedAt %}
             {% set procedure = {'caption': 'Confirmation usager', 'percent': 100} %}
-        {% endif %}
 
-        {% for intervention in signalement.interventions %}
-            {% if procedure.percent < 20 %}
-                {% set procedure = {'caption': 'Contact usager', 'percent': 20} %}
-            {% endif %}
-            {% if intervention.estimationSentAt and procedure.percent < 40 %}
-                {% set procedure = {'caption': 'Estimation envoyée', 'percent': 40} %}
-            {% endif %}
-            {% if intervention.acceptedByUsager and procedure.percent < 60 %}
-                {% set procedure = {'caption': 'Estimation acceptée', 'percent': 60} %}
-            {% endif %}
-            {% if intervention.acceptedByUsager is same as false and procedure.percent < 60 %}
-                {% set procedure = {'caption': 'Estimation refusée', 'percent': 100} %}
-            {% endif %}
-        {% endfor %}
+        {% else %}
+            {% set isAccepted = false %}
+            {% for intervention in signalement.interventions %}
+                {% if procedure.percent < 20 %}
+                    {% set procedure = {'caption': 'Contact usager', 'percent': 20} %}
+                {% endif %}
+                {% if intervention.estimationSentAt and procedure.percent < 40 %}
+                    {% set procedure = {'caption': 'Estimation envoyée', 'percent': 40} %}
+                {% endif %}
+                {% if intervention.acceptedByUsager %}
+                    {% set isAccepted = true %}
+                    {% set procedure = {'caption': 'Estimation acceptée', 'percent': 60} %}
+                {% endif %}
+                {% if intervention.acceptedByUsager is same as false and procedure.percent < 60 and not isAccepted %}
+                    {% set procedure = {'caption': 'Estimation refusée', 'percent': 100} %}
+                {% endif %}
+            {% endfor %}
+        {% endif %}
     {% endif %}
 
 {% endif %}


### PR DESCRIPTION
## Ticket

#291  

## Description
Correction des statuts de signalement dans la liste BO pour les admins

## Tests
- [ ] Créer 2/3 signalements dans le 13
- [ ] Se connecter en admin dans un navigateur pour voir l'évolution des différents statuts
- [ ] Se connecter en entreprise en navigation privée (ou autre navigateur) et accepter / refuser des signalements / envoyer des estimations pour voir si l'affichage correspond
- [ ] Avec un des navigateurs, aller sur l'url publique (récupérée dans Mailcatcher) pour faire des actions usager et vérifier le comportement dans la liste admin
