### PR TITLE
[BO - Cartographie] Rendre les points plus visibles sur la carte de chaleur 

### DIFF
--- a/public/js/maps.js
+++ b/public/js/maps.js
@@ -33,14 +33,14 @@ async function getMarkers(offset) {
                 // pour l'instant on ne prend pas en compte le niveauInfestation
                 // on n'affiche pas les signalements au statut resolved
                 if ('trace' === signalement.statut){
-                    heatValues.push([signalement.geoloc.lat, signalement.geoloc.lng, 0.3]);
+                    heatValues.push([signalement.geoloc.lat, signalement.geoloc.lng, 0.5]);
                 }  
                 if ('en cours' === signalement.statut){
                     heatValues.push([signalement.geoloc.lat, signalement.geoloc.lng, 1]);
                 }         
             }
         })
-        heat = L.heatLayer(heatValues, {radius: 25}).addTo(map);
+        heat = L.heatLayer(heatValues, {maxZoom:15}).addTo(map);
     } else {
         alert('Erreur lors du chargement des signalements...')
     }


### PR DESCRIPTION
## Ticket

#320    

## Description
Rendre les points plus visibles

## Changements apportés
Passage des signalements "traces" à une intensité de 0,5 au lieu de 0,3
Changement du maxZoom de la carte de chaleur qui était par défaut égal au maxZoom de la carte (donc 18), il est maintenant à 15 et il correspond au niveau de zoom auquel les points sont les plus intenses

## Tests
- [ ]  Se connecter au back-office, et vérifier que la carto fonctionne, et que le curseur temporel fonctionne également
