### PR TITLE
[BO] Créer le listing ERP / transport dans le BO 

### DIFF
--- a/assets/controllers/list_signalement.js
+++ b/assets/controllers/list_signalement.js
@@ -88,6 +88,11 @@ function initComponentsEvents() {
       refreshTableWithSearch();
     });
   }
+  if ($('#filter-signalement-type').length > 0) {
+    $('#filter-signalement-type').on('change', function() {
+      refreshTableWithSearch();
+    });
+  }
 }
 
 function refreshTableWithSearch() {
@@ -97,6 +102,10 @@ function refreshTableWithSearch() {
   }
   if ($('.liste-signalements-usagers').length > 0) {
     refreshTableUsagers();
+    return;
+  }
+  if ($('.liste-signalements-erp-transports').length > 0) {
+    refreshTableErpTransports();
     return;
   }
   if ($('.liste-signalements-historique').length > 0) {
@@ -121,6 +130,33 @@ function refreshTableHorsPerimetre() {
   if ($('#search-address').length > 0) {
     let territoire = $('#search-address').val();
     listTable.columns(3).search(territoire);
+  }
+  listTable.draw();
+  let countSignalement = listTable.rows( {search:'applied'} ).count();
+  $("span#count-signalement").text(countSignalement);
+}
+
+function refreshTableErpTransports() {
+  if ($('#filter-date').length > 0) {
+    let dateInput = $('#filter-date').val();
+    let dateFilter = '';
+    if (dateInput != '') {
+      let dateSplit = dateInput.split('-');
+      dateFilter = dateSplit[2] + '/' + dateSplit[1] + '/' + dateSplit[0];
+    }
+    listTable.columns(1).search(dateFilter);
+  }
+  if ($('#filter-signalement-type').length > 0) {
+    let type = $('#filter-signalement-type').val();
+    listTable.columns(2).search(type);
+  }
+  if ($('#search-address').length > 0) {
+    let address = $('#search-address').val();
+    listTable.columns(4).search(address);
+  }
+  if ($('#filter-territoire').length > 0) {
+    let territoire = $('#filter-territoire').val().substring(0,2);
+    listTable.columns(5).search(territoire);
   }
   listTable.draw();
   let countSignalement = listTable.rows( {search:'applied'} ).count();

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -37,6 +37,7 @@ security:
     access_control:
          - { path: ^/bo/entreprises$, roles: ROLE_ADMIN }
          - { path: ^/bo/hors-perimetre$, roles: ROLE_ADMIN }
+         - { path: ^/bo/erp-transports$, roles: ROLE_ADMIN }
          - { path: ^/bo/cartographie$, roles: ROLE_ADMIN }
          - { path: ^/bo, roles: ROLE_ENTREPRISE }
         # - { path: ^/profile, roles: ROLE_USER }

--- a/src/Controller/DashboardController.php
+++ b/src/Controller/DashboardController.php
@@ -12,14 +12,15 @@ class DashboardController extends AbstractController
     #[Route('/bo', name: 'app_dashboard_home')]
     public function index(
         SignalementManager $signalementManager,
-        ): Response {
-        list($countNouveaux, $countEnCours, $countHorsPerimetres) =
+    ): Response {
+        list($countNouveaux, $countEnCours, $countHorsPerimetres, $countErpTransports) =
             $signalementManager->countSignalements();
 
         return $this->render('dashboard/index.html.twig', [
             'count_nouveaux' => $countNouveaux,
             'count_en_cours' => $countEnCours,
             'count_hors_perimetre' => $countHorsPerimetres,
+            'count_erp_transports' => $countErpTransports,
         ]);
     }
 }

--- a/src/Controller/Front/SignalementController.php
+++ b/src/Controller/Front/SignalementController.php
@@ -46,7 +46,7 @@ class SignalementController extends AbstractController
         ZipCodeService $zipCodeService,
         EntrepriseRepository $entrepriseRepository,
         EventDispatcherInterface $eventDispatcher,
-        ): Response {
+    ): Response {
         $signalement = new Signalement();
         $form = $this->createForm(SignalementFrontType::class, $signalement, ['validation_groups' => 'front_add_signalement_logement']);
         $form->handleRequest($request);

--- a/src/Controller/SignalementListController.php
+++ b/src/Controller/SignalementListController.php
@@ -17,8 +17,8 @@ class SignalementListController extends AbstractController
     #[Route('/bo/signalements', name: 'app_signalement_list')]
     public function signalements(
         SignalementManager $signalementManager,
-        TerritoireRepository $territoireRepository): Response
-    {
+        TerritoireRepository $territoireRepository
+    ): Response {
         $territoires = $territoireRepository->findAll();
         $signalements = $signalementManager->findDeclaredByOccupants();
         $entreprise = null;
@@ -39,8 +39,8 @@ class SignalementListController extends AbstractController
     public function historique(
         Request $request,
         SignalementManager $signalementManager,
-        EntrepriseRepository $entrepriseRepository): Response
-    {
+        EntrepriseRepository $entrepriseRepository
+    ): Response {
         $signalements = $signalementManager->findHistoriqueEntreprise();
 
         $entreprises = [];
@@ -60,12 +60,27 @@ class SignalementListController extends AbstractController
     #[Route('/bo/hors-perimetre', name: 'app_horsperimetre_list')]
     public function horsPerimetre(
         SignalementRepository $signalementRepository,
-        TerritoireRepository $territoireRepository): Response
-    {
+        TerritoireRepository $territoireRepository
+    ): Response {
         $territoires = $territoireRepository->findAll();
         $signalements = $signalementRepository->findFromInactiveTerritories();
 
         return $this->render('signalement_list/hors-perimetre.html.twig', [
+            'count_signalement' => \count($signalements),
+            'signalements' => $signalements,
+            'territoires' => $territoires,
+        ]);
+    }
+
+    #[Route('/bo/erp-transports', name: 'app_erptransports_list')]
+    public function erpTransports(
+        SignalementRepository $signalementRepository,
+        TerritoireRepository $territoireRepository
+    ): Response {
+        $territoires = $territoireRepository->findAll();
+        $signalements = $signalementRepository->findErpTransportsSignalements();
+
+        return $this->render('signalement_list/erp-transports.html.twig', [
             'count_signalement' => \count($signalements),
             'signalements' => $signalements,
             'territoires' => $territoires,

--- a/src/Entity/Enum/SignalementType.php
+++ b/src/Entity/Enum/SignalementType.php
@@ -7,4 +7,18 @@ enum SignalementType: string
     case TYPE_LOGEMENT = 'TYPE_LOGEMENT';
     case TYPE_ERP = 'TYPE_ERP';
     case TYPE_TRANSPORT = 'TYPE_TRANSPORT';
+
+    public function label(): string
+    {
+        return self::getLabelList()[$this->name];
+    }
+
+    public static function getLabelList(): array
+    {
+        return [
+            'TYPE_LOGEMENT' => 'Logement',
+            'TYPE_ERP' => 'ERP',
+            'TYPE_TRANSPORT' => 'Transport',
+        ];
+    }
 }

--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -988,6 +988,11 @@ class Signalement
         return $this;
     }
 
+    public function getNomCompletDeclarant(): ?string
+    {
+        return $this->getPrenomDeclarant().' '.$this->getNomDeclarant();
+    }
+
     public function getEmailDeclarant(): ?string
     {
         return $this->emailDeclarant;

--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -65,10 +65,13 @@ class SignalementManager extends AbstractManager
             $result[1] = $this->signalementRepository->countOpenWithIntervention();
             $signalements = $this->signalementRepository->findFromInactiveTerritories();
             $result[2] = \count($signalements);
+            $signalements = $this->signalementRepository->findErpTransportsSignalements();
+            $result[3] = \count($signalements);
         } else {
             $result[0] = $this->signalementRepository->countAvailableForEntrepriseWithoutAnswer($user->getEntreprise());
             $result[1] = $this->signalementRepository->countCurrentlyOpenForEntreprise($user->getEntreprise());
             $result[2] = 0;
+            $result[3] = 0;
         }
 
         return $result;

--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -4,6 +4,7 @@ namespace App\Repository;
 
 use App\Entity\Entreprise;
 use App\Entity\Enum\Declarant;
+use App\Entity\Enum\SignalementType;
 use App\Entity\Signalement;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\DBAL\Connection;
@@ -73,8 +74,19 @@ class SignalementRepository extends ServiceEntityRepository
     public function findFromInactiveTerritories(): ?array
     {
         return $this->createQueryBuilder('s')
-            ->where('t.active != true')
             ->leftJoin('s.territoire', 't')
+            ->where('t.active != true')
+            ->andWhere('s.type = :typeLogement')
+            ->setParameter('typeLogement', SignalementType::TYPE_LOGEMENT->value)
+            ->getQuery()
+            ->getResult();
+    }
+
+    public function findErpTransportsSignalements(): ?array
+    {
+        return $this->createQueryBuilder('s')
+            ->andWhere('s.type != :typeLogement')
+            ->setParameter('typeLogement', SignalementType::TYPE_LOGEMENT->value)
             ->getQuery()
             ->getResult();
     }

--- a/src/Twig/AppExtension.php
+++ b/src/Twig/AppExtension.php
@@ -3,6 +3,8 @@
 namespace App\Twig;
 
 use App\Entity\Enum\InfestationLevel;
+use App\Entity\Enum\PlaceType;
+use App\Entity\Enum\SignalementType;
 use App\Entity\Signalement;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
@@ -20,6 +22,8 @@ class AppExtension extends AbstractExtension
             new TwigFilter('construction_avant_1948', [$this, 'formatConstructionAvant1948']),
             new TwigFilter('array_to_string', [$this, 'formatArrayToString']),
             new TwigFilter('reference_sortable', [$this, 'formatSortableReference']),
+            new TwigFilter('signalement_type', [$this, 'formatSignalementType']),
+            new TwigFilter('place_type', [$this, 'formatPlaceType']),
         ];
     }
 
@@ -58,6 +62,16 @@ class AppExtension extends AbstractExtension
         }
 
         return InfestationLevel::from($niveau)->label();
+    }
+
+    public function formatSignalementType(SignalementType $type): string
+    {
+        return $type->label();
+    }
+
+    public function formatPlaceType(PlaceType $type): string
+    {
+        return $type->label();
     }
 
     public function formatConstructionAvant1948(bool|null $construitAvant1948 = null): string

--- a/src/Twig/EnumExtension.php
+++ b/src/Twig/EnumExtension.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Twig;
+
+use BadMethodCallException;
+use InvalidArgumentException;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+use Twig\TwigFunction;
+
+// https://github.com/twigphp/Twig/issues/3681
+
+/**
+ * USE.
+ *
+ * {% set OrderStatus = enum('\\App\\Helpers\\OrderStatus') %}
+ * {% set waitingStatus = [ OrderStatus.Placed, OrderStatus.BeingPrepared ] %}
+ *
+ * {% if order.status in waitingStatus %}
+ *     Be patient
+ * {% elseif order.status == OrderStatus.Completed %}
+ *     Order complete!
+ * {% endif %}
+ *
+ * ...
+ *
+ * <select>
+ *     {% for type in OrderStatus.cases() %}
+ *         <option value="{{ type.value }}">
+ *             {{ type.stringLiteral() }} {# getStringLiteral is a custom method in my enum #}
+ *         </option>
+ *     {% endfor %}
+ * </select>
+ */
+class EnumExtension extends AbstractExtension
+{
+    /**
+     * @return TwigFunction[]
+     */
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('enum', [$this, 'createProxy']),
+        ];
+    }
+
+    public function getFilters(): array
+    {
+        return [
+            new TwigFilter('joinEnumKeys', [$this, 'joinEnumKeys']),
+        ];
+    }
+
+    public function joinEnumKeys(array $arrayOfEnum, string $delimiter = ','): string
+    {
+        $returnString = '';
+        foreach ($arrayOfEnum as $enum) {
+            $returnString .= $enum->name.$delimiter;
+        }
+
+        return $returnString;
+    }
+
+    public function createProxy(string $enumFQN): object
+    {
+        return new class($enumFQN) {
+            public function __construct(private readonly string $enum)
+            {
+                if (!enum_exists($this->enum)) {
+                    throw new InvalidArgumentException("$this->enum is not an Enum type and cannot be used in this function");
+                }
+            }
+
+            public function __call(string $name, array $arguments)
+            {
+                $enumFQN = sprintf('%s::%s', $this->enum, $name);
+
+                if (\defined($enumFQN)) {
+                    return \constant($enumFQN);
+                }
+
+                if (method_exists($this->enum, $name)) {
+                    return $this->enum::$name(...$arguments);
+                }
+
+                throw new BadMethodCallException("Neither \"{$enumFQN}\" or \"{$enumFQN}::{$name}()\" exist in this runtime.");
+            }
+        };
+    }
+}

