### PR TITLE
[Entreprises publiques] Correction affichage du numéro de téléphone

### DIFF
--- a/templates/front/entreprises-labelisees.html.twig
+++ b/templates/front/entreprises-labelisees.html.twig
@@ -71,8 +71,8 @@
                                     {% endif %}
                                     {% if entreprise_publique.telephone %}
                                     <li>
-                                        <a class="fr-link fr-icon-phone-line fr-link--icon-right" href="tel:{{ entreprise_publique.telephone }}">
-                                            {{ entreprise_publique.telephone }}
+                                        <a class="fr-link fr-icon-phone-line fr-link--icon-right" href="tel:{{ entreprise_publique.telephone|format_phone }}">
+                                            {{ entreprise_publique.telephone|format_phone }}
                                         </a>
                                     </li>
                                     {% endif %}


### PR DESCRIPTION
## Ticket

#427   

## Description
Correction affichage du numéro de téléphone de certaines entreprises labellisées

## Tests
- [ ] Vérifier que tous les numéros s'affichent correctement sur : http://localhost:8090/entreprises-labellisees?code-postal=67000
