### PR TITLE
[CRON] Cloture automatique des signalements en traitement pro après 30 jours d'inactivité

### DIFF
--- a/src/Command/SendRemindersCommand.php
+++ b/src/Command/SendRemindersCommand.php
@@ -137,6 +137,7 @@ class SendRemindersCommand extends Command
     private function closeSignalement(Signalement $signalement)
     {
         $signalement->setClosedAt(new \DateTimeImmutable());
+        $signalement->updateUuidPublic();
         $this->signalementManager->save($signalement);
         $this->mailerProvider->sendSignalementClosedByWebsite($signalement);
 

--- a/src/Command/SendRemindersCommand.php
+++ b/src/Command/SendRemindersCommand.php
@@ -2,11 +2,13 @@
 
 namespace App\Command;
 
+use App\Entity\Signalement;
 use App\Event\InterventionRemindedEvent;
 use App\Event\SignalementClosedEvent;
 use App\Event\SignalementRemindedEvent;
 use App\Manager\InterventionManager;
 use App\Manager\SignalementManager;
+use App\Repository\EventRepository;
 use App\Repository\InterventionRepository;
 use App\Repository\SignalementRepository;
 use App\Service\Mailer\MailerProvider;
@@ -23,6 +25,8 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 )]
 class SendRemindersCommand extends Command
 {
+    private const NB_DAYS_BEFORE_CLOSING_PRO = 30;
+
     private SymfonyStyle $io;
 
     public function __construct(
@@ -30,6 +34,7 @@ class SendRemindersCommand extends Command
         private SignalementManager $signalementManager,
         private InterventionRepository $interventionRepository,
         private InterventionManager $interventionManager,
+        private EventRepository $eventRepository,
         private MailerProvider $mailerProvider,
         private EventDispatcherInterface $eventDispatcher,
     ) {
@@ -48,15 +53,17 @@ class SendRemindersCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        $countSignalementsTraitementProToClose = $this->closeSignalementsTraitementPro();
         $countSignalementsToNotify = $this->notifySignalementsTraitementAuto();
         $countSignalementsTraitementAutoToClose = $this->closeSignalementsTraitementAuto();
         $countInterventionsToNotifyUsager = $this->notifyAskInterventionCompleteForUsager();
         $countInterventionsToNotifyPro = $this->notifyAskInterventionCompleteForPro();
 
         $this->io->success(sprintf(
-            '%s signalements were notified, %s auto-traitement signalements closed, %s interventions were notified for usager, %s interventions were notified for pro',
+            '%s signalements were notified, %s auto-traitement signalements closed, %s traitement pro signalement closed, %s interventions were notified for usager, %s interventions were notified for pro',
             $countSignalementsToNotify,
             $countSignalementsTraitementAutoToClose,
+            $countSignalementsTraitementProToClose,
             $countInterventionsToNotifyUsager,
             $countInterventionsToNotifyPro
         ));
@@ -92,23 +99,54 @@ class SendRemindersCommand extends Command
         $signalementsToClose = $this->signalementRepository->findTraitementAutoToClose();
         $countCloseSignalementsTraitementAuto = \count($signalementsToClose);
         foreach ($signalementsToClose as $signalement) {
-            $this->io->success(sprintf('Signalement id %s is closed',
+            $this->io->success(sprintf('Signalement autotraitement id %s is closed',
                 $signalement->getUuid()
             ));
-            $signalement->setClosedAt(new \DateTimeImmutable());
-            $this->signalementManager->save($signalement);
-            $this->mailerProvider->sendSignalementClosedByWebsite($signalement);
-
-            $this->eventDispatcher->dispatch(
-                new SignalementClosedEvent(
-                    signalement: $signalement,
-                    isAdminAction: true,
-                ),
-                SignalementClosedEvent::NAME
-            );
+            $this->closeSignalement($signalement);
         }
 
         return $countCloseSignalementsTraitementAuto;
+    }
+
+    private function closeSignalementsTraitementPro(): int
+    {
+        $signalementsWithNoEstimationAccepted = $this->signalementRepository->findTraitementProWithNoEstimationAccepted();
+        $countCloseSignalementsTraitementPro = 0;
+        foreach ($signalementsWithNoEstimationAccepted as $signalement_id) {
+            $todayDate = new \DateTimeImmutable();
+            $signalement = $this->signalementManager->findOneBy(['id' => $signalement_id]);
+
+            // if signalement's last event was created less than NB_DAYS_BEFORE_CLOSING_PRO days ago, we don't close
+            $usagersEvents = $this->eventRepository->findUsagerEvents($signalement->getUuid());
+            $lastEvent = \count($usagersEvents) > 0 ? $usagersEvents[0] : null;
+            $lastEventDate = $lastEvent ? $lastEvent['date'] : null;
+            if ($lastEvent && $todayDate->sub(new \DateInterval('P'.self::NB_DAYS_BEFORE_CLOSING_PRO.'D')) < $lastEventDate) {
+                continue;
+            }
+
+            ++$countCloseSignalementsTraitementPro;
+            $this->io->success(sprintf('Signalement pro id %s is closed',
+                $signalement->getUuid()
+            ));
+            $this->closeSignalement($signalement);
+        }
+
+        return $countCloseSignalementsTraitementPro;
+    }
+
+    private function closeSignalement(Signalement $signalement)
+    {
+        $signalement->setClosedAt(new \DateTimeImmutable());
+        $this->signalementManager->save($signalement);
+        $this->mailerProvider->sendSignalementClosedByWebsite($signalement);
+
+        $this->eventDispatcher->dispatch(
+            new SignalementClosedEvent(
+                signalement: $signalement,
+                isAdminAction: true,
+            ),
+            SignalementClosedEvent::NAME
+        );
     }
 
     private function notifyAskInterventionCompleteForUsager(): int


### PR DESCRIPTION
## Ticket

#336    

## Description
Cloture automatique des signalements en traitement pro après 30 jours d'inactivité

## Tests
- [ ] Créer 5 signalements avec traitement pro dans territoire ouvert (13)
  - [ ] Signalement 1 : En BDD, changer la date de dernier événement à plus de 30 jours
  - [ ] Signalement 2 : Se connecter en back-office avec entreprise, ajouter une estimation, accepter avec l'usager
  - [ ] Signalement 3 : Se connecter en back-office avec entreprise, ajouter une estimation, refuser avec l'usager
  - [ ] Signalement 4 : Se connecter en back-office avec entreprise, ajouter une estimation, ne pas répondre
  - [ ] En BDD, changer la date de tous les événements à plus de 30 jours
  - [ ] Signalement 5 : Créer et ne rien toucher
- [ ] Exécuter la commande `make console app="send-reminders"`
- [ ] Les signalements 1, 3 et 4 doivent se fermer. 
- [ ] Les signalements 2 et 5 doivent rester ouverts.
