### PR TITLE
[CD] Forcer la version de node à 18.18.2 LTS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2900,9 +2900,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001412",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001412.tgz",
-            "integrity": "sha512-+TeEIee1gS5bYOiuf+PS/kp2mrXic37Hl66VY6EAfxasIk5fELTktK2oOezYed12H8w7jt3s512PpulQidPjwA==",
+            "version": "1.0.30001553",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001553.tgz",
+            "integrity": "sha512-N0ttd6TrFfuqKNi+pMgWJTb9qrdJu4JSpgPFLe/lrD19ugC6fZgF0pUewRowDwzdDnb9V41mFcdlYgl/PyKf4A==",
             "dev": true,
             "funding": [
                 {
@@ -2912,6 +2912,10 @@
                 {
                     "type": "tidelift",
                     "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
                 }
             ]
         },
@@ -9846,9 +9850,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001412",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001412.tgz",
-            "integrity": "sha512-+TeEIee1gS5bYOiuf+PS/kp2mrXic37Hl66VY6EAfxasIk5fELTktK2oOezYed12H8w7jt3s512PpulQidPjwA==",
+            "version": "1.0.30001553",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001553.tgz",
+            "integrity": "sha512-N0ttd6TrFfuqKNi+pMgWJTb9qrdJu4JSpgPFLe/lrD19ugC6fZgF0pUewRowDwzdDnb9V41mFcdlYgl/PyKf4A==",
             "dev": true
         },
         "chalk": {

--- a/package.json
+++ b/package.json
@@ -28,5 +28,8 @@
         "datatables.net-dt": "^1.12.1",
         "jquery": "^3.6.1",
         "jquery-ui": "^1.13.2"
+    },
+    "engines": {
+        "node": "18.18.2"
     }
 }


### PR DESCRIPTION
## Ticket

#398

## Description
Depuis mercredi, tous les déploiements sont en échec
https://dashboard.scalingo.com/apps/osc-fr1/stop-punaises/deploy/list

Nous remarquons que le build utilise une version 21.0
![image](https://github.com/MTES-MCT/stop-punaises/assets/5757116/14eafeb7-cbc3-4e24-b25d-58fb4cbda677)

Il s’avère que cette version est sorti mardi dernier 
https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V21.md#21.0.0

Nos environnements de developpement ainsi qu'Histologe sont sur une version LTS  de node (voir https://github.com/MTES-MCT/histologe/pull/1011)

## Changements apportés
* MAJ du package caniuse-lite
* Forcer la version de node dans le package.json

## Pré-requis

## Tests
- [ ] Déploiement review app OK (https://stop-punaises-staging-pr399.osc-fr1.scalingo.io/)
- [ ] Build OK https://dashboard.scalingo.com/apps/osc-fr1/stop-punaises-staging-pr399/deploy/list