### PR TITLE
[FO - ERP & transport] Ajouter vérification sur la date

### DIFF
--- a/assets/controllers/component_search_commune.js
+++ b/assets/controllers/component_search_commune.js
@@ -25,7 +25,7 @@ function initSearchCommune() {
                 let searchField = $(this).val();
 
                 ajaxObject = $.ajax({
-                    url: 'https://api-adresse.data.gouv.fr/search/?q=' + searchField + '&&type=municipality&limit10'
+                    url: 'https://api-adresse.data.gouv.fr/search/?q=' + searchField + '&type=municipality&limit10'
                 }).done(function(jsonData) {
                     for (let feature of jsonData.features) {
                         let postCode = feature.properties.postcode;

--- a/assets/controllers/form_signalement_erp_transport.js
+++ b/assets/controllers/form_signalement_erp_transport.js
@@ -59,11 +59,7 @@ function sendSignalement() {
                             elementField
                                 .closest('.fr-input-group, .fr-select-group')
                                 .find('.fr-error-text')
-                                .text(errors[element]);
-
-                            elementField
-                                .closest('.fr-input-group, .fr-select-group')
-                                .find('.fr-error-text')
+                                .text(errors[element])
                                 .removeClass('fr-hidden');
 
                             elementField

--- a/assets/controllers/form_signalement_erp_transport.js
+++ b/assets/controllers/form_signalement_erp_transport.js
@@ -47,26 +47,31 @@ function sendSignalement() {
                     let index = 0;
                     for (let element in errors) {
                         if (errors.hasOwnProperty(element)) {
-                            if (index === 0) { // focus on first error
-                                $('[name="' + element + '"]')[0].focus();
+                            const elementField = $('[name="' + element + '"]');
+                            if (index === 0) {
+                                if (element.indexOf('adresse') === -1) {
+                                    elementField[0].focus(); // Focus on the first error
+                                } else if (element.indexOf('adresse') > 0) {
+                                    $('#rechercheAdresse')[0].focus();
+                                }
                             }
-                            $('[name="' + element + '"]')
+
+                            elementField
                                 .closest('.fr-input-group, .fr-select-group')
                                 .find('.fr-error-text')
                                 .text(errors[element]);
 
-                            $('[name="' + element + '"]')
+                            elementField
                                 .closest('.fr-input-group, .fr-select-group')
                                 .find('.fr-error-text')
                                 .removeClass('fr-hidden');
 
-                            $('[name="' + element + '"]')
+                            elementField
                                 .next()
                                 .removeClass('fr-hidden');
 
                             if (element.indexOf('adresse') > 0) {
                                 $('#rechercheAdresse').next().removeClass('fr-hidden');
-                                $('#rechercheAdresse')[0].focus();
                             }
                         }
                         index++;

--- a/assets/controllers/form_signalement_erp_transport.js
+++ b/assets/controllers/form_signalement_erp_transport.js
@@ -42,17 +42,35 @@ function sendSignalement() {
             },
             error: function (xhr) {
                 if (400 === xhr.status) {
-                    xhr.responseJSON.error.forEach((element, index) => {
-                       if (index === 0) { // focus on first error
-                           $('[name="' + element + '"]')[0].focus();
-                       }
-                       $('[name="' + element + '"]').next().removeClass('fr-hidden');
-                       $('[name="' + element + '"]').closest('.fr-input-group, .fr-select-group').find('.fr-error-text').removeClass('fr-hidden');
-                       if (element.indexOf('adresse') > 0) {
-                           $('#rechercheAdresse').next().removeClass('fr-hidden');
-                           $('#rechercheAdresse')[0].focus();
-                       }
-                    });
+                    const errors = xhr.responseJSON.error;
+
+                    let index = 0;
+                    for (let element in errors) {
+                        if (errors.hasOwnProperty(element)) {
+                            if (index === 0) { // focus on first error
+                                $('[name="' + element + '"]')[0].focus();
+                            }
+                            $('[name="' + element + '"]')
+                                .closest('.fr-input-group, .fr-select-group')
+                                .find('.fr-error-text')
+                                .text(errors[element]);
+
+                            $('[name="' + element + '"]')
+                                .closest('.fr-input-group, .fr-select-group')
+                                .find('.fr-error-text')
+                                .removeClass('fr-hidden');
+
+                            $('[name="' + element + '"]')
+                                .next()
+                                .removeClass('fr-hidden');
+
+                            if (element.indexOf('adresse') > 0) {
+                                $('#rechercheAdresse').next().removeClass('fr-hidden');
+                                $('#rechercheAdresse')[0].focus();
+                            }
+                        }
+                        index++;
+                    }
                 }
             },
             complete: function(xhr) {

--- a/src/Controller/Front/SignalementErpController.php
+++ b/src/Controller/Front/SignalementErpController.php
@@ -50,7 +50,7 @@ class SignalementErpController extends AbstractController
         $errorMessage = [];
         /** @var FormError $error */
         foreach ($form->getErrors(true) as $error) {
-            $errorMessage[] = 'signalement_front['.$error->getOrigin()->getName().']';
+            $errorMessage['signalement_front['.$error->getOrigin()->getName().']'] = $error->getMessage();
         }
 
         return $this->json(['error' => $errorMessage], Response::HTTP_BAD_REQUEST);

--- a/src/Controller/Front/SignalementTransportController.php
+++ b/src/Controller/Front/SignalementTransportController.php
@@ -50,7 +50,7 @@ class SignalementTransportController extends AbstractController
         $errorMessage = [];
         /** @var FormError $error */
         foreach ($form->getErrors(true) as $error) {
-            $errorMessage[] = 'signalement_transport['.$error->getOrigin()->getName().']';
+            $errorMessage['signalement_transport['.$error->getOrigin()->getName().']'] = $error->getMessage();
         }
 
         return $this->json(['error' => $errorMessage], Response::HTTP_BAD_REQUEST);

--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -21,6 +21,7 @@ class Signalement
 {
     use ActivableTrait;
     use TimestampableTrait;
+    public const DEFAULT_TIMEZONE = 'Europe/Paris';
 
     #[ORM\Id]
     #[ORM\GeneratedValue]

--- a/src/Form/SignalementErpType.php
+++ b/src/Form/SignalementErpType.php
@@ -52,7 +52,7 @@ class SignalementErpType extends AbstractType
                 ],
                 'label' => 'Date',
                 'required' => true,
-                'invalid_message' => 'La date que vous avez saisie est invalide. Assurez-vous de respecter le format de date correct.',
+                'invalid_message' => 'La date que vous avez saisie a un format de date incorrect.',
                 'constraints' => [
                     new Assert\NotBlank(message: 'Veuillez renseigner la date.'),
                     new Assert\LessThan(

--- a/src/Form/SignalementErpType.php
+++ b/src/Form/SignalementErpType.php
@@ -7,8 +7,8 @@ use App\Entity\Enum\PlaceType;
 use App\Entity\Enum\SignalementType;
 use App\Entity\Signalement;
 use App\Repository\TerritoireRepository;
-use App\Service\Signalement\PunaiseViewedDateFormatter;
 use App\Service\Signalement\ReferenceGenerator;
+use App\Service\Signalement\SignalementDateTimeProcessing;
 use App\Service\Signalement\ZipCodeProvider;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\CallbackTransformer;
@@ -52,8 +52,13 @@ class SignalementErpType extends AbstractType
                 ],
                 'label' => 'Date',
                 'required' => true,
+                'invalid_message' => 'La date que vous avez saisie est invalide. Assurez-vous de respecter le format de date correct.',
                 'constraints' => [
                     new Assert\NotBlank(message: 'Veuillez renseigner la date.'),
+                    new Assert\LessThan(
+                        value: new \DateTime(),
+                        message: 'La date renseignée n\'est pas encore passée, veuillez renseigner une nouvelle date.'
+                    ),
                 ],
             ])
             ->add('punaisesViewedTimeAt', TimeType::class, [
@@ -290,16 +295,7 @@ class SignalementErpType extends AbstractType
                 ->setDeclarant(Declarant::DECLARANT_USAGER)
                 ->setType(SignalementType::TYPE_ERP);
 
-            if (!empty($form->get('punaisesViewedAt')->getData()) &&
-                !empty($form->get('punaisesViewedTimeAt')->getData())
-            ) {
-                $signalement->setPunaisesViewedAt(
-                    PunaiseViewedDateFormatter::format(
-                        $form->get('punaisesViewedAt')->getData(),
-                        $form->get('punaisesViewedTimeAt')->getData()
-                    )
-                );
-            }
+            SignalementDateTimeProcessing::processDateAndTime($form, $signalement);
 
             $event->setData($signalement);
         });

--- a/src/Form/SignalementTransportType.php
+++ b/src/Form/SignalementTransportType.php
@@ -52,7 +52,7 @@ class SignalementTransportType extends AbstractType
                 ],
                 'label' => 'Date',
                 'required' => true,
-                'invalid_message' => 'La date que vous avez saisie est invalide. Assurez-vous de respecter le format de date correct.',
+                'invalid_message' => 'La date que vous avez saisie a un format de date incorrect.',
                 'constraints' => [
                     new Assert\NotBlank(message: 'Veuillez renseigner la date.'),
                     new Assert\LessThan(

--- a/src/Form/SignalementTransportType.php
+++ b/src/Form/SignalementTransportType.php
@@ -257,6 +257,19 @@ class SignalementTransportType extends AbstractType
             }
         ));
 
+        $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) {
+            $form = $event->getForm();
+            $data = $event->getData();
+
+            if ($data['placeType'] === PlaceType::TYPE_TRANSPORT_AUTRE->name) {
+                $form->add('transportLineNumber', TextType::class, [
+                    'constraints' => [
+                        new Assert\Length(max: 50, maxMessage: 'Veuillez renseigner un numéro de ligne correcte.'),
+                    ],
+                ]);
+            }
+        });
+
         $builder->addEventListener(FormEvents::POST_SUBMIT, function (FormEvent $event) {
             $form = $event->getForm();
             /** @var Signalement $signalement */

--- a/src/Service/Signalement/SignalementDateTimeProcessing.php
+++ b/src/Service/Signalement/SignalementDateTimeProcessing.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Service\Signalement;
+
+use App\Entity\Signalement;
+use Symfony\Component\Form\FormError;
+use Symfony\Component\Form\FormInterface;
+
+class SignalementDateTimeProcessing
+{
+    public static function processDateAndTime(FormInterface $form, Signalement $signalement): void
+    {
+        if (!empty($form->get('punaisesViewedAt')->getData()) &&
+            !empty($form->get('punaisesViewedTimeAt')->getData())
+        ) {
+            $signalement->setPunaisesViewedAt(
+                PunaiseViewedDateFormatter::format(
+                    $form->get('punaisesViewedAt')->getData(),
+                    $form->get('punaisesViewedTimeAt')->getData()
+                )
+            );
+
+            $currentDatetime = (new \DateTimeImmutable())
+                ->setTimezone(new \DateTimeZone(Signalement::DEFAULT_TIMEZONE))
+                ->format('Y-m-d H:i:s');
+
+            if ($form->get('punaisesViewedAt')->getData() == new \DateTimeImmutable('today') &&
+                $signalement->getPunaisesViewedAt() > new \DateTimeImmutable($currentDatetime)
+            ) {
+                $form->get('punaisesViewedTimeAt')->addError(new FormError(
+                    'L\'heure du jour renseignée n\'est pas encore passée, veuillez renseigner une nouvelle heure.'
+                ));
+            }
+        }
+    }
+}

--- a/templates/signalement_list/modal-signalement-erp-transports.html.twig
+++ b/templates/signalement_list/modal-signalement-erp-transports.html.twig
@@ -15,7 +15,7 @@
                             Type de signalement : {{signalement.type|signalement_type }} - 
                             {% if signalement.type is same as enum('App\\Entity\\Enum\\SignalementType').TYPE_TRANSPORT %}
                                 {{ signalement.placeType|place_type }}
-                                <em>({{ signalement.transportLineNumber|upper }})</em>
+                                <em>{{ signalement.transportLineNumber is not empty ? '(' ~ signalement.transportLineNumber|upper ~ ')' : '' }} </em>
                             {% else %}
                                 {{ signalement.nomProprietaire }}
                             {% endif %}
@@ -23,6 +23,10 @@
                             <br>
                             Territoire : {{signalement.territoire.nomComplet}}
                             <br>
+                            {% if signalement.type is same as enum('App\\Entity\\Enum\\SignalementType').TYPE_ERP %}
+                                Adresse : {{ signalement.adresse }}
+                                <br>
+                            {% endif %}
                             Commune : {{signalement.codePostal}} {{signalement.ville}}
                             <br>
                             Punaises vues le : {{signalement.punaisesViewedAt.format('d/m/Y')}} à {{signalement.punaisesViewedAt.format('H:i')}} 

--- a/tests/Functionnal/Controller/Front/SignalementErpControllerTest.php
+++ b/tests/Functionnal/Controller/Front/SignalementErpControllerTest.php
@@ -70,7 +70,7 @@ class SignalementErpControllerTest extends WebTestCase
             json_decode($client->getResponse()->getContent(), true));
     }
 
-    public function testPostWithDateGreaterThanToday(): void
+    public function testPostFormErpWithDateGreaterThanToday(): void
     {
         $client = static::createClient();
 
@@ -99,7 +99,7 @@ class SignalementErpControllerTest extends WebTestCase
         );
     }
 
-    public function testPostWithTimeGreaterThanCurrentTime(): void
+    public function testPostFormErpWithTimeGreaterThanCurrentTime(): void
     {
         $client = static::createClient();
 

--- a/tests/Functionnal/Controller/Front/SignalementErpControllerTest.php
+++ b/tests/Functionnal/Controller/Front/SignalementErpControllerTest.php
@@ -17,7 +17,7 @@ class SignalementErpControllerTest extends WebTestCase
         $route = $router->generate('app_signalement_erp');
         $crawler = $client->request('GET', $route);
         $form = $crawler->selectButton('Signaler mon problème')->form();
-        $form['signalement_front[punaisesViewedAt]'] = '2023-11-10';
+        $form['signalement_front[punaisesViewedAt]'] = '2023-10-10';
         $form['signalement_front[punaisesViewedTimeAt]'] = '10:15';
         $form['signalement_front[nomProprietaire]'] = 'Monsieur patate';
         $form['signalement_front[adresse]'] = 'Rue de la Pata';
@@ -46,7 +46,7 @@ class SignalementErpControllerTest extends WebTestCase
         $route = $router->generate('app_signalement_erp');
         $crawler = $client->request('GET', $route);
         $form = $crawler->selectButton('Signaler mon problème')->form();
-        $form['signalement_front[punaisesViewedAt]'] = '2023-11-10';
+        $form['signalement_front[punaisesViewedAt]'] = '2023-10-10';
         $form['signalement_front[punaisesViewedTimeAt]'] = '10:15';
         $form['signalement_front[nomProprietaire]'] = 'Monsieur patate';
         $form['signalement_front[adresse]'] = 'Rue de la Pata';
@@ -62,11 +62,70 @@ class SignalementErpControllerTest extends WebTestCase
         $this->assertEquals(
             [
                 'error' => [
-                    'signalement_front[nomDeclarant]',
-                    'signalement_front[prenomDeclarant]',
-                    'signalement_front[emailDeclarant]',
+                    'signalement_front[nomDeclarant]' => 'Veuillez renseigner votre nom.',
+                    'signalement_front[prenomDeclarant]' => 'Veuillez renseigner votre prénom.',
+                    'signalement_front[emailDeclarant]' => 'Veuillez renseigner votre email.',
                 ],
             ],
             json_decode($client->getResponse()->getContent(), true));
+    }
+
+    public function testPostWithDateGreaterThanToday(): void
+    {
+        $client = static::createClient();
+
+        /** @var RouterInterface $router */
+        $router = static::getContainer()->get(RouterInterface::class);
+        $route = $router->generate('app_signalement_erp');
+        $crawler = $client->request('GET', $route);
+        $form = $crawler->selectButton('Signaler mon problème')->form();
+
+        $form['signalement_front[punaisesViewedAt]'] = '2025-10-10';
+        $form['signalement_front[punaisesViewedTimeAt]'] = '10:15';
+        $form['signalement_front[nomProprietaire]'] = 'Monsieur patate';
+        $form['signalement_front[adresse]'] = 'Rue de la Pata';
+        $form['signalement_front[codePostal]'] = '69380';
+        $form['signalement_front[ville]'] = "Chazay-d'Azergues";
+        $form['signalement_front[geoloc]'] = '45.883415|4.709895';
+        $form['signalement_front[codeInsee]'] = '69052';
+        $form['signalement_front[placeType]'] = 'TYPE_ERP_PUBLIC';
+        $form['signalement_front[isPlaceAvertie]'] = '1';
+
+        $client->submit($form);
+        $this->assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+
+        $this->assertArrayHasKey('signalement_front[punaisesViewedAt]',
+            json_decode($client->getResponse()->getContent(), true)['error']
+        );
+    }
+
+    public function testPostWithTimeGreaterThanCurrentTime(): void
+    {
+        $client = static::createClient();
+
+        /** @var RouterInterface $router */
+        $router = static::getContainer()->get(RouterInterface::class);
+        $route = $router->generate('app_signalement_erp');
+        $crawler = $client->request('GET', $route);
+        $form = $crawler->selectButton('Signaler mon problème')->form();
+
+        $dateFuture = (new \DateTimeImmutable())->modify('+5 hour');
+
+        $form['signalement_front[punaisesViewedAt]'] = date('Y-m-d');
+        $form['signalement_front[punaisesViewedTimeAt]'] = $dateFuture->format('H:i:s');
+        $form['signalement_front[nomProprietaire]'] = 'Monsieur patate';
+        $form['signalement_front[adresse]'] = 'Rue de la Pata';
+        $form['signalement_front[codePostal]'] = '69380';
+        $form['signalement_front[ville]'] = "Chazay-d'Azergues";
+        $form['signalement_front[geoloc]'] = '45.883415|4.709895';
+        $form['signalement_front[codeInsee]'] = '69052';
+        $form['signalement_front[placeType]'] = 'TYPE_ERP_PUBLIC';
+        $form['signalement_front[isPlaceAvertie]'] = '1';
+
+        $client->submit($form);
+        $this->assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+        $this->assertArrayHasKey('signalement_front[punaisesViewedTimeAt]',
+            json_decode($client->getResponse()->getContent(), true)['error']
+        );
     }
 }

--- a/tests/Functionnal/Controller/Front/SignalementTransportControllerTest.php
+++ b/tests/Functionnal/Controller/Front/SignalementTransportControllerTest.php
@@ -36,6 +36,33 @@ class SignalementTransportControllerTest extends WebTestCase
         $this->assertEmailCount(1);
     }
 
+    public function testPostFormTransportAutreWithLineNumber(): void
+    {
+        $client = static::createClient();
+
+        /** @var RouterInterface $router */
+        $router = static::getContainer()->get(RouterInterface::class);
+        $route = $router->generate('app_signalement_transport');
+        $crawler = $client->request('GET', $route);
+        $form = $crawler->selectButton('Signaler mon problème')->form();
+
+        $form['signalement_transport[punaisesViewedAt]'] = '2022-11-10';
+        $form['signalement_transport[punaisesViewedTimeAt]'] = '10:15';
+        $form['signalement_transport[ville]'] = 'Marseille';
+        $form['signalement_transport[codePostal]'] = '13002';
+        $form['signalement_transport[geoloc]'] = '45.883415|4.709895';
+        $form['signalement_transport[codeInsee]'] = '13102';
+        $form['signalement_transport[placeType]'] = 'TYPE_TRANSPORT_AUTRE';
+        $form['signalement_transport[isPlaceAvertie]'] = '1';
+        $form['signalement_transport[nomDeclarant]'] = 'Doe';
+        $form['signalement_transport[prenomDeclarant]'] = 'John';
+        $form['signalement_transport[emailDeclarant]'] = 'john.doe@punaises.com';
+
+        $client->submit($form);
+        $this->assertResponseIsSuccessful();
+        $this->assertEmailCount(1);
+    }
+
     public function testPostInvalidFormTransport(): void
     {
         $client = static::createClient();
@@ -52,7 +79,6 @@ class SignalementTransportControllerTest extends WebTestCase
         $form['signalement_transport[geoloc]'] = '45.883415|4.709895';
         $form['signalement_transport[codeInsee]'] = '13102';
         $form['signalement_transport[placeType]'] = 'TYPE_TRANSPORT_METRO';
-        $form['signalement_transport[transportLineNumber]'] = 'M2';
         $form['signalement_transport[isPlaceAvertie]'] = '1';
 
         $client->submit($form);
@@ -63,6 +89,7 @@ class SignalementTransportControllerTest extends WebTestCase
                     'signalement_transport[nomDeclarant]' => 'Veuillez renseigner votre nom.',
                     'signalement_transport[prenomDeclarant]' => 'Veuillez renseigner votre prénom.',
                     'signalement_transport[emailDeclarant]' => 'Veuillez renseigner votre email.',
+                    'signalement_transport[transportLineNumber]' => 'Veuillez renseigner le numéro de ligne.',
                 ],
             ],
             json_decode($client->getResponse()->getContent(), true));