--- a/templates/bundles/TwigBundle/Exception/error.html.twig
+++ b/templates/bundles/TwigBundle/Exception/error.html.twig
@@ -11,7 +11,7 @@
                         <br>Veuillez réessayer plus tard ou cliquer sur le bouton ci-dessous pour retourner à
                         l'accueil.</p>
                     <p class="button-container">
-                        <a href="{{ path('home') }}" class="fr-btn">Aller à l'acceuil</a>
+                        <a href="{{ path('home') }}" class="fr-btn">Aller à l'accueil</a>
                     </p>
                 </div>
                 <div class="fr-col-10 fr-col-md-5 fr-col-lg-4">

--- a/templates/bundles/TwigBundle/Exception/error403.html.twig
+++ b/templates/bundles/TwigBundle/Exception/error403.html.twig
@@ -9,7 +9,7 @@
                     <p>Vous n'avez pas les droits nécessaires pour accéder à cette page.<br>
                         Cliquez sur le bouton ci-dessous pour retourner à l'accueil.</p>
                     <p class="button-container">
-                        <a href="{{ path('home') }}" class="fr-btn">Aller à l'acceuil</a>
+                        <a href="{{ path('home') }}" class="fr-btn">Aller à l'accueil</a>
                     </p>
                 </div>
                 <div class="fr-col-10 fr-col-md-5 fr-col-lg-4">

