### PR TITLE
[Annuaire Entreprise] Détection Canine

### DIFF
--- a/assets/controllers/list_entreprises_publiques.js
+++ b/assets/controllers/list_entreprises_publiques.js
@@ -4,10 +4,16 @@ $(function() {
   if ($('select#select-entreprises-order').length > 0) {
     startListeEntreprisesPubliquesApp();
   }
+  if ($('select#select-entreprises-filter').length > 0) {
+    startListeEntreprisesPubliquesApp();
+  }
 });
 
 function startListeEntreprisesPubliquesApp() {
   $('select#select-entreprises-order').on('change', function() {
-    window.location.href = $('select#select-entreprises-order').data('redirect') + '&order=' + $('select#select-entreprises-order').val()
+    window.location.href = $('select#select-entreprises-order').data('redirect') + '&order=' + $('select#select-entreprises-order').val() + '&filter=' + $('select#select-entreprises-filter').val()
+  });
+  $('select#select-entreprises-filter').on('change', function() {
+    window.location.href = $('select#select-entreprises-filter').data('redirect') + '&filter=' + $('select#select-entreprises-filter').val() + '&order=' + $('select#select-entreprises-order').val()
   });
 }

--- a/migrations/Version20231020131118.php
+++ b/migrations/Version20231020131118.php
@@ -16,13 +16,13 @@ final class Version20231020131118 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE entreprise_publique CHANGE adresse adresse VARCHAR(255) DEFAULT NULL ADD is_intervention TINYINT(1) NOT NULL, ADD is_detection_canine TINYINT(1) NOT NULL, ADD is_pro_only TINYINT(1) DEFAULT NULL');
+        $this->addSql('ALTER TABLE entreprise_publique CHANGE adresse adresse VARCHAR(255) DEFAULT NULL, ADD is_intervention TINYINT(1) NOT NULL, ADD is_detection_canine TINYINT(1) NOT NULL, ADD is_pro_only TINYINT(1) DEFAULT NULL');
         $this->addSql('UPDATE entreprise_publique SET is_intervention = 1 WHERE is_intervention = \'\'');
         $this->addSql('UPDATE entreprise_publique SET is_detection_canine = 0 WHERE is_detection_canine = \'\'');
     }
 
     public function down(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE entreprise_publique CHANGE adresse adresse VARCHAR(255) NOT NULL DROP is_intervention, DROP is_detection_canine, DROP is_pro_only');
+        $this->addSql('ALTER TABLE entreprise_publique CHANGE adresse adresse VARCHAR(255) NOT NULL, DROP is_intervention, DROP is_detection_canine, DROP is_pro_only');
     }
 }

--- a/migrations/Version20231020131118.php
+++ b/migrations/Version20231020131118.php
@@ -16,13 +16,13 @@ final class Version20231020131118 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE entreprise_publique ADD is_intervention TINYINT(1) NOT NULL, ADD is_detection_canine TINYINT(1) NOT NULL, ADD is_pro_only TINYINT(1) DEFAULT NULL');
+        $this->addSql('ALTER TABLE entreprise_publique CHANGE adresse adresse VARCHAR(255) DEFAULT NULL ADD is_intervention TINYINT(1) NOT NULL, ADD is_detection_canine TINYINT(1) NOT NULL, ADD is_pro_only TINYINT(1) DEFAULT NULL');
         $this->addSql('UPDATE entreprise_publique SET is_intervention = 1 WHERE is_intervention = \'\'');
         $this->addSql('UPDATE entreprise_publique SET is_detection_canine = 0 WHERE is_detection_canine = \'\'');
     }
 
     public function down(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE entreprise_publique DROP is_intervention, DROP is_detection_canine, DROP is_pro_only');
+        $this->addSql('ALTER TABLE entreprise_publique CHANGE adresse adresse VARCHAR(255) NOT NULL DROP is_intervention, DROP is_detection_canine, DROP is_pro_only');
     }
 }

