### PR TITLE
[Front - Signalement] Ajout de feature flipping sur le nouveau workflow de signalement

### DIFF
--- a/.env
+++ b/.env
@@ -25,6 +25,7 @@ CONTACT_EMAIL=contact@stop-punaises.beta.gouv.fr
 INCONNU_EMAIL=inconnu@stop-punaises.beta.gouv.fr
 MESSENGER_TRANSPORT_DSN=doctrine://default
 REDIS_URL=redis://stopunaises_redis:6379
+FEATURE_THREE_FORMS_ENABLE=1
 
 ###> sentry/sentry-symfony ###
 SENTRY_DSN=

--- a/.env.sample
+++ b/.env.sample
@@ -25,6 +25,7 @@ CONTACT_EMAIL=contact@stop-punaises.beta.gouv.fr
 INCONNU_EMAIL=inconnu@stop-punaises.beta.gouv.fr
 MESSENGER_TRANSPORT_DSN=doctrine://default
 REDIS_URL=redis://stopunaises_redis:6379
+FEATURE_THREE_FORMS_ENABLE=1
 
 ###> sentry/sentry-symfony ###
 SENTRY_DSN=

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -15,6 +15,7 @@ parameters:
     doc_conseil: 'pdf/stop-punaises-eviter-punaises-de-lit.pdf'
     admin_email: '%env(resolve:CONTACT_EMAIL)%'
     inconnu_email: '%env(resolve:INCONNU_EMAIL)%'
+    feature_three_forms: '%env(bool:FEATURE_THREE_FORMS_ENABLE)%'
 
 services:
     # default configuration for services in *this* file

--- a/src/Controller/Front/HomeController.php
+++ b/src/Controller/Front/HomeController.php
@@ -5,6 +5,7 @@ namespace App\Controller\Front;
 use App\Form\ContactType;
 use App\FormHandler\ContactFormHandler;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
@@ -18,9 +19,11 @@ class HomeController extends AbstractController
     }
 
     #[Route('/signalement', name: 'app_front_signalement_type_list')]
-    public function signalementList(): Response
+    public function signalementList(ParameterBagInterface $parameterBag): Response
     {
-        return $this->render('front/signalement-type-list.html.twig');
+        return $this->render('front/signalement-type-list.html.twig', [
+            'feature_three_forms' => $parameterBag->get('feature_three_forms'),
+        ]);
     }
 
     #[Route('/information', name: 'app_front_information')]

