### PR TITLE
[Entreprises labellisées] Correction de l'affichage du lien

### DIFF
--- a/templates/front/entreprises-labelisees.html.twig
+++ b/templates/front/entreprises-labelisees.html.twig
@@ -65,7 +65,7 @@
                                     {% if entreprise_publique.url %}
                                     <li>
                                         <a class="fr-link fr-icon-arrow-right-line fr-link--icon-right" href="{{ entreprise_publique.url }}" target="_blank" rel="noopener">
-                                            {{ entreprise_publique.url }}
+                                            Accéder au site web
                                         </a>
                                     </li>
                                     {% endif %}


### PR DESCRIPTION
## Ticket

#429    

## Description
Correction de l'affichage du lien du site web des entreprises labellisées

## Tests
- [ ] Vérifier l'affichage du lien (il est juste indiqué "Accéder au site web")
