### PR TITLE
Initialiser les données de localisation (longitude, latitude) pour les signalements : données en base et migration

### DIFF
--- a/assets/controllers/component_search_address.js
+++ b/assets/controllers/component_search_address.js
@@ -36,11 +36,15 @@ function initSearchAddress() {
             let adressePostCode = feature.properties.postcode;
             let adresseCity = feature.properties.city;
             let adresseCityCode = feature.properties.citycode;
+            let adresseGeolocLat = feature.geometry.coordinates[1];
+            let adresseGeolocLng = feature.geometry.coordinates[0];
             let elementData = '';
             elementData += ' data-name="'+adresseName+'"';
             elementData += ' data-postcode="'+adressePostCode+'"';
             elementData += ' data-city="'+adresseCity+'"';
             elementData += ' data-citycode="'+adresseCityCode+'"';
+            elementData += ' data-geoloclat="'+adresseGeolocLat+'"';
+            elementData += ' data-geoloclng="'+adresseGeolocLng+'"';
             $('#rechercheAdresseListe').append( '<div '+elementData+' class="fr-mb-1v fr-p-1v">'+adresseLabel+'</div>' );
             $('#rechercheAdresseListe').show();
             $('#rechercheAdresseIcon .fr-icon-timer-line').hide();
@@ -52,6 +56,8 @@ function initSearchAddress() {
               $('#' + formPrefix + '_codePostal').val($(this).data('postcode'));
               $('#' + formPrefix + '_ville').val($(this).data('city'));
               $('#' + formPrefix + '_codeInsee').val($(this).data('citycode'));
+              let geoloc = $(this).data('geoloclat')+'|'+ $(this).data('geoloclng');
+              $('#' + formPrefix + '_geoloc').val(geoloc);
               $('#rechercheAdresseListe').hide();
               if ($('.address-fields').length > 0) {
                 $('.address-fields').removeClass('fr-hidden');

--- a/cypress/e2e/signalement-add-scenarii.cy.js
+++ b/cypress/e2e/signalement-add-scenarii.cy.js
@@ -3,6 +3,9 @@ import '../support/before'
 import '../src/front/front-page-code-postal-refused.cy'
 
 import '../src/front/front-page-code-postal.cy'
+
+import '../src/front/front-signalement-geoloc.cy'
+
 import '../src/front/front-signalement-logement-social.cy'
 
 import '../src/front/front-signalement-result-0.cy'

--- a/cypress/fixtures/user.json
+++ b/cypress/fixtures/user.json
@@ -6,5 +6,6 @@
   "address": "5 rue d'Italie",
   "codepostal": "13006",
   "codepostalRefused": "44006",
-  "city": "Marseille"
+  "city": "Marseille",
+  "geoloc": "43.29058|5.381724"
 }

--- a/cypress/src/front/front-signalement-geoloc.cy.js
+++ b/cypress/src/front/front-signalement-geoloc.cy.js
@@ -1,0 +1,22 @@
+import user from '../../fixtures/user.json'
+
+describe('Post front signalement check geoloc', { testIsolation: false }, () => {
+  it ('Get geoloc information', () => {
+    cy.visit('http://localhost:8090/')
+    cy.get('#code-postal').type(user.codepostal+user.codepostal)
+    cy.get('.btn-next').click()
+    cy.wait(1000)
+    cy.get('section.current-step .btn-next').click()
+    cy.wait(300)
+    cy.get('#signalement_front_typeLogement_1').click()
+    cy.get('#signalement_front_superficie').type(45)
+    cy.get('#rechercheAdresse').type(user.address)
+    cy.wait(300)
+
+    cy.get('#rechercheAdresseListe .fr-mb-1v').first().click()
+    cy.wait(300)
+
+    cy.get('#signalement_front_geoloc').should('have.value',user.geoloc)
+  })
+
+})

--- a/migrations/Version20230609122239.php
+++ b/migrations/Version20230609122239.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20230609122239 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add geoloc for signalement';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE signalement ADD geoloc JSON NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE signalement DROP geoloc');
+    }
+}