--- a/templates/bundles/TwigBundle/Exception/error404.html.twig
+++ b/templates/bundles/TwigBundle/Exception/error404.html.twig
@@ -9,7 +9,7 @@
                     <p> Il semblerait que la page que vous essayez d'atteindre n'existe pas ou a été déplacée !<br>Cliquez
                         sur le bouton ci-dessous pour retourner à l'accueil.</p>
                     <p class="button-container">
-                        <a href="{{ path('home') }}" class="fr-btn">Aller à l'acceuil</a>
+                        <a href="{{ path('home') }}" class="fr-btn">Aller à l'accueil</a>
                     </p>
                 </div>
                 <div class="fr-col-10 fr-col-md-5 fr-col-lg-4">

--- a/templates/common/components/filters/filter-signalement-type.html.twig
+++ b/templates/common/components/filters/filter-signalement-type.html.twig
@@ -1,0 +1,5 @@
+<select class="fr-select" id="filter-signalement-type">
+    <option value="">Type</option>
+    <option value="ERP">ERP</option>
+    <option value="Transport">Transport</option>
+</select>

--- a/templates/dashboard/index.html.twig
+++ b/templates/dashboard/index.html.twig
@@ -53,6 +53,26 @@
                 </div>
             {% endif %}
 
+            {% if is_granted('ROLE_ADMIN') %}
+                <div class="fr-col fr-col-md-4">
+                    <div class="fr-card fr-enlarge-link">
+                        <div class="fr-card__body">
+                        <ul class="fr-badges-group">
+                            <li>
+                                <p class="fr-badge fr-badge--no-icon fr-badge--info">{{count_erp_transports}} signalement(s)</p>
+                            </li>
+                        </ul>
+                            <div class="fr-card__content">
+                                <h3 class="fr-card__title">
+                                    <a href="{{ path('app_erptransports_list') }}">ERP & Transports</a>
+                                </h3>
+                                <p class="fr-card__desc">Consultez les signalements sur les lieux publics et transports en commun.</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            {% endif %}
+
             <div class="fr-col fr-col-md-4">
                 <div class="fr-card fr-enlarge-link">
                     <div class="fr-card__body">

