### PR TITLE
[QA] plusieurs interventions retournées quand 1 attendue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ create-db-test: ## Create test database
 
 
 test: ## Run all tests
-	@$(DOCKER_COMP) exec stopunaises_phpfpm sh -c "$(PHPUNIT) --stop-on-failure --testdox -d memory_limit=-1"
+	@$(DOCKER_COMP) exec stopunaises_phpfpm sh -c "$(PHPUNIT) $(FILE) --stop-on-failure --testdox -d memory_limit=-1"
 
 test-coverage: ## Generate phpunit coverage report in html
 	@$(DOCKER_COMP) exec stopunaises_phpfpm sh -c "XDEBUG_MODE=coverage $(PHPUNIT) --coverage-html coverage"

--- a/src/Repository/InterventionRepository.php
+++ b/src/Repository/InterventionRepository.php
@@ -50,7 +50,9 @@ class InterventionRepository extends ServiceEntityRepository
             ->where('i.signalement = :signalement')
                 ->setParameter('signalement', $signalement)
             ->andWhere('i.entreprise = :entreprise')
-                ->setParameter('entreprise', $entreprise);
+                ->setParameter('entreprise', $entreprise)
+            ->orderBy('i.id')
+            ->setMaxResults(1);
 
         return $qb->getQuery()->getOneOrNullResult();
     }

--- a/tests/Functionnal/Controller/SignalementViewControllerTest.php
+++ b/tests/Functionnal/Controller/SignalementViewControllerTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Tests\Functionnal\Controller;
+
+use App\Repository\InterventionRepository;
+use App\Repository\SignalementRepository;
+use App\Repository\UserRepository;
+use App\Tests\SessionHelper;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\Routing\RouterInterface;
+
+class SignalementViewControllerTest extends WebTestCase
+{
+    use SessionHelper;
+
+    public function testSignalementSuccessfullyDisplay(): void
+    {
+        $client = static::createClient();
+        /** @var UserRepository $userRepository */
+        $userRepository = static::getContainer()->get(UserRepository::class);
+
+        $user = $userRepository->findOneBy(['email' => 'admin@punaises.fr']);
+        /** @var SignalementRepository $signalementRepository */
+        $signalementRepository = static::getContainer()->get(SignalementRepository::class);
+        $signalement = $signalementRepository->findOneBy(['reference' => '2023-1']);
+
+        $client->loginUser($user);
+
+        /** @var RouterInterface $router */
+        $router = self::getContainer()->get(RouterInterface::class);
+        $routePostSignalement = $router->generate('app_signalement_view', ['uuid' => $signalement->getUuid()]);
+        $client->request('GET', $routePostSignalement);
+
+        $this->assertResponseIsSuccessful($signalement->getId());
+    }
+
+    public function testAcceptSignalement(): void
+    {
+        $client = static::createClient();
+
+        /** @var UserRepository $userRepository */
+        $userRepository = static::getContainer()->get(UserRepository::class);
+
+        $user = $userRepository->findOneBy(['email' => 'company-01@punaises.fr']);
+        /** @var SignalementRepository $signalementRepository */
+        $signalementRepository = static::getContainer()->get(SignalementRepository::class);
+        $signalement = $signalementRepository->findOneBy(['reference' => '2023-1']);
+
+        $client->loginUser($user);
+
+        /** @var RouterInterface $router */
+        $router = self::getContainer()->get(RouterInterface::class);
+        $routePostSignalement = $router->generate(
+            'app_signalement_intervention_accept',
+            [
+                'uuid' => $signalement->getUuid(),
+                '_csrf_token' => $this->generateCsrfToken($client, 'signalement_intervention_accept'),
+            ]
+        );
+        $client->request('POST', $routePostSignalement);
+
+        $this->assertResponseRedirects('/bo/signalements/'.$signalement->getUuid());
+
+        /** @var InterventionRepository $interventionRepository */
+        $interventionRepository = static::getContainer()->get(InterventionRepository::class);
+
+        $intervention = $interventionRepository->findBy([
+            'signalement' => $signalement,
+            'entreprise' => $user->getEntreprise(),
+        ]);
+        $this->assertCount(1, $intervention);
+
+        // on rappelle la route une deuxième fois pour vérifier qu'une deuxième intervention n'est pas créée
+        $client->request('POST', $routePostSignalement);
+
+        $intervention = $interventionRepository->findBy([
+            'signalement' => $signalement,
+            'entreprise' => $user->getEntreprise(),
+        ]);
+        $this->assertCount(1, $intervention);
+    }
+}


### PR DESCRIPTION
## Ticket

#384    

## Description
On a actuellement une erreur sentry, car certains signalements ont plusieurs interventions identiques pour la même entreprise.
Je n'ai pas réussi à reproduire la création de ces interventions identiques. Mais si on en suplique une en base, on reproduit l'erreur en affichant la fiche signalement dans le BO avec l'entreprise concernée

## Changements apportés
* Dans la route `app_signalement_intervention_accept`, on vérifie d'abors s'il n'existe pas déjà une intervention pour ce signalement*entreprise avant d'en créer une
* Dans le repository on ne récupère que la première des interventions si elles sont doublonnées

## Pré-requis

## Tests
- [ ] Créer un signalement
- [ ] L'accepter avec une entreprise, vérifier que l'intervention se créé bien "normalement" et qu'il n'y en a pas plusieurs
- [ ] La dupliquer en base
- [ ] Actualiser la fiche signalement et vérifier qu'il n'y a pas d'erreur
