### PR TITLE
[QA] Ajout de contraintes sur le code postal

### DIFF
--- a/assets/controllers/form_signalement_front.js
+++ b/assets/controllers/form_signalement_front.js
@@ -87,10 +87,24 @@ class PunaisesFrontSignalementController {
     $('.link-back-back').on('click', function(){
       self.refreshStep(-2);
     });
-    if ($('form.front-signalement').data('code-postal') !== '') {
+    if (self.checkCodePostal('code-postal')) {
       $('#code-postal').val($('form.front-signalement').data('code-postal'));
       $('#step-home button').click();
     }
+  }
+
+  checkCodePostal(idInput) {
+    if ($('input#' + idInput).val() !== '') {    
+      const postalCodePattern = /^\d{5}$/;
+      if (!postalCodePattern.test($('input#' + idInput).val())) {
+        $('input#' + idInput).siblings('.fr-error-text').removeClass('fr-hidden');
+        return false;
+      }
+    } else {
+      return false;
+    }
+    return true;
+
   }
 
   refreshStep(offset) {
@@ -249,7 +263,7 @@ class PunaisesFrontSignalementController {
   }
 
   checkStepHome() {
-    let canGoNext = self.checkSingleInput('code-postal');
+    let canGoNext = self.checkCodePostal('code-postal');
     if (canGoNext) {
       let inputContent = $('input#code-postal').val();
       let zipCode = inputContent.substring(0, 2);
@@ -273,6 +287,10 @@ class PunaisesFrontSignalementController {
     if (!self.checkSingleInput('signalement_front_codePostal')) {
       canGoNext = false;
     }
+    if (!self.checkCodePostal('signalement_front_codePostal')) {
+      canGoNext = false;
+    }
+
     if (!self.checkSingleInput('signalement_front_ville')) {
       canGoNext = false;
     }

--- a/src/Controller/Front/SignalementController.php
+++ b/src/Controller/Front/SignalementController.php
@@ -36,7 +36,7 @@ class SignalementController extends AbstractController
         ]);
     }
 
-    #[Route('/signalement/ajout', name: 'app_front_signalement_add', methods: ['POST'])]
+    #[Route('/signalement/logement/ajout', name: 'app_front_signalement_add', methods: ['POST'])]
     public function save(
         Request $request,
         SignalementManager $signalementManager,

--- a/src/Controller/Front/SignalementController.php
+++ b/src/Controller/Front/SignalementController.php
@@ -78,21 +78,19 @@ class SignalementController extends AbstractController
                 return $this->json(['response' => 'error', 'errors' => 'code postal null'], Response::HTTP_BAD_REQUEST);
             }
 
-            if (SignalementType::TYPE_LOGEMENT === $signalement->getType()) {
-                if ($signalement->isAutotraitement()) {
-                    if ($signalement->getTerritoire()->isActive()) {
-                        $mailerProvider->sendSignalementValidationWithAutotraitement($signalement);
-                    } else {
-                        $mailerProvider->sendSignalementValidationWithEntreprisesPubliques($signalement);
-                    }
+            if ($signalement->isAutotraitement()) {
+                if ($signalement->getTerritoire()->isActive()) {
+                    $mailerProvider->sendSignalementValidationWithAutotraitement($signalement);
                 } else {
-                    $mailerProvider->sendSignalementValidationWithPro($signalement);
+                    $mailerProvider->sendSignalementValidationWithEntreprisesPubliques($signalement);
+                }
+            } else {
+                $mailerProvider->sendSignalementValidationWithPro($signalement);
 
-                    $entreprises = $entrepriseRepository->findByTerritoire($signalement->getTerritoire());
-                    foreach ($entreprises as $entreprise) {
-                        if ($entreprise->getUser() && $entreprise->getUser()->getEmail()) {
-                            $mailerProvider->sendSignalementNewForPro($entreprise->getUser()->getEmail(), $signalement);
-                        }
+                $entreprises = $entrepriseRepository->findByTerritoire($signalement->getTerritoire());
+                foreach ($entreprises as $entreprise) {
+                    if ($entreprise->getUser() && $entreprise->getUser()->getEmail()) {
+                        $mailerProvider->sendSignalementNewForPro($entreprise->getUser()->getEmail(), $signalement);
                     }
                 }
             }

--- a/src/Form/SignalementErpType.php
+++ b/src/Form/SignalementErpType.php
@@ -122,6 +122,7 @@ class SignalementErpType extends AbstractType
                 'required' => true,
                 'constraints' => [
                     new Assert\NotBlank(message: 'Veuillez renseigner le code postal.'),
+                    new Assert\Regex('/[0-9]{5}/', 'Veuillez utiliser un code postal valide'),
                 ],
             ])
             ->add('ville', TextType::class, [

--- a/src/Form/SignalementFrontType.php
+++ b/src/Form/SignalementFrontType.php
@@ -15,6 +15,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class SignalementFrontType extends AbstractType
 {
@@ -72,14 +73,18 @@ class SignalementFrontType extends AbstractType
                 'attr' => [
                     'class' => 'fr-input',
                     'pattern' => '[0-9]{5}',
-                ],
-                'label_attr' => [
-                    'class' => 'fr-label',
                     'maxlength' => '5',
                     'minlength' => '5',
                 ],
+                'label_attr' => [
+                    'class' => 'fr-label',
+                ],
                 'label' => 'Code postal',
                 'required' => true,
+                'constraints' => [
+                    new Assert\NotBlank(message: 'Veuillez renseigner le code postal'),
+                    new Assert\Regex('/[0-9]{5}/', 'Veuillez utiliser un code postal valide'),
+                ],
             ])
             ->add('codeInsee', HiddenType::class, [
                 'attr' => [

--- a/src/Form/SignalementHistoryType.php
+++ b/src/Form/SignalementHistoryType.php
@@ -24,6 +24,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class SignalementHistoryType extends AbstractType
 {
@@ -49,14 +50,18 @@ class SignalementHistoryType extends AbstractType
                 'attr' => [
                     'class' => 'fr-input',
                     'pattern' => '[0-9]{5}',
-                ],
-                'label_attr' => [
-                    'class' => 'fr-label',
                     'maxlength' => '5',
                     'minlength' => '5',
                 ],
+                'label_attr' => [
+                    'class' => 'fr-label',
+                ],
                 'label' => 'Code postal',
                 'required' => true,
+                'constraints' => [
+                    new Assert\NotBlank(message: 'Veuillez renseigner le code postal'),
+                    new Assert\Regex('/[0-9]{5}/', 'Veuillez utiliser un code postal valide'),
+                ],
             ])
             ->add('codeInsee', HiddenType::class, [
                 'attr' => [

--- a/templates/front_signalement/_partial_step_home.html.twig
+++ b/templates/front_signalement/_partial_step_home.html.twig
@@ -8,7 +8,7 @@
             </p>
 
             <div class="fr-input-group">
-                <input class="fr-input" id="code-postal" name="code-postal" placeholder="Code postal" required>
+                <input class="fr-input" id="code-postal" name="code-postal" placeholder="Code postal" required type="numeric" maxlength=5 minlength=5>
                 <p class="fr-error-text fr-hidden">
                     Veuillez renseigner votre code postal.
                 </p>


### PR DESCRIPTION
## Ticket

#350 
#383    

## Description
Ajout de contraintes sur le code postal pour éviter 2 erreurs sentry

## Changements apportés
* Ajout de contraintes dans les FormType
* Ajout de vérification js

## Pré-requis

## Tests
- [ ] Faire tous les types de signalements possibles pour vérifier l'absence de régression, et essayer de mettre des fausses valeurs dans les codes postaux
