### PR TITLE
[FO - Signalement] Ajout de test pour les signalement sur les territoires fermés

### DIFF
--- a/assets/controllers/form_signalement_front.js
+++ b/assets/controllers/form_signalement_front.js
@@ -59,7 +59,6 @@ class PunaisesFrontSignalementController {
     $('.btn-next').on('click', function(){
       if (!self.isTerritoryOpen && self.stepStr === 'info_usager') {
         if (self.checkStepInfoUsagerOpen()) {
-          console.log('ici');
           self.submitAdd();
         }
         return;

--- a/assets/controllers/form_signalement_front.js
+++ b/assets/controllers/form_signalement_front.js
@@ -58,7 +58,10 @@ class PunaisesFrontSignalementController {
     self = this;
     $('.btn-next').on('click', function(){
       if (!self.isTerritoryOpen && self.stepStr === 'info_usager') {
-        self.submitAdd();
+        if (self.checkStepInfoUsagerOpen()) {
+          console.log('ici');
+          self.submitAdd();
+        }
         return;
       }
       


### PR DESCRIPTION
## Ticket

#379    

## Description
Ajout de test pour les signalement sur les territoires fermés pour avoir des champs renseignés

## Tests
- [ ] Faire un signalement sur un territoire fermé, **ne pas** renseigner les infos, vérifier qu'on est bloqué
- [ ] Faire un signalement sur un territoire fermé, renseigner les infos, vérifier que tout s'envoie
- [ ] Faire un signalement sur un territoire ouvert, vérifier que le fonctionnement reste normal
