### PR TITLE
[BO - Signalement] Bouton de clôture masqué pour l'entreprise si l'estimation a été refusée par l'usager

### DIFF
--- a/templates/signalement_view/signalement.html.twig
+++ b/templates/signalement_view/signalement.html.twig
@@ -49,6 +49,7 @@
                         {% if entrepriseIntervention.accepted and
                             entrepriseIntervention.estimationSentAt is not null and
                             not entrepriseIntervention.canceledByEntrepriseAt and
+                            (not entrepriseIntervention.choiceByUsagerAt or entrepriseIntervention.acceptedByUsager) and
                             signalement.typeIntervention is null
                         %}
                             <form action="{{ path('app_intervention_stop', {'id': entrepriseIntervention.id }) }}" method="POST" class="form-back-stop-intervention fr-mt-1v">


### PR DESCRIPTION
## Ticket

#424   

## Description
Bouton de clôture masqué pour l'entreprise si l'estimation a été refusée par l'usager

## Test fonctionnel
- [ ] Créer un signalement
- [ ] Se connecter en entreprise, faire une estimation
- [ ] En tant qu'usager, refuser l'estimation
- [ ] En tant qu'entreprise, le bouton de clôture est masqué

## Test de non-régression
- [ ] Créer un signalement
- [ ] Se connecter en entreprise, faire une estimation
- [ ] En tant qu'usager, valider l'estimation
- [ ] En tant qu'entreprise, le bouton de clôture apparait
