### PR TITLE
[BO - Signalements historiques] hotfix sur la génération de référence

### DIFF
--- a/src/Command/ImportSignalementCommand.php
+++ b/src/Command/ImportSignalementCommand.php
@@ -48,6 +48,7 @@ class ImportSignalementCommand extends Command
     {
         $io = new SymfonyStyle($input, $output);
         $entrepriseUuid = $input->getArgument('entreprise_uuid');
+        /** @var Entreprise $entreprise */
         $entreprise = $this->entityManager->getRepository(Entreprise::class)->findOneBy(['uuid' => $entrepriseUuid]);
         if (null === $entreprise) {
             $io->error('Entreprise does not exist');
@@ -74,7 +75,7 @@ class ImportSignalementCommand extends Command
 
         $metadata = $this->signalementImportLoader->getMetadata();
 
-        $io->success(sprintf('%s signalement(s) have been imported', $metadata['count_signalement']));
+        $io->success(sprintf('%s signalement(s) have been imported for entreprise %s', $metadata['count_signalement'], $entreprise->getNom()));
 
         return Command::SUCCESS;
     }

--- a/src/DataFixtures/Loader/LoadSignalementData.php
+++ b/src/DataFixtures/Loader/LoadSignalementData.php
@@ -7,6 +7,7 @@ use App\Entity\Signalement;
 use App\Repository\EmployeRepository;
 use App\Repository\EntrepriseRepository;
 use App\Repository\TerritoireRepository;
+use App\Service\Signalement\ReferenceGenerator;
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
@@ -18,7 +19,8 @@ class LoadSignalementData extends Fixture implements OrderedFixtureInterface
     public function __construct(
         private EntrepriseRepository $entrepriseRepository,
         private EmployeRepository $employeRepository,
-        private TerritoireRepository $territoireRepository
+        private TerritoireRepository $territoireRepository,
+        private ReferenceGenerator $referenceGenerator,
     ) {
     }
 
@@ -58,7 +60,7 @@ class LoadSignalementData extends Fixture implements OrderedFixtureInterface
             ->setCodeInsee($row['code_insee'])
             ->setNiveauInfestation($row['niveau_infestation'])
             ->setDateIntervention(new \DateTimeImmutable())
-            ->setReference($row['reference'])
+            ->setReference($this->referenceGenerator->generate())
             ->setDeclarant(Declarant::from($row['declarant']))
             ->setTerritoire($this->territoireRepository->findOneBy(['zip' => $row['territoire']]));
 
@@ -73,6 +75,7 @@ class LoadSignalementData extends Fixture implements OrderedFixtureInterface
         }
 
         $manager->persist($signalement);
+        $manager->flush();
     }
 
     public function getOrder(): int

--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -54,9 +54,11 @@ class SignalementRepository extends ServiceEntityRepository
         return $qb->getQuery()->getOneOrNullResult();
     }
 
-    public function findLastReference(): ?array
+    public function findLastReference(?string $year = null): ?array
     {
-        $year = (new \DateTime())->format('Y');
+        if (null === $year) {
+            $year = (new \DateTime())->format('Y');
+        }
         $queryBuilder = $this->createQueryBuilder('s')
             ->select('s.reference')
             ->where('YEAR(s.createdAt) = :year')

--- a/src/Service/Signalement/ReferenceGenerator.php
+++ b/src/Service/Signalement/ReferenceGenerator.php
@@ -10,17 +10,16 @@ class ReferenceGenerator
     {
     }
 
-    public function generate(): string
+    public function generate(?string $yearIn = null): string
     {
-        $lastReference = $this->signalementRepository->findLastReference();
+        $lastReference = $this->signalementRepository->findLastReference($yearIn);
         if (!empty($lastReference)) {
             list($year, $id) = explode('-', $lastReference['reference']);
             $id = (int) $id + 1;
 
             return $year.'-'.$id;
         }
-        $year = (new \DateTime())->format('Y');
 
-        return $year.'-'. 1;
+        return $yearIn.'-'. 1;
     }
 }

--- a/src/Service/Signalement/ReferenceGenerator.php
+++ b/src/Service/Signalement/ReferenceGenerator.php
@@ -19,6 +19,9 @@ class ReferenceGenerator
 
             return $year.'-'.$id;
         }
+        if (null === $yearIn) {
+            $yearIn = (new \DateTime())->format('Y');
+        }
 
         return $yearIn.'-'. 1;
     }


### PR DESCRIPTION
## Ticket

#325   

## Description
Hotfix de la commande qui permet d'importer les signalements historiques d'une entreprise, en fonction de son uuid.
cf doc ici https://github.com/MTES-MCT/stop-punaises/wiki/Import-signalements-historiques

## Changements apportés
* Fix sur la création de référence en prenant bien l'année de création d'un signalement

## Tests
- [ ] Les 20 fichiers csv ont déjà été poussés sur le bucket
- [ ] défini la variable  d'environnement `export BUCKET_URL=dev.stop-punaises.beta.gouv.fr`
- [ ] Donc faire des tests avec les uuid suivants, et la commande `make console app="import-signalement [uuid_entreprise]"`
- [ ] Et vérifier en base et sur le site que les données sont bien importées (vérifier les totaux par entreprise, vérifier les références par rapport aux dates de création)
- 645ba1e3ccc7a 	EPUR
- 645ba4262be42 	CANEM DETECT
- 63b6c306ec8bc 	Antipesti 
- 63b6c1f37473d 	A3DS
- 63b6c29ebf3a9 	A4D Sanitation
- 645ba3835a509 	COTIERE HYGIENE ASSAINISSEMENT
- 63b6c22f88ef0 	DKM Experts
- 63bd8aa4bdf8d 	Eco flair 
- 63b6c20ec2c3e 	ELIS Pest Control 
- 645ba251e316f 	 ESIAN NUISIBLES
- 645ba299ea088 	GAME OVER PRO
- 645ba4550c379 	LA CAMDA-Rhône
- 645ba483bcd06 	MS Plus
- 645ba35297404 	NGAN 69 
- 645ba3e85de3e 	OMNYS SOLUTION 
- 63bd8a72e16ed 	Rentokil Initial 13
- 63f7636dc9304 	SAPIAN
- 645d040b814e3 	Societe Lyonnaise de Detection Canine
- 63b6c2c0d5c89 	Techmo hygiene
- 63b55480d6c78 	Stop Punaises 	Gouv 
