### PR TITLE
[FO - Signalement] Ne pas proposer de faire un appel à un pro pour les signalements dans les territoires inactifs

### DIFF
--- a/templates/front_suivi_usager/modal-toujours-punaises.html.twig
+++ b/templates/front_suivi_usager/modal-toujours-punaises.html.twig
@@ -10,17 +10,21 @@
                         <h1 id="fr-modal-title-modal-toujours-punaises" class="fr-modal__title">Vous avez toujours un problème de punaises</h1>
                         <p>
                             Vous avez indiqué avoir toujours un problème de punaises de lit.
+                            {% if signalement.territoire.active %}
                             <br>
                             Nous pouvons vous aider à trouver une entreprise labellisée pour traiter votre logement.
+                            {% endif %}
                         </p>
                         <p>
                             Que souhaitez-vous faire ?
                         </p>
                         <div>
+                            {% if signalement.territoire.active %}
                             <form action="{{ path('app_signalement_switch_pro', {'uuid': signalement.uuid }) }}" method="POST" class="fr-mb-3v">
                                 <input type="hidden" name="_csrf_token" value="{{ csrf_token('signalement_switch_pro') }}">
                                 <button class="fr-btn fr-btn--sm fr-btn--icon-left fr-icon-check-line color-check">Trouver une entreprise</button>
                             </form>
+                            {% endif %}
 
                             <form action="{{ path('app_signalement_stop', {'uuid': signalement.uuid }) }}" method="POST" class="fr-mb-3v">
                                 <input type="hidden" name="_csrf_token" value="{{ csrf_token('signalement_stop') }}">


### PR DESCRIPTION
## Ticket

#236   

## Description
Après 45 jours, les signalements qui ont opté pour l'auto-traitement reçoivent un mail de rappel pour demander où ils en sont.
Ce mail conduit à la page de suivi.
Si le problème n'est pas résolu, on proposait soit d'arrêter la procédure, soit de faire appel à un pro.
La correction consiste à masquer la partie "appel à un pro" pour les signalements sur des territoires inactifs.

## Tests
- [ ] Créer un signalement sur un territoire inactif
- [ ] Changer sa date pour qu'elle soit plus de 45 jours plus tôt
- [ ] Jouer la commande de rappel `make console app="send-reminders"`
- [ ] Aller sur la page front de suivi (`/signalements/uuid_public`) et vérifier qu'on ne peut pas faire appel à un pro : ni à travers les boutons, ni à travers les modales
- [ ] Faire le même test sur un territoire actif et vérifier que c'est toujours possible