--- a/migrations/Version20231020131118.php
+++ b/migrations/Version20231020131118.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20231020131118 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add information to entreprises publiques';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE entreprise_publique ADD is_intervention TINYINT(1) NOT NULL, ADD is_detection_canine TINYINT(1) NOT NULL, ADD is_pro_only TINYINT(1) DEFAULT NULL');
+        $this->addSql('UPDATE entreprise_publique SET is_intervention = 1 WHERE is_intervention = \'\'');
+        $this->addSql('UPDATE entreprise_publique SET is_detection_canine = 0 WHERE is_detection_canine = \'\'');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE entreprise_publique DROP is_intervention, DROP is_detection_canine, DROP is_pro_only');
+    }
+}

--- a/scripts/postdeploy.sh
+++ b/scripts/postdeploy.sh
@@ -11,6 +11,9 @@ then
 else
     echo "Load data fixtures..."
     composer dump-env dev && php bin/console -e dev doctrine:fixtures:load --no-interaction
+    echo "Load entreprises publiques"
+    php bin/console app:import-entreprise-publique --no-interaction
+    php bin/console app:import-entreprise-publique-detection-canine--no-interaction
     echo "Optimize Composer Autoloader with dev dependencies"
     composer dump-autoload --classmap-authoritative
 fi

--- a/scripts/upload-s3.sh
+++ b/scripts/upload-s3.sh
@@ -10,13 +10,11 @@
 #
 # Usage: ./script.sh [option] [zip]
 #   option - The type of file to upload (grid, signalement, or image)
-#   zip - The code of the department
+#   zip - The code of the department (for signalement)
 #
-# Example 1: ./scripts/upload-s3.sh grid 33
-# Example 2: ./scripts/upload-s3.sh signalement 33
-# Example 3: ./scripts/upload-s3.sh image 33
-# Example 4: ./scripts/upload-s3.sh mapping-doc 33
-# Example 5: ./scripts/upload-s3.sh process-all 33
+# Example 1: ./scripts/upload-s3.sh signalement 33
+# Example 2: ./scripts/upload-s3.sh entreprisespubliques
+# Example 3: ./scripts/upload-s3.sh entreprisespubliques-detectioncanine
 #
 # Notice:
 # - File must be executed in local, ignored during the deployment
@@ -29,12 +27,16 @@ else
   option=$1
   uuid=$2
   debug=${3:null}
-  if [ -z "$uuid" ]; then
-    echo "uuid argument is missing: ./scripts/upload-s3.sh [option] [uuid]"
+  if [ -z "$option" ]; then
+    echo "option argument is missing: ./scripts/upload-s3.sh [option]"
     exit 1
   fi
   case "$option" in
     "signalement")
+      if [ -z "$uuid" ]; then
+        echo "uuid argument is missing: ./scripts/upload-s3.sh [option] [uuid]"
+        exit 1
+      fi
       echo "Upload signalements_$2.csv to cloud..."
       aws s3 cp data/signalement/signalements_${uuid}.csv s3://${BUCKET_URL}/csv/ ${debug}
       aws s3 ls s3://${BUCKET_URL}/csv/signalements_${uuid}.csv
@@ -44,8 +46,13 @@ else
       aws s3 cp data/entreprises.csv s3://${BUCKET_URL}/csv/ ${debug}
       aws s3 ls s3://${BUCKET_URL}/csv/entreprises.csv
       ;;
+    "entreprisespubliques-detectioncanine")
+      echo "Upload entreprises-detection-canine.csv to cloud..."
+      aws s3 cp data/entreprises-detection-canine.csv s3://${BUCKET_URL}/csv/ ${debug}
+      aws s3 ls s3://${BUCKET_URL}/csv/entreprises-detection-canine.csv
+      ;;
     *)
