### PR TITLE
[FO - Entreprises labellisées] Correction de l'affichage pour les entreprises dans les DOM

### DIFF
--- a/src/Controller/Front/EntreprisesPubliquesController.php
+++ b/src/Controller/Front/EntreprisesPubliquesController.php
@@ -27,6 +27,9 @@ class EntreprisesPubliquesController extends AbstractController
 
         $codePostal = str_pad($codePostal, 5, '0', \STR_PAD_LEFT);
         $zipCode = substr($codePostal, 0, 2);
+        if ('97' == $zipCode) {
+            $zipCode = substr($codePostal, 0, 3);
+        }
 
         $listEntreprisesPubliquesByZipCode = $entreprisePubliqueRepository->findByZipCode($zipCode, $order);
 


### PR DESCRIPTION
## Ticket

#366    

## Description
Correction de l'affichage pour les entreprises labellisées dans les DOM

## Pré-requis
`make console app="import-entreprise-publique"`

## Tests
- [ ] Vérifier que des entreprises s'affichent sur un département avec zip à 2 chiffres : http://localhost:8090/entreprises-labellisees?code-postal=92000
- [ ] Vérifier pour zip à 3 chiffres : http://localhost:8090/entreprises-labellisees?code-postal=97400
