### PR TITLE
[FO - Suivi usager] Désactivation de l'accès à la page après cloture par administrateur

### DIFF
--- a/src/Controller/Front/SignalementController.php
+++ b/src/Controller/Front/SignalementController.php
@@ -54,7 +54,7 @@ class SignalementController extends AbstractController
         if ($form->isValid() && $this->isCsrfTokenValid('front-add-signalement', $submittedToken)) {
             $signalement->setReference($referenceGenerator->generate());
             $signalement->setDeclarant(Declarant::DECLARANT_OCCUPANT);
-            $signalement->setUuidPublic(uniqid());
+            $signalement->updateUuidPublic();
 
             $filesPosted = $request->files->get('file-upload');
             $filesToSave = $uploadHandlerService->handleUploadFilesRequest($filesPosted);

--- a/src/Controller/Front/SuiviUsagerViewController.php
+++ b/src/Controller/Front/SuiviUsagerViewController.php
@@ -138,7 +138,7 @@ class SuiviUsagerViewController extends AbstractController
             $this->addFlash('success', 'Votre procédure est terminée !');
 
             $signalement->setResolvedAt(new \DateTimeImmutable());
-            $signalement->setUuidPublic(uniqid());
+            $signalement->updateUuidPublic();
             $signalementManager->save($signalement);
 
             if (!$signalement->isAutotraitement()) {
@@ -189,8 +189,6 @@ class SuiviUsagerViewController extends AbstractController
         Request $request,
         Signalement $signalement,
         SignalementManager $signalementManager,
-        InterventionRepository $interventionRepository,
-        MailerProvider $mailerProvider,
         EventDispatcherInterface $eventDispatcher,
         ): Response {
         if ($this->isCsrfTokenValid('signalement_stop', $request->get('_csrf_token'))) {

--- a/src/Controller/SignalementResolveController.php
+++ b/src/Controller/SignalementResolveController.php
@@ -33,7 +33,7 @@ class SignalementResolveController extends AbstractController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $signalement->setUuidPublic(uniqid());
+            $signalement->updateUuidPublic();
             $signalementManager->save($signalement);
 
             $this->addFlash('success', 'Le traitement a été marqué comme effectué. Un email de suivi sera envoyé à l\'usager dans 30 jours.');

--- a/src/Controller/SignalementViewController.php
+++ b/src/Controller/SignalementViewController.php
@@ -244,6 +244,7 @@ class SignalementViewController extends AbstractController
         if ($this->isCsrfTokenValid('signalement_admin_stop', $request->get('_csrf_token'))) {
             $this->addFlash('success', 'La procédure est terminée !');
             $signalement->setClosedAt(new \DateTimeImmutable());
+            $signalement->updateUuidPublic();
             $signalementManager->save($signalement);
 
             $eventDispatcher->dispatch(

--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -835,6 +835,13 @@ class Signalement
         return $this->uuidPublic;
     }
 
+    public function updateUuidPublic(): self
+    {
+        $this->uuidPublic = uniqid();
+
+        return $this;
+    }
+
     public function setUuidPublic(?string $uuidPublic): self
     {
         $this->uuidPublic = $uuidPublic;

--- a/templates/front_suivi_usager/index.html.twig
+++ b/templates/front_suivi_usager/index.html.twig
@@ -4,6 +4,7 @@
 
 {% block body %}
 
+{% if signalement.closedAt is not defined %}
 {% include "front_suivi_usager/modal-empty-estimations.html.twig" %}
 {% for intervention in interventions_to_answer %}
     {% include "front_suivi_usager/modal-choice-estimation.html.twig" %}
@@ -22,6 +23,7 @@
 {% include "front_suivi_usager/modal-toujours-punaises.html.twig" %}
 {% include "front_suivi_usager/modal-toujours-punaises-pro.html.twig" %}
 {% include "front_suivi_usager/modal-close-signalement.html.twig" %}
+{% endif %}
 
 <div class="suivi-usager fr-container fr-my-3v">
 


### PR DESCRIPTION
## Ticket

#331   

## Description
Si un administrateur ferme un signalement, on change l'uuid public sans l'envoyer à l'usager pour désactiver l'accès

## Tests
- [ ] Créer un signalement dans un territoire ouvert (13)
- [ ] Récupérer l'url de suivi usager (soit avec l'uuid_public, soit avec le lien qu'on trouve dans MailCatcher)
- [ ] Dans le BO, fermer le signalement
- [ ] Aller sur le lien récupéré plus tôt : il ne fonctionne pas