--- a/templates/dashboard/nav.html.twig
+++ b/templates/dashboard/nav.html.twig
@@ -13,6 +13,9 @@
                         <a class="fr-nav__link" href="{{ path('app_horsperimetre_list') }}" target="_self" {% if app.request.get('_route') == 'app_horsperimetre_list' %}aria-current="page"{% endif %}>Hors périmètre</a>
                     </li>
                     <li class="fr-nav__item">
+                        <a class="fr-nav__link" href="{{ path('app_erptransports_list') }}" target="_self" {% if app.request.get('_route') == 'app_erptransports_list' %}aria-current="page"{% endif %}>ERP & Transports</a>
+                    </li>
+                    <li class="fr-nav__item">
                         <a class="fr-nav__link" href="{{ path('app_entreprise_list') }}" target="_self" {% if app.request.get('_route') == 'app_entreprise_list' or app.request.get('_route') == 'app_entreprise_view' %}aria-current="page"{% endif %}>Les entreprises</a>
                     </li>
                 {% endif %}

--- a/templates/signalement_list/erp-transports.html.twig
+++ b/templates/signalement_list/erp-transports.html.twig
@@ -1,0 +1,74 @@
+{% extends 'base-back.html.twig' %}
+
+{% block title %}Stop punaises - Les signalements ERP et transports{% endblock %}
+
+{% block body %}
+{% for signalement in signalements %}
+    {% include "signalement_list/modal-signalement-erp-transports.html.twig" %}
+{% endfor %}
+<div class="liste-signalements fr-p-5w grey-bg">
+    <div class="fr-container">
+        <h1>Signalements ERP et transports</h1>
+
+        <div class="fr-grid-row fr-grid-row--gutters">
+            <div class="fr-select-group fr-col-12 fr-col-lg-3">
+                {% include "common/components/filters/filter-territoire.html.twig" %}
+            </div>
+
+            <div class="fr-input-wrap fr-icon-search-line fr-col-12 fr-col-lg-3">
+                <input type="text" class="fr-input" id="search-address" placeholder="CP...">
+            </div>
+
+            <div class="fr-input-wrap fr-col-12 fr-col-lg-3">
+                <input type="date" id="filter-date">
+            </div>
+
+            <div class="fr-select-group fr-col-12 fr-col-lg-3">
+                {% include "common/components/filters/filter-signalement-type.html.twig" %}
+            </div>
+        </div>
+    </div>
+
+    <div class="fr-container fr-mt-3w">
+        <h2><span id="count-signalement">{{ count_signalement }}</span> signalements trouvés</h2>
+
+        {% if signalements is not empty %}
+            <table id="datatable" class="liste-signalements-erp-transports">
+                <thead>
+                    <tr>
+                        <th>ID</th>
+                        <th>Créé le</th>
+                        <th>Type</th>
+                        <th>Nom</th>
+                        <th>Code postal</th>
+                        <th>Territoire</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for signalement in signalements %}
+                        <tr>
+                            <td data-order="{{ signalement.reference|reference_sortable }}">{{ signalement.reference }} <span>{{ signalement.nomOccupant }} {{ signalement.prenomOccupant }} {{ signalement.emailOccupant }}</span></td>
+                            <td data-order="{{ signalement.createdAt.format('Y-m-d') }}">{{ signalement.createdAt.format('d/m/Y') }}</td>
+                            <td>{{ signalement.type|signalement_type }}</td>
+                            {% if signalement.type is same as enum('App\\Entity\\Enum\\SignalementType').TYPE_TRANSPORT %}
+                                <td>{{ signalement.placeType|place_type }}</td>
+                            {% else %}
+                                <td>{{ signalement.nomProprietaire }}</td>
+                            {% endif %}
+                            <td>{{ signalement.codePostal }} {{ signalement.ville }}</td>
+                            <td>{{ signalement.territoire.zip }}</td>
+                            <td class="button-view">
+                                <button class="fr-btn fr-icon-arrow-right-fill" data-fr-opened="false" aria-controls="fr-modal-signalement-erp-transports-{{signalement.uuid}}"></button>
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+            
+        {% else %}
+            Aucun.
+        {% endif %}
+    </div>
+</div>
+{% endblock %}

