### PR TITLE
[FO - Signalement] Ligne de transport non obligatoire lorsque autre est selectionné

### DIFF
--- a/assets/controllers/component_search_commune.js
+++ b/assets/controllers/component_search_commune.js
@@ -25,7 +25,7 @@ function initSearchCommune() {
                 let searchField = $(this).val();
 
                 ajaxObject = $.ajax({
-                    url: 'https://api-adresse.data.gouv.fr/search/?q=' + searchField + '&&type=municipality&limit10'
+                    url: 'https://api-adresse.data.gouv.fr/search/?q=' + searchField + '&type=municipality&limit10'
                 }).done(function(jsonData) {
                     for (let feature of jsonData.features) {
                         let postCode = feature.properties.postcode;

--- a/src/Form/SignalementTransportType.php
+++ b/src/Form/SignalementTransportType.php
@@ -257,6 +257,20 @@ class SignalementTransportType extends AbstractType
             }
         ));
 
+        $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) {
+            $form = $event->getForm();
+            /** @var Signalement $signalement */
+            $data = $event->getData();
+
+            if ($data['placeType'] === PlaceType::TYPE_TRANSPORT_AUTRE->name) {
+                $form->add('transportLineNumber', TextType::class, [
+                    'constraints' => [
+                        new Assert\Length(max: 50, maxMessage: 'Veuillez renseigner un numéro de ligne correcte.'),
+                    ],
+                ]);
+            }
+        });
+
         $builder->addEventListener(FormEvents::POST_SUBMIT, function (FormEvent $event) {
             $form = $event->getForm();
             /** @var Signalement $signalement */

--- a/src/Form/SignalementTransportType.php
+++ b/src/Form/SignalementTransportType.php
@@ -259,7 +259,6 @@ class SignalementTransportType extends AbstractType
 
         $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) {
             $form = $event->getForm();
-            /** @var Signalement $signalement */
             $data = $event->getData();
 
             if ($data['placeType'] === PlaceType::TYPE_TRANSPORT_AUTRE->name) {

--- a/templates/signalement_list/modal-signalement-erp-transports.html.twig
+++ b/templates/signalement_list/modal-signalement-erp-transports.html.twig
@@ -23,6 +23,10 @@
                             <br>
                             Territoire : {{signalement.territoire.nomComplet}}
                             <br>
+                            {% if signalement.type is same as enum('App\\Entity\\Enum\\SignalementType').TYPE_ERP %}
+                                Adresse : {{ signalement.adresse }}
+                                <br>
+                            {% endif %}
                             Commune : {{signalement.codePostal}} {{signalement.ville}}
                             <br>
                             Punaises vues le : {{signalement.punaisesViewedAt.format('d/m/Y')}} à {{signalement.punaisesViewedAt.format('H:i')}} 

--- a/templates/signalement_list/modal-signalement-erp-transports.html.twig
+++ b/templates/signalement_list/modal-signalement-erp-transports.html.twig
@@ -15,7 +15,7 @@
                             Type de signalement : {{signalement.type|signalement_type }} - 
                             {% if signalement.type is same as enum('App\\Entity\\Enum\\SignalementType').TYPE_TRANSPORT %}
                                 {{ signalement.placeType|place_type }}
-                                <em>({{ signalement.transportLineNumber|upper }})</em>
+                                <em>{{ signalement.transportLineNumber is not empty ? '(' ~ signalement.transportLineNumber|upper ~ ')' : '' }} </em>
                             {% else %}
                                 {{ signalement.nomProprietaire }}
                             {% endif %}

--- a/tests/Functionnal/Controller/Front/SignalementTransportControllerTest.php
+++ b/tests/Functionnal/Controller/Front/SignalementTransportControllerTest.php
@@ -36,6 +36,33 @@ class SignalementTransportControllerTest extends WebTestCase
         $this->assertEmailCount(1);
     }
 
+    public function testPostFormTransportAutreWithLineNumber(): void
+    {
+        $client = static::createClient();
+
+        /** @var RouterInterface $router */
+        $router = static::getContainer()->get(RouterInterface::class);
+        $route = $router->generate('app_signalement_transport');
+        $crawler = $client->request('GET', $route);
+        $form = $crawler->selectButton('Signaler mon problème')->form();
+
+        $form['signalement_transport[punaisesViewedAt]'] = '2022-11-10';
+        $form['signalement_transport[punaisesViewedTimeAt]'] = '10:15';
+        $form['signalement_transport[ville]'] = 'Marseille';
+        $form['signalement_transport[codePostal]'] = '13002';
+        $form['signalement_transport[geoloc]'] = '45.883415|4.709895';
+        $form['signalement_transport[codeInsee]'] = '13102';
+        $form['signalement_transport[placeType]'] = 'TYPE_TRANSPORT_AUTRE';
+        $form['signalement_transport[isPlaceAvertie]'] = '1';
+        $form['signalement_transport[nomDeclarant]'] = 'Doe';
+        $form['signalement_transport[prenomDeclarant]'] = 'John';
+        $form['signalement_transport[emailDeclarant]'] = 'john.doe@punaises.com';
+
+        $client->submit($form);
+        $this->assertResponseIsSuccessful();
+        $this->assertEmailCount(1);
+    }
+
     public function testPostInvalidFormTransport(): void
     {
         $client = static::createClient();
@@ -52,7 +79,6 @@ class SignalementTransportControllerTest extends WebTestCase
         $form['signalement_transport[geoloc]'] = '45.883415|4.709895';
         $form['signalement_transport[codeInsee]'] = '13102';
         $form['signalement_transport[placeType]'] = 'TYPE_TRANSPORT_METRO';
-        $form['signalement_transport[transportLineNumber]'] = 'M2';
         $form['signalement_transport[isPlaceAvertie]'] = '1';
 
         $client->submit($form);
@@ -63,6 +89,7 @@ class SignalementTransportControllerTest extends WebTestCase
                     'signalement_transport[nomDeclarant]' => 'Veuillez renseigner votre nom.',
                     'signalement_transport[prenomDeclarant]' => 'Veuillez renseigner votre prénom.',
                     'signalement_transport[emailDeclarant]' => 'Veuillez renseigner votre email.',
+                    'signalement_transport[transportLineNumber]' => 'Veuillez renseigner le numéro de ligne.',
                 ],
             ],
             json_decode($client->getResponse()->getContent(), true));


### PR DESCRIPTION
## Ticket

#421    

## Description
Ne pas rendre Ligne de transport obligatoire lorsque autre est sélectionné

## Changements apportés
* Ajout d'un listener au `PRE_SUBMIT` afin de supprimer la contrainte NotBlank

## Pré-requis

## Tests
- [ ] Soumettre un formulaire transport en sélectionnant AUTRE comme type de transport
