### PR TITLE
Correction du double affichage d'icone de calendrier

### DIFF
--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -1,3 +1,7 @@
+.fr-input[type="date"] {
+    --data-uri-svg: none;
+}
+
 span.niveau-infestation {
     display: inline-block;
     padding: 5px 10px;


### PR DESCRIPTION
## Ticket

#301    

## Description
Correction du double affichage d'icone de calendrier sur les champ fr-input de type date

## Tests
`npm run watch`
- [ ] Vérifier qu'il y a bien une icone (et une seule) sur les champs de date (ex : quand une entreprise crée un signalement "historique")