--- a/templates/signalement_list/modal-signalement-erp-transports.html.twig
+++ b/templates/signalement_list/modal-signalement-erp-transports.html.twig
@@ -8,32 +8,40 @@
                     </div>
                     <div class="fr-modal__content">
                         <h1 id="fr-modal-title-modal-signalement-erp-transports-{{signalement.uuid}}" class="fr-modal__title"><span class="fr-fi-arrow-right-line fr-fi--lg"></span>Signalement #{{signalement.reference}}</h1>
-                        
                         <p>Déposé le : {{signalement.createdAt.format('d/m/Y')}}</p>
-                        <p>Punaises vues le : {{signalement.punaisesViewedAt.format('d/m/Y')}}</p>
 
+                        <h2 class="fr-h5">Signalement</h2>
                         <p>
-                            Type de signalement : {{signalement.type|signalement_type }}
-                            <br>
+                            Type de signalement : {{signalement.type|signalement_type }} - 
                             {% if signalement.type is same as enum('App\\Entity\\Enum\\SignalementType').TYPE_TRANSPORT %}
                                 {{ signalement.placeType|place_type }}
                             {% else %}
                                 {{ signalement.nomProprietaire }}
                             {% endif %}
                             <br>
-                            Avez-vous prévenu l'établissement : {{ signalement.isPlaceAvertie ? 'Oui' : 'Non' }}
-                        </p>
-
-                        <p>
                             Territoire : {{signalement.territoire.nomComplet}}
                             <br>
                             Commune : {{signalement.codePostal}} {{signalement.ville}}