--- a/src/Command/GeolocateCommand.php
+++ b/src/Command/GeolocateCommand.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Command;
+
+use App\Entity\Signalement;
+use Doctrine\ORM\EntityManagerInterface;
+use GuzzleHttp\Client;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class GeolocateCommand extends Command
+{
+    protected static $defaultName = 'app:geolocate';
+
+    private EntityManagerInterface $entityManager;
+    private Client $httpClient;
+
+    public function __construct(EntityManagerInterface $entityManager)
+    {
+        parent::__construct();
+        $this->entityManager = $entityManager;
+        $this->httpClient = new Client();
+    }
+
+    protected function configure()
+    {
+        $this->setDescription('Geolocates existing addresses and updates the geolocation coordinates');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $signalements = $this->entityManager->getRepository(Signalement::class)->findAll();
+
+        foreach ($signalements as $signalement) {
+            $address = $signalement->getAdresse();
+            $postalCode = $signalement->getCodePostal();
+            $city = $signalement->getVille();
+
+            // Compose the address string to be used in the geocoding API request
+            $fullAddress = $address.', '.$postalCode.' '.$city;
+
+            // Make the API request to geocode the address
+            $response = $this->httpClient->request('GET', 'https://api-adresse.data.gouv.fr/search', [
+                'query' => [
+                    'q' => $fullAddress,
+                    'limit' => 1,
+                ],
+            ]);
+
+            $data = json_decode($response->getBody(), true);
+
+            if (!empty($data['features'][0]['geometry']['coordinates'])) {
+                $coordinates = [
+                    'lat' => (string) ($data['features'][0]['geometry']['coordinates'][1]),
+                    'lng' => (string) ($data['features'][0]['geometry']['coordinates'][0]),
+                ];
+
+                // Update the geolocation coordinates in the signalement entity
+                $signalement->setGeoloc($coordinates);
+                // $signalement->setGeoloc(json_encode($coordinates));
+
+                $this->entityManager->persist($signalement);
+                $this->entityManager->flush();
+
+                $output->writeln('Geolocation updated for Signalement ID: '.$signalement->getId());
+            } else {
+                $output->writeln('Geolocation not found for Signalement ID: '.$signalement->getId());
+            }
+        }
+
+        $output->writeln('Geolocation process completed.');
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Command/GeolocateCommand.php
+++ b/src/Command/GeolocateCommand.php
@@ -4,23 +4,21 @@ namespace App\Command;
 
 use App\Entity\Signalement;
 use Doctrine\ORM\EntityManagerInterface;
-use GuzzleHttp\Client;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 class GeolocateCommand extends Command
 {
     protected static $defaultName = 'app:geolocate';
 
-    private EntityManagerInterface $entityManager;
-    private Client $httpClient;
-
-    public function __construct(EntityManagerInterface $entityManager)
-    {
+    public function __construct(
+        private readonly HttpClientInterface $client,
+        private EntityManagerInterface $entityManager
+    ) {
         parent::__construct();
-        $this->entityManager = $entityManager;
-        $this->httpClient = new Client();
     }
 
     protected function configure()
@@ -40,31 +38,44 @@ class GeolocateCommand extends Command
             // Compose the address string to be used in the geocoding API request
             $fullAddress = $address.', '.$postalCode.' '.$city;
 
-            // Make the API request to geocode the address
-            $response = $this->httpClient->request('GET', 'https://api-adresse.data.gouv.fr/search', [
-                'query' => [
-                    'q' => $fullAddress,
-                    'limit' => 1,
-                ],
-            ]);
+            $statusCode = Response::HTTP_SERVICE_UNAVAILABLE;
+            try {
+                // Make the API request to geocode the address
+                $response = $this->client->request('GET', 'https://api-adresse.data.gouv.fr/search', [
+                    'query' => [
+                        'q' => $fullAddress,
+                        'limit' => 1,
+                    ],
+                ]);
 
-            $data = json_decode($response->getBody(), true);
+                $statusCode = $response->getStatusCode();
+                if (200 === $statusCode) {
+                    $data = json_decode($response->getContent(), true);
 
-            if (!empty($data['features'][0]['geometry']['coordinates'])) {
-                $coordinates = [
-                    'lat' => (string) $data['features'][0]['geometry']['coordinates'][1],
-                    'lng' => (string) $data['features'][0]['geometry']['coordinates'][0],
-                ];
+                    if (!empty($data['features'][0]['geometry']['coordinates'])) {
+                        $coordinates = [
+                            'lat' => (string) $data['features'][0]['geometry']['coordinates'][1],
+                            'lng' => (string) $data['features'][0]['geometry']['coordinates'][0],
+                        ];
 
-                // Update the geolocation coordinates in the signalement entity
-                $signalement->setGeoloc($coordinates);
+                        // Update the geolocation coordinates in the signalement entity
+                        $signalement->setGeoloc($coordinates);
 
-                $this->entityManager->persist($signalement);
-                $this->entityManager->flush();
+                        $this->entityManager->persist($signalement);
+                        $this->entityManager->flush();
 
-                $output->writeln('Geolocation updated for Signalement ID: '.$signalement->getId());
-            } else {
-                $output->writeln('Geolocation not found for Signalement ID: '.$signalement->getId());
+                        $output->writeln('Geolocation updated for Signalement ID: '.$signalement->getId());
+                    } else {
+                        $output->writeln('Geolocation not found for Signalement ID: '.$signalement->getId());
+                    }
+                } else {
+                    $output->writeln('Geolocation request failed for Signalement ID: '.$signalement->getId()
+                    .' statusCode = '.$statusCode);
+                }
+            } catch (\Throwable $exception) {
+                $output->writeln('Exception for Signalement ID: '.$signalement->getId()
+                .' statusCode = '.$statusCode
+                .' message = '.$exception->getMessage());
             }
         }
 

--- a/src/Command/GeolocateCommand.php
+++ b/src/Command/GeolocateCommand.php
@@ -52,13 +52,12 @@ class GeolocateCommand extends Command
 
             if (!empty($data['features'][0]['geometry']['coordinates'])) {
                 $coordinates = [
-                    'lat' => (string) ($data['features'][0]['geometry']['coordinates'][1]),
-                    'lng' => (string) ($data['features'][0]['geometry']['coordinates'][0]),
+                    'lat' => (string) $data['features'][0]['geometry']['coordinates'][1],
+                    'lng' => (string) $data['features'][0]['geometry']['coordinates'][0],
                 ];
 
                 // Update the geolocation coordinates in the signalement entity
                 $signalement->setGeoloc($coordinates);
-                // $signalement->setGeoloc(json_encode($coordinates));
 
                 $this->entityManager->persist($signalement);
                 $this->entityManager->flush();

--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -181,6 +181,9 @@ class Signalement
     #[ORM\Column(type: Types::GUID, nullable: true)]
     private ?string $uuidPublic = null;
 
+    #[ORM\Column(type: 'json')]
+    private $geoloc = [];
+
     public function __construct()
     {
         $this->uuid = Uuid::v4();
@@ -835,6 +838,18 @@ class Signalement
     public function setUuidPublic(?string $uuidPublic): self
     {
         $this->uuidPublic = $uuidPublic;
+
+        return $this;
+    }
+
+    public function getGeoloc(): ?array
+    {
+        return $this->geoloc;
+    }
+
+    public function setGeoloc(array $geoloc): self
+    {
+        $this->geoloc = $geoloc;
 
         return $this;
     }

--- a/src/Form/SignalementFrontType.php
+++ b/src/Form/SignalementFrontType.php
@@ -4,6 +4,7 @@ namespace App\Form;
 
 use App\Entity\Signalement;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\CallbackTransformer;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
@@ -97,6 +98,12 @@ class SignalementFrontType extends AbstractType
                 ],
                 'label' => 'Ville',
                 'required' => true,
+            ])
+            ->add('geoloc', HiddenType::class, [
+                'attr' => [
+                    'class' => 'fr-hidden',
+                ],
+                'required' => false,
             ])
 
             // Step info_locataire
@@ -315,6 +322,26 @@ class SignalementFrontType extends AbstractType
                 'empty_data' => false,
             ])
         ;
+        $builder->get('geoloc')->addModelTransformer(new CallbackTransformer(
+            function ($tagsAsArray) {
+                // transform the array to a string
+                if (!empty($tagsAsArray)) {
+                    return $tagsAsArray[0].'|'.$tagsAsArray[1];
+                }
+
+                return '';
+            },
+            function ($tagsAsString) {
+                // transform the string back to an array
+                if (!empty($tagsAsString)) {
+                    $coord = explode('|', $tagsAsString);
+
+                    return ['lat' => $coord[0], 'lng' => $coord[1]];
+                }
+
+                return [];
+            }
+        ));
 
         $builder->addEventListener(FormEvents::SUBMIT, function (FormEvent $event) {
             /** @var Signalement $signalement */

--- a/src/Form/SignalementType.php
+++ b/src/Form/SignalementType.php
@@ -341,6 +341,26 @@ class SignalementType extends AbstractType
                 'required' => true,
             ])
         ;
+        $builder->get('geoloc')->addModelTransformer(new CallbackTransformer(
+            function ($tagsAsArray) {
+                // transform the array to a string
+                if (!empty($tagsAsArray)) {
+                    return $tagsAsArray[0].'|'.$tagsAsArray[1];
+                }
+
+                return '';
+            },
+            function ($tagsAsString) {
+                // transform the string back to an array
+                if (!empty($tagsAsString)) {
+                    $coord = explode('|', $tagsAsString);
+
+                    return ['lat' => $coord[0], 'lng' => $coord[1]];
+                }
+
+                return [];
+            }
+        ));
 
         $builder->get('niveauInfestation')
             ->addModelTransformer(new CallbackTransformer(

--- a/src/Form/SignalementType.php
+++ b/src/Form/SignalementType.php
@@ -76,7 +76,12 @@ class SignalementType extends AbstractType
                 'label' => 'Ville',
                 'required' => true,
             ])
-
+            ->add('geoloc', HiddenType::class, [
+                'attr' => [
+                    'class' => 'fr-hidden',
+                ],
+                'required' => false,
+            ])
             ->add('typeLogement', ChoiceType::class, [
                 'attr' => [
                     'class' => 'fr-select',

--- a/templates/front_signalement/_partial_step_info_logement.html.twig
+++ b/templates/front_signalement/_partial_step_info_logement.html.twig
@@ -82,7 +82,10 @@
                 </p>
             </div>
         </div>
-    </div>
+
+        {{ form_widget(form.geoloc) }}
+        
+   </div>
 
     {% include 'front_signalement/_partial_signalement_navigation_container.html.twig' with {'next': 'Suivant', 'previous': 'Précédent' } %}
 {% endblock %}

--- a/templates/signalement_create/tab-1.html.twig
+++ b/templates/signalement_create/tab-1.html.twig
@@ -52,6 +52,8 @@
             </div>
         </div>
 
+        {{ form_widget(form.geoloc) }}
+
         <span class="column-label">Informations complémentaires</span>
         <br>
 


### PR DESCRIPTION
## Ticket

#318    

## Description
Enregistrement de la géolocalisation pour les signalements. Première étape nécessaire pour la cartographie

## Changements apportés
* Ajout d'un champ geoloc à la table signalement
* Création d'une commande qui ajoute la géolocalisation à tous les signalements existants
* Ajout de paramètre au formulaire front pour enregistrer la localisation lors de la création d'un nouveau signalement

## Tests
- [] Jouer la commande "`symfony console app:geolocate`" et vérifier en base que les coordonnées ont bien été ajoutées aux signalements existants
- [] Créer un nouveau signalement, et vérifier en base que sa géolocalisation a bien été enregistrée