--- a/src/Controller/Front/SignalementErpController.php
+++ b/src/Controller/Front/SignalementErpController.php
@@ -8,6 +8,7 @@ use App\Manager\SignalementManager;
 use App\Service\Mailer\MailerProvider;
 use App\Service\Upload\UploadHandlerService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -16,8 +17,12 @@ use Symfony\Component\Routing\Annotation\Route;
 class SignalementErpController extends AbstractController
 {
     #[Route('/signalement/erp', name: 'app_signalement_erp')]
-    public function index(): Response
+    public function index(ParameterBagInterface $parameterBag): Response
     {
+        if (!$parameterBag->get('feature_three_forms')) {
+            return $this->redirectToRoute('home');
+        }
+
         $form = $this->createForm(SignalementErpType::class, new Signalement());
 
         return $this->render('front_signalement_erp/index.html.twig', [

--- a/src/Controller/Front/SignalementTransportController.php
+++ b/src/Controller/Front/SignalementTransportController.php
@@ -8,6 +8,7 @@ use App\Manager\SignalementManager;
 use App\Service\Mailer\MailerProvider;
 use App\Service\Upload\UploadHandlerService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -16,8 +17,12 @@ use Symfony\Component\Routing\Annotation\Route;
 class SignalementTransportController extends AbstractController
 {
     #[Route('/signalement/transport', name: 'app_signalement_transport')]
-    public function index(): Response
+    public function index(ParameterBagInterface $parameterBag): Response
     {
+        if (!$parameterBag->get('feature_three_forms')) {
+            return $this->redirectToRoute('home');
+        }
+
         $form = $this->createForm(SignalementTransportType::class, new Signalement());
 
         return $this->render('front_signalement_transport/index.html.twig', [

--- a/templates/front/signalement-type-list.html.twig
+++ b/templates/front/signalement-type-list.html.twig
@@ -11,51 +11,53 @@
     </section>
 
     <section class="fr-container fr-my-3w fr-my-md-6w signalement-list-items">
-        <div class=" fr-grid-row fr-grid-row--gutters">
+        <div class=" fr-grid-row fr-grid-row--gutters fr-grid-row--center">
             <div class="fr-col-12 fr-col-md-4 fr-mt-5w fr-mt-md-3v">
-            <div class="fr-tile fr-tile--sm fr-tile--horizontal fr-enlarge-link" id="tile-logement">
-                <div class="fr-tile__body">
-                    <div class="fr-tile__content">
-                        <h3 class="fr-tile__title fr-h6">
-                            <span class="fr-icon-home-4-line" aria-hidden="true"></span>
-                            <a href="{{ path('app_front_signalement_logement') }}">Dans mon logement</a>
-                        </h3>
-                        <p class="fr-tile__detail">Stop Punaises vous accompagne pour trouver une solution</p>
-                        <p class="align-right"><span class="fr-icon-arrow-right-line" aria-hidden="true"></span></p>
+                <div class="fr-tile fr-tile--sm fr-tile--horizontal fr-enlarge-link" id="tile-logement">
+                    <div class="fr-tile__body">
+                        <div class="fr-tile__content">
+                            <h3 class="fr-tile__title fr-h6">
+                                <span class="fr-icon-home-4-line" aria-hidden="true"></span>
+                                <a href="{{ path('app_front_signalement_logement') }}">Dans mon logement</a>
+                            </h3>
+                            <p class="fr-tile__detail">Stop Punaises vous accompagne pour trouver une solution</p>
+                            <p class="align-right"><span class="fr-icon-arrow-right-line" aria-hidden="true"></span></p>
+                        </div>
                     </div>
                 </div>
             </div>
+
+            {% if feature_three_forms %}
+            <div class="fr-col-12 fr-col-md-4 fr-mt-5w fr-mt-md-3v">
+                <div class="fr-tile fr-tile--sm fr-tile--horizontal fr-enlarge-link" id="tile-logement">
+                    <div class="fr-tile__body">
+                        <div class="fr-tile__content">
+                            <h3 class="fr-tile__title fr-h6">
+                                <span class="fr-icon-bus-line" aria-hidden="true"></span>
+                                <a href="{{ path('app_signalement_transport') }}">Dans les transports</a>
+                            </h3>
+                            <p class="fr-tile__detail">Métro, tramways, train... Signaler un problème dans les transports</p>
+                            <p class="align-right"><span class="fr-icon-arrow-right-line" aria-hidden="true"></span></p>
+                        </div>
+                    </div>
+                </div>
             </div>
 
             <div class="fr-col-12 fr-col-md-4 fr-mt-5w fr-mt-md-3v">
-            <div class="fr-tile fr-tile--sm fr-tile--horizontal fr-enlarge-link" id="tile-logement">
-                <div class="fr-tile__body">
-                    <div class="fr-tile__content">
-                        <h3 class="fr-tile__title fr-h6">
-                            <span class="fr-icon-bus-line" aria-hidden="true"></span>
-                            <a href="{{ path('app_signalement_transport') }}">Dans les transports</a>
-                        </h3>
-                        <p class="fr-tile__detail">Métro, tramways, train... Signaler un problème dans les transports</p>
-                        <p class="align-right"><span class="fr-icon-arrow-right-line" aria-hidden="true"></span></p>
+                <div class="fr-tile fr-tile--sm fr-tile--horizontal fr-enlarge-link" id="tile-logement">
+                    <div class="fr-tile__body">
+                        <div class="fr-tile__content">
+                            <h3 class="fr-tile__title fr-h6">
+                                <span class="fr-icon-hotel-line" aria-hidden="true"></span>
+                                <a href="{{ path('app_signalement_erp') }}">Dans un lieu public</a>
+                            </h3>
+                            <p class="fr-tile__detail">Signaler un problème dans un hôtel, restaurant, école, administration...</p>
+                            <p class="align-right"><span class="fr-icon-arrow-right-line" aria-hidden="true"></span></p>
+                        </div>
                     </div>
                 </div>
             </div>
-            </div>
-
-            <div class="fr-col-12 fr-col-md-4 fr-mt-5w fr-mt-md-3v">
-            <div class="fr-tile fr-tile--sm fr-tile--horizontal fr-enlarge-link" id="tile-logement">
-                <div class="fr-tile__body">
-                    <div class="fr-tile__content">
-                        <h3 class="fr-tile__title fr-h6">
-                            <span class="fr-icon-hotel-line" aria-hidden="true"></span>
-                            <a href="{{ path('app_signalement_erp') }}">Dans un lieu public</a>
-                        </h3>
-                        <p class="fr-tile__detail">Signaler un problème dans un hôtel, restaurant, école, administration...</p>
-                        <p class="align-right"><span class="fr-icon-arrow-right-line" aria-hidden="true"></span></p>
-                    </div>
-                </div>
-            </div>
-            </div>
+            {% endif %}
         </div>
     </section>
 


### PR DESCRIPTION
## Ticket

#440    

## Description
Ajout de feature flipping sur le nouveau workflow de signalement :
- ne pas proposer les 3 types de formulaire mais donner accès à un seul

## Tests avec les formulaires activés
Dans `.env.local`
`FEATURE_THREE_FORMS_ENABLE = 1`
- [ ] Vérifier que l'accès aux formulaires ERP et Transport est toujours ok

Dans `.env.local`
`FEATURE_THREE_FORMS_ENABLE = 0`
- [ ] Vérifier que l'accès aux formulaires ERP et Transport est masqué