+                            <br>
+                            Punaises vues le : {{signalement.punaisesViewedAt.format('d/m/Y')}} à {{signalement.punaisesViewedAt.format('H:i')}} 
+                            <br>
+                            Etablissement prévenu : {{ signalement.isPlaceAvertie ? 'Oui' : 'Non' }}
+                            <br>
+                            {% if signalement.autresInformations %}
+                                Autres informations : {{signalement.autresInformations}}
+                                <br>
+                            {% endif %}
+                            {% if signalement.photos %}
+                                {% for index,photo in signalement.photos %}
+                                    <a href="{{ path('show_uploaded_file',{filename:photo.file}) }}?_csrf_token={{ csrf_token('signalement_ext_file_view') }}" title="Voir la photo" target="_blank" rel="noopener">
+                                        Voir la photo
+                                    </a>
+                                    <br>
+                                {% endfor %}
+                            {% endif %}
                         </p>
 
-                        <p>
-                            Autres informations : {{signalement.autresInformations}}
-                        </p>
-
+                        <h2 class="fr-h5">Déclarant</h2>
                         <p>
                             Usager : {{signalement.nomCompletDeclarant}}
                             <br>
@@ -44,4 +52,14 @@
             </div>
         </div>
     </div>
+
+
+
+    Type : label "transport" (couleur info) - nom du transport
+    Territoire :
+    Commune :
+    Punaises vues le : [date] à [heure]
+    Etablissement prévenu : 
+
+
 </dialog>

