### PR TITLE
[CRON] Envoi de notifications aux entreprises 60 jours après acceptation d'estimation par l'usager

### DIFF
--- a/migrations/Version20230810133819.php
+++ b/migrations/Version20230810133819.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20230810133819 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'add reminder_pending_entreprise_conclusion date field to intervention';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE intervention ADD reminder_pending_entreprise_conclusion_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\'');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE intervention DROP reminder_pending_entreprise_conclusion_at');
+    }
+}

--- a/src/Command/SendRemindersCommand.php
+++ b/src/Command/SendRemindersCommand.php
@@ -50,7 +50,7 @@ class SendRemindersCommand extends Command
         $signalementsToNotify = $this->signalementRepository->findToNotify();
         $countSignalementsToNotify = \count($signalementsToNotify);
         foreach ($signalementsToNotify as $signalement) {
-            $this->io->success(sprintf('%s to notify',
+            $this->io->success(sprintf('Signalement id %s to notify',
                 $signalement->getUuid()
             ));
             $signalement->setReminderAutotraitementAt(new \DateTimeImmutable());
@@ -65,10 +65,10 @@ class SendRemindersCommand extends Command
             );
         }
 
-        $interventionsToNotify = $this->interventionRepository->findToNotify();
-        $countInterventionsToNotify = \count($interventionsToNotify);
-        foreach ($interventionsToNotify as $intervention) {
-            $this->io->success(sprintf('%s to notify',
+        $interventionsToNotifyUsager = $this->interventionRepository->findToNotifyUsager();
+        $countInterventionsToNotifyUsager = \count($interventionsToNotifyUsager);
+        foreach ($interventionsToNotifyUsager as $intervention) {
+            $this->io->success(sprintf('Intervention id %s to notify for usager',
                 $intervention->getId()
             ));
             $intervention->setReminderResolvedByEntrepriseAt(new \DateTimeImmutable());
@@ -83,9 +83,21 @@ class SendRemindersCommand extends Command
             );
         }
 
-        $this->io->success(sprintf('%s signalements were notified, %s interventions were notified',
+        $interventionsToNotifyPro = $this->interventionRepository->findToNotifyPro();
+        $countInterventionsToNotifyPro = \count($interventionsToNotifyPro);
+        foreach ($interventionsToNotifyPro as $intervention) {
+            $this->io->success(sprintf('Intervention id %s to notify for pro',
+                $intervention->getId()
+            ));
+            $intervention->setReminderPendingEntrepriseConclusionAt(new \DateTimeImmutable());
+            $this->interventionManager->save($intervention);
+            $this->mailerProvider->sendSignalementSuiviTraitementProForPro($intervention);
+        }
+
+        $this->io->success(sprintf('%s signalements were notified, %s interventions were notified for usager, %s interventions were notified for pro',
             $countSignalementsToNotify,
-            $countInterventionsToNotify,
+            $countInterventionsToNotifyUsager,
+            $countInterventionsToNotifyPro
         ));
 
         return Command::SUCCESS;

--- a/src/Entity/Intervention.php
+++ b/src/Entity/Intervention.php
@@ -57,6 +57,9 @@ class Intervention
     #[ORM\Column(nullable: true)]
     private ?\DateTimeImmutable $canceledByEntrepriseAt = null;
 
+    #[ORM\Column(nullable: true)]
+    private ?\DateTimeImmutable $reminderPendingEntrepriseConclusionAt = null;
+
     public function getId(): ?int
     {
         return $this->id;
@@ -214,6 +217,18 @@ class Intervention
     public function setCanceledByEntrepriseAt(?\DateTimeImmutable $canceledByEntrepriseAt): self
     {
         $this->canceledByEntrepriseAt = $canceledByEntrepriseAt;
+
+        return $this;
+    }
+
+    public function getReminderPendingEntrepriseConclusionAt(): ?\DateTimeImmutable
+    {
+        return $this->reminderPendingEntrepriseConclusionAt;
+    }
+
+    public function setReminderPendingEntrepriseConclusionAt(?\DateTimeImmutable $reminderPendingEntrepriseConclusionAt): self
+    {
+        $this->reminderPendingEntrepriseConclusionAt = $reminderPendingEntrepriseConclusionAt;
 
         return $this;
     }

--- a/src/Service/Mailer/MailerProvider.php
+++ b/src/Service/Mailer/MailerProvider.php
@@ -274,6 +274,22 @@ class MailerProvider implements MailerProviderInterface
         $this->send($message);
     }
 
+    public function sendSignalementSuiviTraitementProForPro(Intervention $intervention): void
+    {
+        $emailEntreprise = $intervention->getEntreprise()->getUser()->getEmail();
+        $signalement = $intervention->getSignalement();
+        $link = $this->urlGenerator->generate('app_signalement_view', ['uuid' => $signalement->getUuid()]);
+        $message = $this
+            ->messageFactory
+            ->createInstanceFrom(Template::SIGNALEMENT_SUIVI_TRAITEMENT_PRO_FOR_PRO, [
+                'reference' => $signalement->getReference(),
+                'link' => $link,
+            ])
+            ->setTo([$emailEntreprise]);
+
+        $this->send($message);
+    }
+
     public function sendSignalementSuiviTraitementAuto(Signalement $signalement): void
     {
         $emailOccupant = $signalement->getEmailOccupant();

--- a/src/Service/Mailer/Template.php
+++ b/src/Service/Mailer/Template.php
@@ -3,8 +3,8 @@
 namespace App\Service\Mailer;
 
 /**
- * ID related to Sendinblue Provider, you have to login et get the ID
- * https://my.sendinblue.com/camp/lists/template#active.
+ * ID related to Brevo Provider, you have to login et get the ID
+ * https://my.brevo.com/camp/lists/template.
  */
 enum Template: int
 {
@@ -21,6 +21,7 @@ enum Template: int
     case SIGNALEMENT_INTERVENTION_CANCELED = 19;
     case SIGNALEMENT_NO_MORE_ENTREPRISES = 5;
     case SIGNALEMENT_SUIVI_TRAITEMENT_PRO = 3;
+    case SIGNALEMENT_SUIVI_TRAITEMENT_PRO_FOR_PRO = 21;
     case SIGNALEMENT_SUIVI_TRAITEMENT_AUTO = 4;
     case SIGNALEMENT_TRAITEMENT_RESOLVED = 1;
     case SIGNALEMENT_TRAITEMENT_RESOLVED_FOR_PRO = 8;


### PR DESCRIPTION
## Ticket

#337    

## Description
Si une intervention est toujours en cours 60 jours après l'acceptation d'une estimation par l'usager, on envoie un notification à l'entreprise

## Changements apportés
* Ajout template
* Modification de la commande d'envoi de notifications

## Tests
- [ ] Créer un signalement dans un territoire actif (13)
- [ ] Se connecter avec un compte entreprise dans le back-office, accepter le signalement et faire une estimation
- [ ] Utiliser mail catcher pour récupérer l'url de suivi usager, se rendre sur la page et accepter l'estimation
- [ ] En BDD, changer la date d'acceptation de l'intervention pour qu'elle soit au moins 60 jours avant la date du jour
- [ ] Exécuter la commande `make console app="send-reminders"`
- [ ] Dans l'invite de commande, une notification a bien été envoyée
- [ ] Dans MailCatcher, on retrouve la notification avec le `template 21`
