### PR TITLE
[FO - Signalement] Ne pas afficher la modale de demande d'information si le signalement est fermé

### DIFF
--- a/templates/front_suivi_usager/index.html.twig
+++ b/templates/front_suivi_usager/index.html.twig
@@ -12,7 +12,7 @@
     {% include "front_suivi_usager/modal-estimation-accepted.html.twig" %}
 {% endif %}
 
-{% if signalement.autotraitement and signalement.reminderAutotraitementAt %}
+{% if signalement.autotraitement and signalement.reminderAutotraitementAt and not signalement.closedAt %}
     {% include "front_suivi_usager/modal-probleme-resolu.html.twig" %}
 {% endif %}
 {% if not signalement.autotraitement and intervention_accepted_by_usager and intervention_accepted_by_usager.reminderResolvedByEntrepriseAt %}


### PR DESCRIPTION
## Ticket

#330    

## Description
A J+45, si l'usager a choisi auto-traitement, on lui demande une mise à jour par mail.
L'usager peut alors cloturer sa demande.
Une fois la demande cloturée, la modale de demande continuait à s'afficher en boucle.

## Tests
- [ ] Créer un signalement en auto-traitement (ça va plus vite si c'est hors territoire)
- [ ] Changer sa date de création en BDD pour que ce soit supérieur à 45J
- [ ] Jouer la commande de rappels : `make console app="send-reminders"`
- [ ] Aller sur le signalement (`/signalements/uuid_public`)
- [ ] Vérifier que la modale d'arrêt de procédure s'affiche
- [ ] Arrêter la procédure
- [ ] Vérifier que la modale ne s'affiche plus
