### PR TITLE
[Front - Signalement] Correction des signalements sur un CP corse

### DIFF
--- a/src/Controller/Front/EntreprisesPubliquesController.php
+++ b/src/Controller/Front/EntreprisesPubliquesController.php
@@ -3,6 +3,7 @@
 namespace App\Controller\Front;
 
 use App\Repository\EntreprisePubliqueRepository;
+use App\Service\Signalement\ZipCodeProvider;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -14,6 +15,7 @@ class EntreprisesPubliquesController extends AbstractController
     public function signalement(
         Request $request,
         EntreprisePubliqueRepository $entreprisePubliqueRepository,
+        ZipCodeProvider $zipCodeProvider,
     ): Response {
         $codePostal = $request->get('code-postal');
         if (empty($codePostal)) {
@@ -31,10 +33,7 @@ class EntreprisesPubliquesController extends AbstractController
         }
 
         $codePostal = str_pad($codePostal, 5, '0', \STR_PAD_LEFT);
-        $zipCode = substr($codePostal, 0, 2);
-        if ('97' == $zipCode) {
-            $zipCode = substr($codePostal, 0, 3);
-        }
+        $zipCode = $zipCodeProvider->getByCodePostal($codePostal);
 
         $listEntreprisesPubliquesByZipCode = $entreprisePubliqueRepository->findByZipCodeAndFilter($zipCode, $order, $filter);
 

--- a/src/DataFixtures/Files/Territoire.yml
+++ b/src/DataFixtures/Files/Territoire.yml
@@ -407,8 +407,3 @@ territoires:
     zip: "976"
     name: "Mayotte"
     active: 0
-
-  -
-    zip: "64"
-    name: "Agglo de Pau"
-    active: 0

--- a/src/Service/Signalement/ZipCodeProvider.php
+++ b/src/Service/Signalement/ZipCodeProvider.php
@@ -10,6 +10,9 @@ class ZipCodeProvider
         if ('97' == $zipCode) {
             $zipCode = substr($codePostal, 0, 3);
         }
+        if ('20' == $zipCode) {
+            $zipCode = $codePostal < 20200 ? '2A' : '2B';
+        }
 
         return $zipCode;
     }

--- a/tests/Functionnal/Service/ZipCodeProviderTest.php
+++ b/tests/Functionnal/Service/ZipCodeProviderTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Tests\Functional\Service;
+
+use App\Service\Signalement\ZipCodeProvider;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class ZipCodeProviderTest extends KernelTestCase
+{
+    private ZipCodeProvider $zipcodeProvider;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $container = static::getContainer();
+        $this->zipcodeProvider = $container->get(ZipcodeProvider::class);
+    }
+
+    public function testGetZipCodeTerritory(): void
+    {
+        $this->assertEquals(
+            '2A',
+            $this->zipcodeProvider->getByCodePostal('20167'),
+        );
+        $this->assertEquals(
+            '2B',
+            $this->zipcodeProvider->getByCodePostal('20600'),
+        );
+        $this->assertEquals(
+            '974',
+            $this->zipcodeProvider->getByCodePostal('97400')
+        );
+        $this->assertEquals(
+            '972',
+            $this->zipcodeProvider->getByCodePostal('97200')
+        );
+        $this->assertEquals(
+            '13',
+            $this->zipcodeProvider->getByCodePostal('13002')
+        );
+    }
+}


### PR DESCRIPTION
## Ticket

#434    

## Description
Correction de la prise en compte des codes postaux corse

## Tests
- [ ] Faire un signalement sur un code postal en corse 2A (cf ici : https://www.annuaire-administration.com/code-postal/region/corse.html) ; vérifier enregistrement et redirection
- [ ] Faire un signalement sur un code postal en corse 2B (cf ici : https://www.annuaire-administration.com/code-postal/region/corse.html) ; vérifier enregistrement et redirection