-      echo "Invalid argument. Please use 'grid' or 'signalement' or 'image' or 'mapping-doc' or 'process-all'"
+      echo "Invalid argument. Please use 'signalement' or 'entreprisespubliques' or 'entreprisespubliques-detectioncanine'"
       ;;
   esac
 fi

--- a/src/Command/ImportEntreprisePubliqueDetectionCanineCommand.php
+++ b/src/Command/ImportEntreprisePubliqueDetectionCanineCommand.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Command;
+
+use App\Service\Import\CsvParser;
+use App\Service\Import\EntreprisePublique\EntreprisePubliqueImportLoader;
+use App\Service\Upload\UploadHandlerService;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\NonUniqueResultException;
+use League\Flysystem\FilesystemException;
+use League\Flysystem\FilesystemOperator;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+
+#[AsCommand(
+    name: 'app:import-entreprise-publique-detection-canine',
+    description: 'Import entreprise publique from storage S3',
+)]
+class ImportEntreprisePubliqueDetectionCanineCommand extends Command
+{
+    public function __construct(
+        private CsvParser $csvParser,
+        private ParameterBagInterface $parameterBag,
+        private EntityManagerInterface $entityManager,
+        private FilesystemOperator $fileStorage,
+        private UploadHandlerService $uploadHandlerService,
+        private EntreprisePubliqueImportLoader $entreprisePubliqueImportLoader,
+    ) {
+        parent::__construct();
+    }
+
+    /**
+     * @throws FilesystemException
+     * @throws NonUniqueResultException
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $fromFile = 'csv/entreprises-detection-canine.csv';
+        $toFile = $this->parameterBag->get('uploads_tmp_dir').'entreprises-detection-canine.csv';
+        if (!$this->fileStorage->fileExists($fromFile)) {
+            $io->error('CSV File does not exist');
+
+            return Command::FAILURE;
+        }
+
+        $this->uploadHandlerService->createTmpFileFromBucket($fromFile, $toFile);
+
+        $this->entreprisePubliqueImportLoader->load(
+            data: $this->csvParser->parseAsDict($toFile),
+            headers: $this->csvParser->getHeaders($toFile),
+            output: $output,
+            isDetectionCanine: true
+        );
+
+        $countEntreprises = $this->entreprisePubliqueImportLoader->countEntreprises();
+
+        $io->success(sprintf('%s entreprises publiques de détection canine importées ou mises à jour', $countEntreprises));
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Controller/Front/EntreprisesPubliquesController.php
+++ b/src/Controller/Front/EntreprisesPubliquesController.php
@@ -25,17 +25,23 @@ class EntreprisesPubliquesController extends AbstractController
             $order = 'random';
         }
 
+        $filter = $request->get('filter');
+        if (empty($filter)) {
+            $filter = 'all';
+        }
+
         $codePostal = str_pad($codePostal, 5, '0', \STR_PAD_LEFT);
         $zipCode = substr($codePostal, 0, 2);
         if ('97' == $zipCode) {
             $zipCode = substr($codePostal, 0, 3);
         }
 
-        $listEntreprisesPubliquesByZipCode = $entreprisePubliqueRepository->findByZipCode($zipCode, $order);
+        $listEntreprisesPubliquesByZipCode = $entreprisePubliqueRepository->findByZipCodeAndFilter($zipCode, $order, $filter);
 
         return $this->render('front/entreprises-labelisees.html.twig', [
             'code_postal' => $request->get('code-postal'),
             'order' => $request->get('order'),
+            'filter' => $request->get('filter'),
             'code_departement' => $zipCode,
             'entreprises_publiques' => $listEntreprisesPubliquesByZipCode,
         ]);

--- a/src/Entity/EntreprisePublique.php
+++ b/src/Entity/EntreprisePublique.php
@@ -28,6 +28,15 @@ class EntreprisePublique
     #[ORM\Column(length: 3)]
     private ?string $zip = null;
 
+    #[ORM\Column]
+    private ?bool $isIntervention = null;
+
+    #[ORM\Column]
+    private ?bool $isDetectionCanine = null;
+
+    #[ORM\Column(nullable: true)]
+    private ?bool $isProOnly = null;
+
     public function getId(): ?int
     {
         return $this->id;
@@ -89,6 +98,42 @@ class EntreprisePublique
     public function setZip(string $zip): self
     {
         $this->zip = $zip;
+
+        return $this;
+    }
+
+    public function getIsIntervention(): bool
+    {
+        return $this->isIntervention;
+    }
+
+    public function setIsIntervention(bool $isIntervention): self
+    {
+        $this->isIntervention = $isIntervention;
+
+        return $this;
+    }
+
+    public function getIsDetectionCanine(): bool
+    {
+        return $this->isDetectionCanine;
+    }
+
+    public function setIsDetectionCanine(bool $isDetectionCanine): self
+    {
+        $this->isDetectionCanine = $isDetectionCanine;
+
+        return $this;
+    }
+
+    public function getIsProOnly(): ?bool
+    {
+        return $this->isProOnly;
+    }
+
+    public function setIsProOnly(?bool $isProOnly): self
+    {
+        $this->isProOnly = $isProOnly;
 
         return $this;
     }

--- a/src/Entity/EntreprisePublique.php
+++ b/src/Entity/EntreprisePublique.php
@@ -16,7 +16,7 @@ class EntreprisePublique
     #[ORM\Column(length: 255)]
     private ?string $nom = null;
 
-    #[ORM\Column(length: 255)]
+    #[ORM\Column(length: 255, nullable: true)]
     private ?string $adresse = null;
 
     #[ORM\Column(length: 255, nullable: true)]
@@ -59,7 +59,7 @@ class EntreprisePublique
         return $this->adresse;
     }
 
-    public function setAdresse(string $adresse): self
+    public function setAdresse(?string $adresse): self
     {
         $this->adresse = $adresse;
 

--- a/src/Factory/EntreprisePubliqueFactory.php
+++ b/src/Factory/EntreprisePubliqueFactory.php
@@ -10,9 +10,12 @@ class EntreprisePubliqueFactory
     {
         return (new EntreprisePublique())
         ->setNom($data['nom'])
-        ->setAdresse($data['adresse'])
+        ->setAdresse($data['adresse'] ?? '')// TODO à enlever une fois qu'on aura les adresses des entreprises de détection canine
         ->setUrl($data['url'])
         ->setTelephone($data['telephone'])
-        ->setZip($data['zip']);
+        ->setZip($data['zip'])
+        ->setIsDetectionCanine($data['detection_canine'])
+        ->setIsIntervention($data['intervention'])
+        ->setIsProOnly($data['is_pro_only']);
     }
 }

--- a/src/Factory/EntreprisePubliqueFactory.php
+++ b/src/Factory/EntreprisePubliqueFactory.php
@@ -10,7 +10,7 @@ class EntreprisePubliqueFactory
     {
         return (new EntreprisePublique())
         ->setNom($data['nom'])
-        ->setAdresse($data['adresse'] ?? '')// TODO à enlever une fois qu'on aura les adresses des entreprises de détection canine
+        ->setAdresse($data['adresse'])
         ->setUrl($data['url'])
         ->setTelephone($data['telephone'])
         ->setZip($data['zip'])

--- a/src/Manager/EntreprisePubliqueManager.php
+++ b/src/Manager/EntreprisePubliqueManager.php
@@ -35,11 +35,31 @@ class EntreprisePubliqueManager extends AbstractManager
 
     public function update(EntreprisePublique $entreprisePublique, array $data): EntreprisePublique
     {
-        return $entreprisePublique
-            ->setNom($data['nom'])
-            ->setAdresse($data['adresse'])
-            ->setUrl($data['url'])
-            ->setTelephone($data['telephone'])
-            ->setZip($data['zip']);
+        if (null !== $data['nom']) {
+            $entreprisePublique->setNom($data['nom']);
+        }
+        if (null !== $data['adresse']) {
+            $entreprisePublique->setAdresse($data['adresse']);
+        }
+        if (null !== $data['url']) {
+            $entreprisePublique->setUrl($data['url']);
+        }
+        if (null !== $data['telephone']) {
+            $entreprisePublique->setTelephone($data['telephone']);
+        }
+        if (null !== $data['zip']) {
+            $entreprisePublique->setZip($data['zip']);
+        }
+        if (null !== $data['detection_canine']) {
+            $entreprisePublique->setIsDetectionCanine($data['detection_canine']);
+        }
+        if (null !== $data['intervention']) {
+            $entreprisePublique->setIsIntervention($data['intervention']);
+        }
+        if (null !== $data['is_pro_only']) {
+            $entreprisePublique->setIsProOnly($data['is_pro_only']);
+        }
+
+        return $entreprisePublique;
     }
 }

--- a/src/Repository/EntreprisePubliqueRepository.php
+++ b/src/Repository/EntreprisePubliqueRepository.php
@@ -39,11 +39,17 @@ class EntreprisePubliqueRepository extends ServiceEntityRepository
         }
     }
 
-    public function findByZipCode(string $zipCode, string $order): array
+    public function findByZipCodeAndFilter(string $zipCode, string $order, string $filter): array
     {
         $qb = $this->createQueryBuilder('ep');
         $qb->where('ep.zip LIKE :zipCode')
             ->setParameter('zipCode', $zipCode);
+        if ('intervention' === $filter) {
+            $qb->andWhere('ep.isIntervention = 1');
+        }
+        if ('detection-canine' === $filter) {
+            $qb->andWhere('ep.isDetectionCanine = 1');
+        }
 
         if ('ASC' === $order || 'DESC' === $order) {
             $qb->orderBy('ep.nom', $order);

--- a/src/Service/Import/EntreprisePublique/EntreprisePubliqueImportLoader.php
+++ b/src/Service/Import/EntreprisePublique/EntreprisePubliqueImportLoader.php
@@ -41,13 +41,8 @@ class EntreprisePubliqueImportLoader
         foreach ($data as $item) {
             $dataMapped = $this->entreprisePubliqueImportMapper->map($headers, $item);
             if (!empty($dataMapped)) {
-                if ($isDetectionCanine) {
-                    $dataMapped['detection_canine'] = true;
-                    $dataMapped['intervention'] = false;
-                } else {
-                    $dataMapped['detection_canine'] = false;
-                    $dataMapped['intervention'] = true;
-                }
+                $dataMapped['detection_canine'] = $isDetectionCanine;
+                $dataMapped['intervention'] = !$isDetectionCanine;
 
                 if (null !== $dataMapped['zips']) {
                     $zips = explode('|', $dataMapped['zips']);

--- a/src/Service/Import/EntreprisePublique/EntreprisePubliqueImportMapper.php
+++ b/src/Service/Import/EntreprisePublique/EntreprisePubliqueImportMapper.php
@@ -12,6 +12,8 @@ class EntreprisePubliqueImportMapper
             'adresse' => 'adresse',
             'url' => 'url',
             'telephone' => 'telephone',
+            'is_pro_only' => 'is_pro_only',
+            'zips' => 'zips',
         ];
     }
 

--- a/templates/front/entreprises-labelisees.html.twig
+++ b/templates/front/entreprises-labelisees.html.twig
@@ -12,6 +12,18 @@
         <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--right">
             <div class="fr-col-3">
                 <div class="fr-select-group">
+                    <label class="fr-label" for="select-entreprises-filter">
+                        Filtré par
+                    </label>
+                    <select class="fr-select" id="select-entreprises-filter" name="select" data-redirect="{{ path('app_front_entreprises_labellisees') }}?code-postal={{ code_postal }}">
+                        <option value="all">Tous</option>
+                        <option value="intervention" {{ filter is same as 'intervention' ? 'selected' : '' }}>Intervention</option>
+                        <option value="detection-canine" {{ filter is same as 'detection-canine' ? 'selected' : '' }}>Détection canine</option>
+                    </select>
+                </div>
+            </div>
+            <div class="fr-col-3">
+                <div class="fr-select-group">
                     <label class="fr-label" for="select-entreprises-order">
                         Trié par
                     </label>
@@ -37,6 +49,14 @@
                                     <a href="{{ entreprise_publique.url }}" target="_blank" rel="noopener">{{ entreprise_publique.nom }}</a>
                                 </h3>
                                 <p class="fr-card__desc">{{ entreprise_publique.adresse }}</p>
+                                {% if entreprise_publique.isIntervention == 1 %}
+                                <p class="fr-card__desc fr-badge">Intervention</p>
+                                {% elseif entreprise_publique.isDetectionCanine == 1 %}
+                                <p class="fr-card__desc fr-badge">Détection canine</p>
+                                {% endif %}
+                                {% if entreprise_publique.isProOnly == 1 %}
+                                <p class="fr-card__desc fr-badge">Pour les professionnels uniquement</p>
+                                {% endif %}
                             </div>
                             <div class="fr-card__footer">
                                 <ul class="fr-links-group display-list-block">

--- a/templates/front/entreprises-labelisees.html.twig
+++ b/templates/front/entreprises-labelisees.html.twig
@@ -48,7 +48,9 @@
                                 <h3 class="fr-card__title">
                                     <a href="{{ entreprise_publique.url }}" target="_blank" rel="noopener">{{ entreprise_publique.nom }}</a>
                                 </h3>
-                                <p class="fr-card__desc">{{ entreprise_publique.adresse }}</p>
+                                {% if entreprise_publique.adresse %}
+                                    <p class="fr-card__desc">{{ entreprise_publique.adresse }}</p>
+                                {% endif %}
                                 {% if entreprise_publique.isIntervention == 1 %}
                                 <p class="fr-card__desc fr-badge">Intervention</p>
                                 {% elseif entreprise_publique.isDetectionCanine == 1 %}


### PR DESCRIPTION
## Ticket

#372    

## Description
    Intégrer les entreprises manquantes
    Distinguer dans l'annuaire la détection et l'intervention


## Changements apportés
*  faire évoluer l'entité entreprise_publique pour ajouter isIntervention, isDetectionCanine, isProOnly (3 booléens)
*  dans la migration, attribuer les valeurs 1, 0, 0 à ces 3 nouvelles informations
*  création d'une commande qui parcourt le fichier des entreprises de détection canine :  si l'entreprise existe déjà lui mettre les bonnes valeurs pour isIntervention, isDetectionCanine, isProOnly (0, 1 et selon le fichier) (pour chaque occurence), et si l'entreprise n'existe pas la créer dans les départements adéquats.
*  faire évoluer l'affichage de la page entreprises-labellisees pour ajouter les informations detection/intervention et "only pro" dans l'encart et pour créer un filtre

## Pré-requis

## Tests
- [ ] Le fichier csv des entreprises de détection canine est déjà sur le bucket
- [ ] Jouer la commande d'import d'entreprises publiques si ce n'est pas déjà fait `symfony console app:import-entreprise-publique`
- [ ] Jouer la nouvelle commande `symfony console app:import-entreprise-publique-detection-canine`
- [ ] Aller sur la page http://localhost:8090/entreprises-labellisees?code-postal=81000 , vérifier qu'il y a bien des badges pour préciser si les entreprises font de l'intervention ou de la détection canine ou si elles ne sont que pour les pro
- [ ] Vérifier le fonctionnement du filtre, et du tri avec le filtre