--- a/tests/Functionnal/Controller/Front/SignalementTransportControllerTest.php
+++ b/tests/Functionnal/Controller/Front/SignalementTransportControllerTest.php
@@ -18,7 +18,7 @@ class SignalementTransportControllerTest extends WebTestCase
         $crawler = $client->request('GET', $route);
         $form = $crawler->selectButton('Signaler mon problème')->form();
 
-        $form['signalement_transport[punaisesViewedAt]'] = '2023-11-10';
+        $form['signalement_transport[punaisesViewedAt]'] = '2022-11-10';
         $form['signalement_transport[punaisesViewedTimeAt]'] = '10:15';
         $form['signalement_transport[ville]'] = 'Marseille';
         $form['signalement_transport[codePostal]'] = '13002';
@@ -36,7 +36,7 @@ class SignalementTransportControllerTest extends WebTestCase
         $this->assertEmailCount(1);
     }
 
-    public function testPostInvalidFormErp(): void
+    public function testPostInvalidFormTransport(): void
     {
         $client = static::createClient();
 
@@ -45,7 +45,7 @@ class SignalementTransportControllerTest extends WebTestCase
         $route = $router->generate('app_signalement_transport');
         $crawler = $client->request('GET', $route);
         $form = $crawler->selectButton('Signaler mon problème')->form();
-        $form['signalement_transport[punaisesViewedAt]'] = '2023-11-10';
+        $form['signalement_transport[punaisesViewedAt]'] = '2023-10-10';
         $form['signalement_transport[punaisesViewedTimeAt]'] = '10:15';
         $form['signalement_transport[ville]'] = 'Marseille';
         $form['signalement_transport[codePostal]'] = '13002';
@@ -60,11 +60,74 @@ class SignalementTransportControllerTest extends WebTestCase
         $this->assertEquals(
             [
                 'error' => [
-                    'signalement_transport[nomDeclarant]',
-                    'signalement_transport[prenomDeclarant]',
-                    'signalement_transport[emailDeclarant]',
+                    'signalement_transport[nomDeclarant]' => 'Veuillez renseigner votre nom.',
+                    'signalement_transport[prenomDeclarant]' => 'Veuillez renseigner votre prénom.',
+                    'signalement_transport[emailDeclarant]' => 'Veuillez renseigner votre email.',
                 ],
             ],
             json_decode($client->getResponse()->getContent(), true));
+    }
+
+    public function testPostWithDateGreaterThanToday(): void
+    {
+        $client = static::createClient();
+
+        /** @var RouterInterface $router */
+        $router = static::getContainer()->get(RouterInterface::class);
+        $route = $router->generate('app_signalement_transport');
+        $crawler = $client->request('GET', $route);
+        $form = $crawler->selectButton('Signaler mon problème')->form();
+
+        $form['signalement_transport[punaisesViewedAt]'] = '2025-11-10';
+        $form['signalement_transport[punaisesViewedTimeAt]'] = '10:15';
+        $form['signalement_transport[ville]'] = 'Marseille';
+        $form['signalement_transport[codePostal]'] = '13002';
+        $form['signalement_transport[geoloc]'] = '45.883415|4.709895';
+        $form['signalement_transport[codeInsee]'] = '13102';
+        $form['signalement_transport[placeType]'] = 'TYPE_TRANSPORT_METRO';
+        $form['signalement_transport[transportLineNumber]'] = 'M2';
+        $form['signalement_transport[isPlaceAvertie]'] = '1';
+        $form['signalement_transport[nomDeclarant]'] = 'Doe';
+        $form['signalement_transport[prenomDeclarant]'] = 'John';
+        $form['signalement_transport[emailDeclarant]'] = 'john.doe@punaises.com';
+
+        $client->submit($form);
+        $this->assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+
+        $this->assertArrayHasKey('signalement_transport[punaisesViewedAt]',
+            json_decode($client->getResponse()->getContent(), true)['error']
+        );
+    }
+
+    public function testPostWithTimeGreaterThanCurrentTime(): void
+    {
+        $client = static::createClient();
+
+        /** @var RouterInterface $router */
+        $router = static::getContainer()->get(RouterInterface::class);
+        $route = $router->generate('app_signalement_transport');
+        $crawler = $client->request('GET', $route);
+        $form = $crawler->selectButton('Signaler mon problème')->form();
+
+        $dateFuture = (new \DateTimeImmutable())->modify('+5 hour');
+
+        $form['signalement_transport[punaisesViewedAt]'] = date('Y-m-d');
+        $form['signalement_transport[punaisesViewedTimeAt]'] = $dateFuture->format('H:i:s');
+        $form['signalement_transport[ville]'] = 'Marseille';
+        $form['signalement_transport[codePostal]'] = '13002';
+        $form['signalement_transport[geoloc]'] = '45.883415|4.709895';
+        $form['signalement_transport[codeInsee]'] = '13102';
+        $form['signalement_transport[placeType]'] = 'TYPE_TRANSPORT_METRO';
+        $form['signalement_transport[transportLineNumber]'] = 'M2';
+        $form['signalement_transport[isPlaceAvertie]'] = '1';
+        $form['signalement_transport[nomDeclarant]'] = 'Doe';
+        $form['signalement_transport[prenomDeclarant]'] = 'John';
+        $form['signalement_transport[emailDeclarant]'] = 'john.doe@punaises.com';
+
+        $client->submit($form);
+        $this->assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+        $this->assertArrayHasKey('signalement_transport[punaisesViewedTimeAt]',
+            json_decode($client->getResponse()->getContent(), true)['error']
+        );
     }
 }

