### PR TITLE
Ouverture automatique de modales de résolution de problème

### DIFF
--- a/src/Repository/InterventionRepository.php
+++ b/src/Repository/InterventionRepository.php
@@ -77,10 +77,10 @@ class InterventionRepository extends ServiceEntityRepository
 
     public function findToNotify(): array
     {
-        return $this->createQueryBuilder('s')
-            ->where('s.reminderResolvedByEntrepriseAt IS NULL')
-            ->andWhere('s.resolvedByEntrepriseAt IS NOT NULL')
-            ->andWhere('datediff(CURRENT_DATE(), s.resolvedByEntrepriseAt) > :nb_days_before_notifying')
+        return $this->createQueryBuilder('i')
+            ->where('i.reminderResolvedByEntrepriseAt IS NULL')
+            ->andWhere('i.resolvedByEntrepriseAt IS NOT NULL')
+            ->andWhere('datediff(CURRENT_DATE(), i.resolvedByEntrepriseAt) > :nb_days_before_notifying')
                 ->setParameter('nb_days_before_notifying', self::NB_DAYS_BEFORE_NOTIFYING)
             ->getQuery()
             ->getResult();

--- a/templates/common/components/signalement-detail-evenements.html.twig
+++ b/templates/common/components/signalement-detail-evenements.html.twig
@@ -18,7 +18,7 @@
                 {% set modalToOpen = event.actionLink[12:] %}
             {% endif %}
             <div class="event-item-action fr-mt-3v">
-                <a href="#" class="info" data-fr-opened="false" aria-controls="fr-modal-{{ modalToOpen }}">{{ event.actionLabel }}</a>
+                <a href="#" class="info" data-fr-opened="{% if modalToOpen is same as 'probleme-resolu' or modalToOpen is same as 'probleme-resolu-pro' %}true{% else %}false{% endif %}" aria-controls="fr-modal-{{ modalToOpen }}">{{ event.actionLabel }}</a>
             </div>
         {% elseif event.actionLink is defined and event.actionLink is not null %}
             {% if 'link-send-message' == event.actionLink %}

--- a/templates/front_suivi_usager/index.html.twig
+++ b/templates/front_suivi_usager/index.html.twig
@@ -12,8 +12,10 @@
     {% include "front_suivi_usager/modal-estimation-accepted.html.twig" %}
 {% endif %}
 
-{% include "front_suivi_usager/modal-probleme-resolu.html.twig" %}
-{% if intervention_accepted_by_usager and intervention_accepted_by_usager.resolvedByEntrepriseAt %}
+{% if signalement.autotraitement and signalement.reminderAutotraitementAt %}
+    {% include "front_suivi_usager/modal-probleme-resolu.html.twig" %}
+{% endif %}
+{% if not signalement.autotraitement and intervention_accepted_by_usager and intervention_accepted_by_usager.reminderResolvedByEntrepriseAt %}
     {% include "front_suivi_usager/modal-probleme-resolu-pro.html.twig" %}
 {% endif %}
 


### PR DESCRIPTION
## Ticket

#296 

## Description
Ouverture automatique des modales dans la page usager après réception notification de résolution de problème

## Tests
### Pro
Faire le parcours d'un signalement jusqu'à ce qu'une entreprise déclare le problème résolu
- [ ] Vérifier qu'aucune modale ne s'ouvre automatiquement pendant le parcours

Changer la date de résolution en bas de données (donnée `Intervention`, champ `resolved_by_entreprise_at`)
Jouer la commande d'envoi de notifications de rappel `make console app="send-reminders"`
- [ ] Vérifier que la modale s'ouvre automatiquement quand l'usager arrive sur la page

### Auto-traitement
Faire le parcours d'un signalement en auto-traitement
- [ ] Vérifier qu'aucune modale ne s'ouvre automatiquement pendant le parcours

Changer la date de création du signalement (donnée `Signalement`, champ `created_at`)
Jouer la commande d'envoi de notifications de rappel `make console app="send-reminders"`
- [ ] Vérifier que la modale s'ouvre automatiquement quand l'usager arrive sur la page
