### PR TITLE
[QA - Sentry] Ajout d'un test de valeur pour récupérer le niveau d'infestation dans le formulaire BO

### DIFF
--- a/src/DataFixtures/Files/Signalement.yml
+++ b/src/DataFixtures/Files/Signalement.yml
@@ -116,7 +116,6 @@ signalements:
   geoloc: "{\"lat\":\"43.2996767\",\"lng\":\"5.3876584\"}"
   type_logement: "maison"
   construit_avant1948: 1
-  type_intervention: "diagnostic"
   niveau_infestation: 3
   type_diagnostic: "visuel"
   code_insee: "13202"
@@ -133,7 +132,6 @@ signalements:
   geoloc: "{\"lat\":\"47.205291\",\"lng\":\"-1.5546\"}"
   type_logement: "maison"
   construit_avant1948: 1
-  type_intervention: "diagnostic"
   niveau_infestation: 2
   type_diagnostic: "visuel"
   code_insee: "14202"

--- a/src/Form/SignalementHistoryType.php
+++ b/src/Form/SignalementHistoryType.php
@@ -370,6 +370,10 @@ class SignalementHistoryType extends AbstractType
         $builder->get('niveauInfestation')
             ->addModelTransformer(new CallbackTransformer(
                 function (?int $level) {
+                    if (empty($level)) {
+                        return InfestationLevel::from(InfestationLevel::NULLE->value);
+                    }
+
                     return InfestationLevel::from($level);
                 },
                 function (InfestationLevel $level) {

--- a/src/Twig/AppExtension.php
+++ b/src/Twig/AppExtension.php
@@ -57,7 +57,7 @@ class AppExtension extends AbstractExtension
 
     public function formatLabelInfestation(?int $niveau = 0): string
     {
-        if (empty($niveau)) {
+        if (empty($niveau) && 0 !== $niveau) {
             return '-';
         }
 


### PR DESCRIPTION
## Ticket

#437    

## Description
Dans le formulaire d'ajout/édition de signalement BO, un enum supporte mal les valeurs nulles.
J'ai ajouté un test.

Normalement, j'imagine que la méthode pour reproduire est 

- d'être connecté en tant qu'entreprise
- d'aller sur un signalement front qui a un niveau d'infestation nul
- de le marquer comme traité

Mais je n'ai pas réussi à reproduire l'erreur de base qui a été relevée par Sentry : https://sentry.incubateur.net/organizations/betagouv/issues/71873/?query=is%3Aunresolved&referrer=issue-stream


## Tests
- [ ] Vérifier qu'il n'y a pas de régression en ajoutant un signalement via le formulaire back
- [ ] Vérifier qu'il n'y a pas de régression en marquant comme traité un signalement via le formulaire back