--- a/tests/Functionnal/Controller/Front/SignalementTransportControllerTest.php
+++ b/tests/Functionnal/Controller/Front/SignalementTransportControllerTest.php
@@ -8,7 +8,7 @@ use Symfony\Component\Routing\RouterInterface;
 
 class SignalementTransportControllerTest extends WebTestCase
 {
-    public function testPostValidFormErp(): void
+    public function testPostValidFormTransport(): void
     {
         $client = static::createClient();
 
@@ -95,7 +95,7 @@ class SignalementTransportControllerTest extends WebTestCase
             json_decode($client->getResponse()->getContent(), true));
     }
 
-    public function testPostWithDateGreaterThanToday(): void
+    public function testPostFormTransportWithDateGreaterThanToday(): void
     {
         $client = static::createClient();
 
@@ -126,7 +126,7 @@ class SignalementTransportControllerTest extends WebTestCase
         );
     }
 
-    public function testPostWithTimeGreaterThanCurrentTime(): void
+    public function testPostFormTransportWithTimeGreaterThanCurrentTime(): void
     {
         $client = static::createClient();
 


### PR DESCRIPTION
## Ticket

#422    

## Description
Un usager ne doit pas pouvoir soumettre un signalement avec une date dans le futur 

## Changements apportés
* Ajout contrainte et traitements pour la gestion des dates

## Pré-requis
```php
make npm-build
```

## Tests
- [ ] Soumettre un signalement avec une date dans le futur
- [ ] Soumettre un signalement avec une date du jour et une heure dans le futu