--- a/templates/signalement_list/modal-signalement-erp-transports.html.twig
+++ b/templates/signalement_list/modal-signalement-erp-transports.html.twig
@@ -52,14 +52,4 @@
             </div>
         </div>
     </div>
-
-
-
-    Type : label "transport" (couleur info) - nom du transport
-    Territoire :
-    Commune :
-    Punaises vues le : [date] à [heure]
-    Etablissement prévenu : 
-
-
 </dialog>

--- a/templates/signalement_list/modal-signalement-erp-transports.html.twig
+++ b/templates/signalement_list/modal-signalement-erp-transports.html.twig
@@ -1,0 +1,47 @@
+<dialog aria-labelledby="fr-modal-title-modal-signalement-erp-transports-{{signalement.uuid}}" role="dialog" id="fr-modal-signalement-erp-transports-{{signalement.uuid}}" class="fr-modal fr-sidemodal">
+    <div class="fr-container fr-container--fluid fr-container-md">
+        <div class="fr-grid-row fr-grid-row--center">
+            <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
+                <div class="fr-modal__body">
+                    <div class="fr-modal__header">
+                        <button class="fr-link--close fr-link" title="Fermer la fenêtre modale" aria-controls="fr-modal-signalement-erp-transports-{{signalement.uuid}}" type="button">Fermer</button>
+                    </div>
+                    <div class="fr-modal__content">
+                        <h1 id="fr-modal-title-modal-signalement-erp-transports-{{signalement.uuid}}" class="fr-modal__title"><span class="fr-fi-arrow-right-line fr-fi--lg"></span>Signalement #{{signalement.reference}}</h1>
+                        
+                        <p>Déposé le : {{signalement.createdAt.format('d/m/Y')}}</p>
+                        <p>Punaises vues le : {{signalement.punaisesViewedAt.format('d/m/Y')}}</p>
+
+                        <p>
+                            Type de signalement : {{signalement.type|signalement_type }}
+                            <br>
+                            {% if signalement.type is same as enum('App\\Entity\\Enum\\SignalementType').TYPE_TRANSPORT %}
+                                {{ signalement.placeType|place_type }}
+                            {% else %}
+                                {{ signalement.nomProprietaire }}
+                            {% endif %}
+                            <br>
+                            Avez-vous prévenu l'établissement : {{ signalement.isPlaceAvertie ? 'Oui' : 'Non' }}
+                        </p>
+
+                        <p>
+                            Territoire : {{signalement.territoire.nomComplet}}
+                            <br>
+                            Commune : {{signalement.codePostal}} {{signalement.ville}}
+                        </p>
+
+                        <p>
+                            Autres informations : {{signalement.autresInformations}}
+                        </p>
+
+                        <p>
+                            Usager : {{signalement.nomCompletDeclarant}}
+                            <br>
+                            Email : {{signalement.emailDeclarant}}
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</dialog>


### PR DESCRIPTION
## Ticket

#373    

## Description
Création de la liste des signalements ERP/Transports https://github.com/MTES-MCT/stop-punaises/wiki/listes-de-signalements#signalements-erp-et-transports
Création du menu et de la carte sur le dashboard pour les admins

## Changements apportés
* Création des templates twigs pour la liste, la modale et le filtre
* Ajout d'un item dans le menu et d'une carte dans le dashboard
* Ajout d'extensions twig pour le bon affichage
* Ajout d'une fonction dans le repository pour récupérer les signalements ERP et transports, et modification d'autres fonctions
* Ajout d'une route erp-transports

## Pré-requis

`make create-db`

## Tests
- [ ] Se connecter en admin
- [ ] Vérifier sur le dashboard qu'il y a une nouvelle carte pour les ERP et les transports et qu'elle redirige vers la nouvelle liste
- [ ] Vérifier aussi le fonctionnement du nouvel item dans le menu
- [ ] Vérifier l'affichage de la liste, et les 4 possibilités de filtre
- [ ] Vérifier l'ouverture de la modale
- [ ] Se connecter pas en admin
- [ ] vérifier qu'on n'y a pas accès
