### PR TITLE
[QA] Gestion des contrainte de validations du aux erreurs d'envoi d'email

### DIFF
--- a/.env
+++ b/.env
@@ -22,6 +22,7 @@ MAILER_DSN=smtp://stopunaises_mailer:1025
 DATABASE_URL="mysql://stopunaises:stopunaises@stopunaises_mysql:3308/stopunaises_db?serverVersion=5.7&charset=utf8"
 NOTIFICATIONS_EMAIL=notifications@stop-punaises.beta.gouv.fr
 CONTACT_EMAIL=contact@stop-punaises.beta.gouv.fr
+INCONNU_EMAIL=inconnu@stop-punaises.beta.gouv.fr
 MESSENGER_TRANSPORT_DSN=doctrine://default
 REDIS_URL=redis://stopunaises_redis:6379
 

--- a/.env.sample
+++ b/.env.sample
@@ -21,8 +21,9 @@ MAILER_DSN=smtp://stopunaises_mailer:1025
 # MAILER_DSN=sendinblue+smtp://USERNAME:PASSWORD@default
 DATABASE_URL="mysql://stopunaises:stopunaises@stopunaises_mysql:3308/stopunaises_db?serverVersion=5.7&charset=utf8"
 NOTIFICATIONS_EMAIL=notifications@stop-punaises.beta.gouv.fr
-MESSENGER_TRANSPORT_DSN=doctrine://default
 CONTACT_EMAIL=contact@stop-punaises.beta.gouv.fr
+INCONNU_EMAIL=inconnu@stop-punaises.beta.gouv.fr
+MESSENGER_TRANSPORT_DSN=doctrine://default
 REDIS_URL=redis://stopunaises_redis:6379
 
 ###> sentry/sentry-symfony ###

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -107,4 +107,6 @@ jobs:
         env:
           DATABASE_URL: mysql://root:stopunaises@127.0.0.1:${{ job.services.mysql.ports['3306'] }}/stopunaises_db
           NOTIFICATIONS_EMAIL: notifications@stop-punaises.beta.gouv.fr
+          CONTACT_EMAIL: contact@stop-punaises.beta.gouv.fr
+          INCONNU_EMAIL: inconnu@stop-punaises.beta.gouv.fr
           APP_URL: http://localhost:8080

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -99,6 +99,11 @@ jobs:
           php bin/console --env=test doctrine:fixtures:load --no-interaction
         env:
           DATABASE_URL: mysql://root:stopunaises@127.0.0.1:${{ job.services.mysql.ports['3306'] }}/stopunaises_db
+          NOTIFICATIONS_EMAIL: notifications@stop-punaises.beta.gouv.fr
+          CONTACT_EMAIL: contact@stop-punaises.beta.gouv.fr
+          INCONNU_EMAIL: inconnu@stop-punaises.beta.gouv.fr
+          APP_URL: http://localhost:8090
+          MAILER_DSN: ${{ secrets.MAILER_DSN_CI }}
 
       - name: Run tests
         run: |
@@ -109,4 +114,6 @@ jobs:
           NOTIFICATIONS_EMAIL: notifications@stop-punaises.beta.gouv.fr
           CONTACT_EMAIL: contact@stop-punaises.beta.gouv.fr
           INCONNU_EMAIL: inconnu@stop-punaises.beta.gouv.fr
-          APP_URL: http://localhost:8080
+          APP_URL: http://localhost:8090
+          MAILER_DSN: ${{ secrets.MAILER_DSN_CI }}
+

--- a/assets/controllers/form_signalement_front.js
+++ b/assets/controllers/form_signalement_front.js
@@ -628,6 +628,7 @@ class PunaisesFrontSignalementController {
         }
         $('.front-signalement #step-professionnel_info .btn-next').removeAttr('disabled');
         $('.front-signalement #step-autotraitement_info .btn-next').removeAttr('disabled');
+        $('.front-signalement #step-info_usager .btn-next').removeAttr('disabled');
       }
     });
   }

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -13,6 +13,7 @@ parameters:
     doc_autotraitement: 'pdf/stop-punaises-protocole-auto-traitement.pdf'
     doc_domicile: 'pdf/stop-punaises-preparer-son-domicile.pdf'
     admin_email: '%env(resolve:CONTACT_EMAIL)%'
+    inconnu_email: '%env(resolve:INCONNU_EMAIL)%'
 
 services:
     # default configuration for services in *this* file

