### PR TITLE
[Suivi usager] Correction de l'affichage des modales

### DIFF
--- a/templates/front_suivi_usager/index.html.twig
+++ b/templates/front_suivi_usager/index.html.twig
@@ -4,25 +4,25 @@
 
 {% block body %}
 
-{% if signalement.closedAt is not defined %}
-{% include "front_suivi_usager/modal-empty-estimations.html.twig" %}
-{% for intervention in interventions_to_answer %}
-    {% include "front_suivi_usager/modal-choice-estimation.html.twig" %}
-{% endfor %}
-{% if intervention_accepted_by_usager %}
-    {% include "front_suivi_usager/modal-estimation-accepted.html.twig" %}
-{% endif %}
+{% if not signalement.closedAt %}
+    {% include "front_suivi_usager/modal-empty-estimations.html.twig" %}
+    {% for intervention in interventions_to_answer %}
+        {% include "front_suivi_usager/modal-choice-estimation.html.twig" %}
+    {% endfor %}
+    {% if intervention_accepted_by_usager %}
+        {% include "front_suivi_usager/modal-estimation-accepted.html.twig" %}
+    {% endif %}
 
-{% if signalement.autotraitement and signalement.reminderAutotraitementAt and not signalement.closedAt %}
-    {% include "front_suivi_usager/modal-probleme-resolu.html.twig" %}
-{% endif %}
-{% if not signalement.autotraitement and intervention_accepted_by_usager and intervention_accepted_by_usager.reminderResolvedByEntrepriseAt %}
-    {% include "front_suivi_usager/modal-probleme-resolu-pro.html.twig" %}
-{% endif %}
+    {% if signalement.autotraitement and signalement.reminderAutotraitementAt %}
+        {% include "front_suivi_usager/modal-probleme-resolu.html.twig" %}
+    {% endif %}
+    {% if not signalement.autotraitement and intervention_accepted_by_usager and intervention_accepted_by_usager.reminderResolvedByEntrepriseAt %}
+        {% include "front_suivi_usager/modal-probleme-resolu-pro.html.twig" %}
+    {% endif %}
 
-{% include "front_suivi_usager/modal-toujours-punaises.html.twig" %}
-{% include "front_suivi_usager/modal-toujours-punaises-pro.html.twig" %}
-{% include "front_suivi_usager/modal-close-signalement.html.twig" %}
+    {% include "front_suivi_usager/modal-toujours-punaises.html.twig" %}
+    {% include "front_suivi_usager/modal-toujours-punaises-pro.html.twig" %}
+    {% include "front_suivi_usager/modal-close-signalement.html.twig" %}
 {% endif %}
 
 <div class="suivi-usager fr-container fr-my-3v">


### PR DESCRIPTION
## Ticket

## Description
Correction de l'affichage des modales dans le suivi usager

## Tests
- [ ] Créer un signalement dans le 13
- [ ] Se connecter avec company-punaises-01@yopmail.com, accepter le signalement et faire une estimation
- [ ] Idem avec company-punaises-04@yopmail.com
- [ ] Aller sur la page de suivi usager et vérifier que les modales contenant les estimations s'affichent
- [ ] Se connecter en admin, fermer le signalement
- [ ] Récupérer l'id de suivi en bdd pour se rendre sur la nouvelle page de suivi, et vérifier qu'on ne peut plus ouvrir aucune modale
