### PR TITLE
[FO] Formulaire ERP / Transport

### DIFF
--- a/.docker/nginx/default.conf
+++ b/.docker/nginx/default.conf
@@ -4,6 +4,10 @@ server {
 
     client_max_body_size 200M;
 
+    location ~* ^/_up/.*\.(jpg|jpeg|png)$ {
+        try_files $uri /index.php$is_args$args;
+    }
+
     include /etc/nginx/conf.d/server.location;
 
     location / {

--- a/.docker/nginx/default.conf
+++ b/.docker/nginx/default.conf
@@ -4,10 +4,6 @@ server {
 
     client_max_body_size 200M;
 
-    location ~* ^/_up/.*\.(jpg|jpeg|png)$ {
-        try_files $uri /index.php$is_args$args;
-    }
-
     include /etc/nginx/conf.d/server.location;
 
     location / {

--- a/.scalingo/nginx/server.location
+++ b/.scalingo/nginx/server.location
@@ -1,3 +1,7 @@
+location ~* ^/_up/.*\.(jpg|jpeg|png)$ {
+    try_files $uri /index.php$is_args$args;
+}
+
 location ~* \.(css|js|jpg|jpeg|png|svg|webp|mp4|ico|woff2|woff|eot|ttf) {
     # Cache for 1 year.
     # Caching JS and CSS is safe too, as Symfony includes hashes in build filenames.

--- a/assets/controllers/form_signalement_erp_transport.js
+++ b/assets/controllers/form_signalement_erp_transport.js
@@ -50,7 +50,6 @@ function handleFileUpload() {
         $('.fr-upload-group').next().addClass('fr-hidden');
 
         for (let i = 0; i < event.target.files.length; i++) {
-            console.log(event.target.files[i], event.target.files[i] < 10 * 1024 * 1024);
             if (event.target.files[i].size < 10 * 1024 * 1024) {
                 let imgSrc = URL.createObjectURL(event.target.files[i]);
                 let strAppend = '<div class="fr-col-6 fr-col-md-3" style="text-align: center;">';
@@ -58,7 +57,6 @@ function handleFileUpload() {
                 strAppend += '</div>';
                 $('.fr-front-signalement-photos').append(strAppend);
             } else {
-                console.log($('.fr-upload-group'));
                 $('.fr-upload-group').next().removeClass('fr-hidden');
                 break;
             }

--- a/assets/controllers/form_signalement_erp_transport.js
+++ b/assets/controllers/form_signalement_erp_transport.js
@@ -5,6 +5,7 @@ $(function () {
         $('.signalement-punaises-success').hide();
         sendSignalement();
         handleFileUpload();
+        handleBehaviourRadio();
     }
 });
 
@@ -46,12 +47,32 @@ function sendSignalement() {
 function handleFileUpload() {
     $('#file-upload').on('change', function(event) {
         $('.fr-front-signalement-photos').empty();
+        $('.fr-upload-group').next().addClass('fr-hidden');
+
         for (let i = 0; i < event.target.files.length; i++) {
-            let imgSrc = URL.createObjectURL(event.target.files[i]);
-            let strAppend = '<div class="fr-col-6 fr-col-md-3" style="text-align: center;">';
-            strAppend += '<img src="' + imgSrc + '" width="100" height="100">';
-            strAppend += '</div>';
-            $('.fr-front-signalement-photos').append(strAppend);
+            console.log(event.target.files[i], event.target.files[i] < 10 * 1024 * 1024);
+            if (event.target.files[i].size < 10 * 1024 * 1024) {
+                let imgSrc = URL.createObjectURL(event.target.files[i]);
+                let strAppend = '<div class="fr-col-6 fr-col-md-3" style="text-align: center;">';
+                strAppend += '<img src="' + imgSrc + '" width="100" height="100">';
+                strAppend += '</div>';
+                $('.fr-front-signalement-photos').append(strAppend);
+            } else {
+                console.log($('.fr-upload-group'));
+                $('.fr-upload-group').next().removeClass('fr-hidden');
+                break;
+            }
         }
     });
+}
+
+function handleBehaviourRadio() {
+    $('input[type=radio]').on('click', function(event) {
+        if (event.target.checked) {
+            $(this).parent().siblings().removeClass('is-checked');
+            $(this).parent().addClass('is-checked');
+        } else {
+            $(this).parent().removeClass('is-checked');
+        }
+    })
 }

--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -1,3 +1,7 @@
+input[type="time"]::-webkit-calendar-picker-indicator {
+    background: none;
+}
+
 span.niveau-infestation {
     display: inline-block;
     padding: 5px 10px;
@@ -929,6 +933,33 @@ span.image-caption {
         &::after {
             --icon-size: 0rem;
         }
+    }
+}
+
+.signalement-punaises {
+    .fr-radio-group {
+        border: 1px solid var(--border-disabled-grey);
+        max-width: 500px;
+        padding: 0.2rem 1rem;
+        width: 100%;
+        margin: 1rem 0;
+
+        &:hover {
+            background-color: var(--grey-1000-50-hover);
+        }
+        &.is-checked {
+            border: 1px solid #000091;
+        }
+    }
+    .fr-btn--secondary {
+        width: fit-content;
+    }
+    .custom-file-input {
+        line-height: 2.5rem;
+        opacity: 0;
+        position: relative;
+        top: -2.5rem;
+        width: 100%;
     }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,9 @@
                 "webpack": "^5.76.0",
                 "webpack-cli": "^4.10.0",
                 "webpack-notifier": "^1.15.0"
+            },
+            "engines": {
+                "node": "18.18.2"
             }
         },
         "node_modules/@ampproject/remapping": {

--- a/templates/front_signalement_erp/index.html.twig
+++ b/templates/front_signalement_erp/index.html.twig
@@ -31,7 +31,9 @@
                 <div class="fr-form-group display-if-diagnostic display-if-traitement">
                     <div class="fr-input-group">
                         {{ form_label(form.punaisesViewedTimeAt) }}
-                        {{ form_widget(form.punaisesViewedTimeAt) }}
+                        <div class="fr-input-wrap fr-icon-timer-line">
+                            {{ form_widget(form.punaisesViewedTimeAt) }}
+                        </div>
                         <p class="fr-error-text fr-hidden">
                             Veuillez renseigner l'heure.
                         </p>
@@ -51,16 +53,14 @@
                     <div class="fr-input-group search-address">
                         <label for="">Adresse de l'établissement</label>
                         <span class="fr-hint-text help-text">Tapez l'adresse puis selectionnez-la dans la liste</span>
-                        <input id="rechercheAdresse" type="text" class="fr-input">
-                        <div id="rechercheAdresseIcon">
-                            <span class="fr-icon-map-pin-2-line" aria-hidden="true"></span>
-                            <span class="fr-icon-timer-line" aria-hidden="true"></span>
+                        <div class="fr-input-wrap fr-icon-map-pin-2-line">
+                            <input id="rechercheAdresse" type="text" class="fr-input">
                         </div>
                         <div id="rechercheAdresseListe" class="fr-mt-1v fr-py-1w">
                         </div>
                     </div>
                 </div>
-                <div id="adresse_afficher_les_champs" style="margin-top: -3rem">
+                <div id="adresse_afficher_les_champs">
                     <button type="button" class="fr-btn btn-link fr-btn--icon-left fr-icon-eye-line">
                         Afficher tous les champs
                     </button>
@@ -136,7 +136,8 @@
                         <label class="fr-label" for="file-upload">Photos (facultatif)</label>
                         <p>Vous avez pris des photos des punaises ? Ajoutez-les en cliquant sur le bouton
                             ci-dessous.</p>
-                        <input class="fr-upload"
+                        <label class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-add-line" for="file-upload">Ajouter des photos</label>
+                        <input class="fr-upload custom-file-input"
                                type="file"
                                id="file-upload"
                                name="file-upload[]"
@@ -144,6 +145,9 @@
                                accept=".jpg, .jpeg, .png"
                         >
                     </div>
+                    <p class="fr-error-text fr-hidden">
+                        Merci d'ajouter une photo de moins de 10Mo.
+                    </p>
                     <div class="fr-grid-row fr-grid fr-grid-row--gutters fr-mt-3v fr-front-signalement-photos">
                     </div>
                 </div>
@@ -189,7 +193,7 @@
                 </div>
                 <input type="hidden" name="_csrf_token" value="{{ csrf_token('save_signalement_erp') }}">
                 <div class="fr-input-group">
-                    <button type="submit" class="fr-btn btn-next-next">
+                    <button type="submit" class="fr-btn btn-next fr-btn--icon-left fr-icon-check-line">
                         Signaler mon problème
                     </button>
                 </div>

--- a/templates/front_signalement_transport/index.html.twig
+++ b/templates/front_signalement_transport/index.html.twig
@@ -32,7 +32,9 @@
                 <div class="fr-form-group display-if-diagnostic display-if-traitement">
                     <div class="fr-input-group">
                         {{ form_label(form.punaisesViewedTimeAt) }}
-                        {{ form_widget(form.punaisesViewedTimeAt) }}
+                        <div class="fr-input-wrap fr-icon-timer-line">
+                            {{ form_widget(form.punaisesViewedTimeAt) }}
+                        </div>
                         <p class="fr-error-text fr-hidden">
                             Veuillez renseigner l'heure.
                         </p>
@@ -43,7 +45,9 @@
                     <div class="fr-select-group search-commune">
                         {{ form_label(form.ville) }}
                         {{ form_help(form.ville) }}
-                        {{ form_widget(form.ville) }}
+                        <div class="fr-input-wrap fr-icon-map-pin-2-line">
+                            {{ form_widget(form.ville) }}
+                        </div>
                         <p class="fr-error-text fr-hidden">
                             Veuillez renseigner la commune.
                         </p>
@@ -95,8 +99,10 @@
                         <label class="fr-label" for="file-upload">Photos (facultatif)</label>
                         <p>Vous avez pris des photos des punaises ? Ajoutez-les en cliquant sur le bouton
                             ci-dessous.</p>
+                        <label class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-add-line" for="file-upload">Ajouter
+                            des photos</label>
                         <input
-                                class="fr-upload"
+                                class="fr-upload custom-file-input"
                                 type="file"
                                 id="file-upload"
                                 name="file-upload[]"
@@ -104,6 +110,9 @@
                                 accept=".jpg, .jpeg, .png"
                         >
                     </div>
+                    <p class="fr-error-text fr-hidden">
+                        Merci d'ajouter une photo de moins de 10Mo.
+                    </p>
                     <div class="fr-grid-row fr-grid fr-grid-row--gutters fr-mt-3v fr-front-signalement-photos">
                     </div>
                 </div>


### PR DESCRIPTION
## Ticket

#374 
#375    

## Description
Ajout d'un bloc de configuration Nginx pour laisser symfony servir toute URL commençant par "/_up/" suivie de n'importe quel nombre de caractères, puis se terminant par l'extension ".jpg", ".jpeg" ou ".png".

**L'ordre des bloc est important  il se situe avant le bloc qui sert les assets pour mise en cache**

## Changements apportés
* Mise à jour de la conf nginx
* Mise à jour UI (icones, bouton d'upload, radio, ect..)
* Limiter les fichiers à 10 MB

## Pré-requis
```
make build
```

## Tests
 - [ ]Soumettre un signalement ERP et vérifier qu'il apparaît bien dans la liste et qu'un email est bien envoyé
 - [ ] Soumettre un signalement transport et vérifier qu'il apparaît bien dans la liste et qu'un email est bien envoyé
 - [ ] Afficher les signalement et ouvrir les images