--- a/src/Controller/Front/SignalementController.php
+++ b/src/Controller/Front/SignalementController.php
@@ -48,15 +48,16 @@ class SignalementController extends AbstractController
         EventDispatcherInterface $eventDispatcher,
         ): Response {
         $signalement = new Signalement();
-        $form = $this->createForm(SignalementFrontType::class, $signalement);
+        $form = $this->createForm(SignalementFrontType::class, $signalement, ['validation_groups' => 'front_add_signalement_logement']);
         $form->handleRequest($request);
 
         $submittedToken = $request->request->get('_csrf_token');
         if ($form->isValid() && $this->isCsrfTokenValid('front-add-signalement', $submittedToken)) {
-            $signalement->setReference($referenceGenerator->generate());
-            $signalement->setDeclarant(Declarant::DECLARANT_OCCUPANT);
-            $signalement->setType(SignalementType::TYPE_LOGEMENT);
-            $signalement->updateUuidPublic();
+            $signalement
+                ->setType(SignalementType::TYPE_LOGEMENT)
+                ->setReference($referenceGenerator->generate())
+                ->setDeclarant(Declarant::DECLARANT_OCCUPANT)
+                ->updateUuidPublic();
 
             $filesPosted = $request->files->get('file-upload');
             $filesToSave = $uploadHandlerService->handleUploadFilesRequest($filesPosted);

--- a/src/Controller/SignalementCreateController.php
+++ b/src/Controller/SignalementCreateController.php
@@ -25,16 +25,21 @@ class SignalementCreateController extends AbstractController
         SignalementManager $signalementManager,
         TerritoireRepository $territoireRepository,
         ZipCodeService $zipCodeService,
-        ReferenceGenerator $referenceGenerator): Response
-    {
+        ReferenceGenerator $referenceGenerator
+    ): Response {
         $signalement = new Signalement();
-        $form = $this->createForm(SignalementHistoryType::class, $signalement);
+        $form = $this->createForm(
+            SignalementHistoryType::class,
+            $signalement,
+            ['validation_groups' => 'back_add_signalement_logement']
+        );
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $signalement->setReference($referenceGenerator->generate());
-            $signalement->setDeclarant(Declarant::DECLARANT_ENTREPRISE);
-            $signalement->setType(SignalementType::TYPE_LOGEMENT);
+            $signalement
+                ->setReference($referenceGenerator->generate())
+                ->setDeclarant(Declarant::DECLARANT_ENTREPRISE)
+                ->setType(SignalementType::TYPE_LOGEMENT);
 
             $zipCode = $zipCodeService->getByCodePostal($signalement->getCodePostal());
             $territoire = $territoireRepository->findOneBy(['zip' => $zipCode]);

--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -46,9 +46,17 @@ class Signalement
     private ?bool $construitAvant1948 = null;
 
     #[ORM\Column(length: 50, nullable: true)]
+    #[Assert\NotBlank(
+        message: 'Veuillez renseigner votre nom.',
+        groups: ['front_add_signalement_logement', 'back_add_signalement_logement']
+    )]
     private ?string $nomOccupant = null;
 
     #[ORM\Column(length: 50, nullable: true)]
+    #[Assert\NotBlank(
+        message: 'Veuillez renseigner votre prenom.',
+        groups: ['front_add_signalement_logement', 'back_add_signalement_logement']
+    )]
     private ?string $prenomOccupant = null;
 
     #[ORM\Column(length: 20, nullable: true)]
@@ -61,6 +69,7 @@ class Signalement
 
     #[ORM\Column(length: 100, nullable: true)]
     #[Assert\Email]
+    #[Assert\NotBlank(message: 'Veuillez renseigner votre email.', groups: ['front_add_signalement_logement'])]
     private ?string $emailOccupant = null;
 
     #[ORM\Column(length: 30, nullable: true)]

--- a/src/Form/SignalementFrontType.php
+++ b/src/Form/SignalementFrontType.php
@@ -371,6 +371,7 @@ class SignalementFrontType extends AbstractType
             'data_class' => Signalement::class,
             'allow_extra_fields' => true,
             'csrf_protection' => false,
+            'validation_groups' => ['Default', 'front_add_signalement_logement'],
         ]);
     }
 

--- a/src/Form/SignalementHistoryType.php
+++ b/src/Form/SignalementHistoryType.php
@@ -383,6 +383,7 @@ class SignalementHistoryType extends AbstractType
     {
         $resolver->setDefaults([
             'data_class' => Signalement::class,
+            'validation_groups' => ['Default', 'back_add_signalement_logement'],
         ]);
     }
 

