### PR TITLE
[FO] Formulaire ERP - Focus sur le champs autocompletion adresse en cas d'erreur

### DIFF
--- a/assets/controllers/form_signalement_erp_transport.js
+++ b/assets/controllers/form_signalement_erp_transport.js
@@ -50,6 +50,7 @@ function sendSignalement() {
                        $('[name="' + element + '"]').closest('.fr-input-group, .fr-select-group').find('.fr-error-text').removeClass('fr-hidden');
                        if (element.indexOf('adresse') > 0) {
                            $('#rechercheAdresse').next().removeClass('fr-hidden');
+                           $('#rechercheAdresse')[0].focus();
                        }
                     });
                 }


### PR DESCRIPTION
## Ticket

#409

## Description
Description de la modification apportée

## Changements apportés
* Ajout du focus

## Pré-requis

## Tests
- [ ] Soumettre le formulaire ERP sans saisir l'adresse, vérifier que le focus est bien sur le champs d'auto-complétion