--- a/src/Service/Mailer/MailerProvider.php
+++ b/src/Service/Mailer/MailerProvider.php
@@ -22,6 +22,11 @@ class MailerProvider implements MailerProviderInterface
 
     public function send(MessageInterface $message): void
     {
+        if (empty($message->getTo())) {
+            /* @var Message $message */
+            $message->setTo([$this->parameterBag->get('inconnu_email')]);
+        }
+
         $email = (new Email())
             ->from($message->getFrom())
             ->to(...$message->getTo())

--- a/src/Service/Mailer/MessageFactory.php
+++ b/src/Service/Mailer/MessageFactory.php
@@ -8,7 +8,7 @@ class MessageFactory
     {
     }
 
-    public function createInstanceFrom(Template $template, array $parameters = [])
+    public function createInstanceFrom(Template $template, array $parameters = []): Message
     {
         if (isset($parameters['link'])) {
             $parameters['link'] = $this->baseUrl.$parameters['link'];

--- a/tests/Functionnal/Controller/Front/SignalementControllerTest.php
+++ b/tests/Functionnal/Controller/Front/SignalementControllerTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace App\Tests\Functionnal\Controller\Front;
+
+use App\Tests\SessionHelper;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\RouterInterface;
+
+class SignalementControllerTest extends WebTestCase
+{
+    use SessionHelper;
+
+    private ?KernelBrowser $client = null;
+
+    protected function setUp(): void
+    {
+        self::ensureKernelShutdown();
+        $this->client = static::createClient();
+    }
+
+    /** @dataProvider providePayloadSignalement */
+    public function testAddSignalementLogement(array $payload, ?string $codePostal = null): void
+    {
+        $payloadSignalement = [
+            'signalement_front' => $payload,
+            '_csrf_token' => $this->generateCsrfToken($this->client, 'front-add-signalement'),
+            'code-postal' => $codePostal,
+        ];
+
+        /** @var RouterInterface $router */
+        $router = self::getContainer()->get(RouterInterface::class);
+        $routePostSignalement = $router->generate('app_front_signalement_add');
+        $this->client->request('POST', $routePostSignalement, $payloadSignalement);
+
+        $this->assertEquals(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        $bodyContent = $this->client->getResponse()->getContent();
+        $this->assertEquals(json_decode($bodyContent, true)['response'], 'success');
+    }
+
+    public function providePayloadSignalement(): \Generator
+    {
+        yield 'Post signalement in territory not open' => [
+            [
+                'superficie' => '',
+                'adresse' => '',
+                'codePostal' => '18250',
+                'codeInsee' => '',
+                'ville' => '',
+                'geoloc' => '',
+                'nomProprietaire' => '',
+                'numeroAllocataire' => '',
+                'infestationLogementsVoisins' => '2',
+                'niveauInfestation' => '',
+                'nomOccupant' => 'Doe',
+                'prenomOccupant' => 'John',
+                'telephoneOccupant' => '',
+                'emailOccupant' => 'john.doe@punaises.com',
+                'autotraitement' => 'true',
+            ],
+            '18250',
+        ];
+
+        yield 'Post signalement in territory open' => [
+            [
+                'typeLogement' => 'appartement',
+                'superficie' => '34',
+                'adresse' => '31 Rue des phoceens',
+                'codePostal' => '91270',
+                'codeInsee' => '13202',
+                'ville' => 'Marseille',
+                'geoloc' => '43.302225|5.367932',
+                'locataire' => '1',
+                'nomProprietaire' => '13 Habitat',
+                'logementSocial' => '0',
+                'allocataire' => '0',
+                'numeroAllocataire' => '',
+                'dureeInfestation' => 'MORE-6-MONTHS',
+                'infestationLogementsVoisins' => '1',
+                'piquresExistantes' => '1',
+                'piquresConfirmees' => '1',
+                'dejectionsTrouvees' => 'true',
+                'dejectionsNombrePiecesConcernees' => '2',
+                'dejectionsFaciliteDetections' => 'RECHERCHE',
+                'dejectionsLieuxObservations' => [
+                    'LIT',
+                    'CANAPE',
+                    'MEUBLES',
+                ],
+                'oeufsEtLarvesTrouves' => 'true',
+                'oeufsEtLarvesNombrePiecesConcernees' => '1',
+                'oeufsEtLarvesFaciliteDetections' => 'FACILE',
+                'oeufsEtLarvesLieuxObservations' => [
+                    'LIT',
+                    'CANAPE',
+                    'MEUBLES',
+                    'MURS',
+                ],
+                'punaisesTrouvees' => 'true',
+                'punaisesNombrePiecesConcernees' => '1',
+                'punaisesFaciliteDetections' => 'FACILE',
+                'punaisesLieuxObservations' => [
+                    'LIT',
+                ],
+                'niveauInfestation' => '3',
+                'nomOccupant' => 'Doe',
+                'prenomOccupant' => 'John',
+                'telephoneOccupant' => '0611451245',
+                'emailOccupant' => 'john.doe@yopmail.com',
+                'autotraitement' => 'true',
+            ],
+        ];
+    }
+}

--- a/tests/Functionnal/Controller/SignalementControllerTest.php
+++ b/tests/Functionnal/Controller/SignalementControllerTest.php
@@ -3,12 +3,14 @@
 namespace App\Tests\Functionnal\Controller;
 
 use App\Repository\UserRepository;
+use App\Tests\SessionHelper;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\RouterInterface;
 
 class SignalementControllerTest extends WebTestCase
 {
+    use SessionHelper;
+
     public function testAddSignalementHistoriqueLogementAsEntreprise(): void
     {
         $client = static::createClient();
@@ -21,7 +23,7 @@ class SignalementControllerTest extends WebTestCase
 
         $payloadSignalement = [
             'signalement' => [
-                    '_token' => $this->generateCsrfToken($this->client, 'front-add-signalement'),
+                    '_token' => $this->generateCsrfToken($client, 'signalement'),
                     'adresse' => '17 Boulevard saade - quai joliette',
                     'codePostal' => '13002',
                     'codeInsee' => '13202',
@@ -30,8 +32,8 @@ class SignalementControllerTest extends WebTestCase
                     'typeLogement' => 'appartement',
                     'localisationDansImmeuble' => 'logement',
                     'construitAvant1948' => '0',
-                    'nomOccupant' => 'AHAMADA',
-                    'prenomOccupant' => 'Techmind Consulting',
+                    'nomOccupant' => 'Doe',
+                    'prenomOccupant' => 'John',
                     'telephoneOccupant' => '',
                     'emailOccupant' => '',
                     'typeIntervention' => 'diagnostic',
@@ -50,10 +52,8 @@ class SignalementControllerTest extends WebTestCase
         /** @var RouterInterface $router */
         $router = self::getContainer()->get(RouterInterface::class);
         $routePostSignalement = $router->generate('app_signalement_create');
-        $this->client->request('POST', $routePostSignalement, $payloadSignalement);
+        $client->request('POST', $routePostSignalement, $payloadSignalement);
 
-        $this->assertEquals(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
-        $bodyContent = $this->client->getResponse()->getContent();
-        $this->assertEquals(json_decode($bodyContent, true)['response'], 'success');
+        $this->assertResponseRedirects('/bo/historique');
     }
 }

--- a/tests/Functionnal/Controller/SignalementControllerTest.php
+++ b/tests/Functionnal/Controller/SignalementControllerTest.php
@@ -22,8 +22,8 @@ class SignalementControllerTest extends WebTestCase
         $client->loginUser($user);
 
         $payloadSignalement = [
-            'signalement' => [
-                    '_token' => $this->generateCsrfToken($client, 'signalement'),
+            'signalement_history' => [
+                    '_token' => $this->generateCsrfToken($client, 'signalement_history'),
                     'adresse' => '17 Boulevard saade - quai joliette',
                     'codePostal' => '13002',
                     'codeInsee' => '13202',

--- a/tests/Functionnal/Controller/SignalementControllerTest.php
+++ b/tests/Functionnal/Controller/SignalementControllerTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Tests\Functionnal\Controller;
+
+use App\Repository\UserRepository;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\RouterInterface;
+
+class SignalementControllerTest extends WebTestCase
+{
+    public function testAddSignalementHistoriqueLogementAsEntreprise(): void
+    {
+        $client = static::createClient();
+        /** @var UserRepository $userRepository */
+        $userRepository = static::getContainer()->get(UserRepository::class);
+
+        $user = $userRepository->findOneBy(['email' => 'company-01@punaises.fr']);
+
+        $client->loginUser($user);
+
+        $payloadSignalement = [
+            'signalement' => [
+                    '_token' => $this->generateCsrfToken($this->client, 'front-add-signalement'),
+                    'adresse' => '17 Boulevard saade - quai joliette',
+                    'codePostal' => '13002',
+                    'codeInsee' => '13202',
+                    'ville' => 'Marseille',
+                    'geoloc' => '43.301787|5.364626',
+                    'typeLogement' => 'appartement',
+                    'localisationDansImmeuble' => 'logement',
+                    'construitAvant1948' => '0',
+                    'nomOccupant' => 'AHAMADA',
+                    'prenomOccupant' => 'Techmind Consulting',
+                    'telephoneOccupant' => '',
+                    'emailOccupant' => '',
+                    'typeIntervention' => 'diagnostic',
+                    'dateIntervention' => '2020-10-10',
+                    'agent' => '1',
+                    'niveauInfestation' => '4',
+                    'nomBiocide' => '',
+                    'typeDiagnostic' => 'canin',
+                    'nombrePiecesTraitees' => '',
+                    'delaiEntreInterventions' => '',
+                    'dateVisitePostTraitement' => '',
+                    'prixFactureHT' => '555',
+            ],
+        ];
+
+        /** @var RouterInterface $router */
+        $router = self::getContainer()->get(RouterInterface::class);
+        $routePostSignalement = $router->generate('app_signalement_create');
+        $this->client->request('POST', $routePostSignalement, $payloadSignalement);
+
+        $this->assertEquals(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        $bodyContent = $this->client->getResponse()->getContent();
+        $this->assertEquals(json_decode($bodyContent, true)['response'], 'success');
+    }
+}

--- a/tests/SessionHelper.php
+++ b/tests/SessionHelper.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Tests;
+
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Component\BrowserKit\Cookie;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockFileSessionStorage;
+use Symfony\Component\Security\Csrf\TokenStorage\SessionTokenStorage;
+
+trait SessionHelper
+{
+    public function getSession(KernelBrowser $client): Session
+    {
+        $cookie = $client->getCookieJar()->get('MOCKSESSID');
+
+        // create a new session object
+        $container = static::getContainer();
+        $sessionSavePath = $container->getParameter('session.save_path');
+        $sessionStorage = new MockFileSessionStorage($sessionSavePath);
+        $session = new Session($sessionStorage);
+
+        if ($cookie) {
+            // get the session id from the session cookie if it exists
+            $session->setId($cookie->getValue());
+            $session->start();
+        } else {
+            // or create a new session id and a session cookie
+            $session->start();
+            $session->save();
+
+            $sessionCookie = new Cookie(
+                $session->getName(),
+                $session->getId(),
+                null,
+                null,
+                'localhost',
+            );
+            $client->getCookieJar()->set($sessionCookie);
+        }
+
+        return $session;
+    }
+
+    public function generateCsrfToken(KernelBrowser $client, ?string $tokenId = null): string
+    {
+        $session = $this->getSession($client);
+        $container = static::getContainer();
+        $tokenGenerator = $container->get('security.csrf.token_generator');
+        $csrfToken = $tokenGenerator->generateToken();
+        $session->set(SessionTokenStorage::SESSION_NAMESPACE."/{$tokenId}", $csrfToken);
+        $session->save();
+
+        return $csrfToken;
+    }
+}


### PR DESCRIPTION
## Ticket

#385    

## Description
Des mails s'envoient sans destinataires. Remonter à la source du problème avec une validation non présente sur le front (corrigé dans https://github.com/MTES-MCT/stop-punaises/pull/390/files)

BIen que la validation ai été ajouté sur ce formulaire, une double validation est nécessaire. 

## Changements apportés
* Validation géré par des groupe de validation pour le formulaire front et back 
* Création d'une boite mail inconnu afin de recevoir les messages sans destinataire

## Pré-requis
Ajout d'une nouvelle variable d'environnement
`INCONNU_EMAIL=inconnu@stop-punaises.beta.gouv.fr`

## Tests
- [ ] Soumettre un formulaire coté front dans un territoire autorisé
- [ ] Soumettre un formulaire coté back dans un territoire non autorisé
- [ ] Soumettre un formulaire coté back sans email
~~- [ ] Supprimer l'email occupant sur le signalement dans la base et envoyer un message via la plateforme à l'usage (vérifier qu"on recoit bien le mail)~~