### PR TITLE
[Front] Ajout de cache navigateur sur les pages statiques

### DIFF
--- a/src/Controller/Front/HomeController.php
+++ b/src/Controller/Front/HomeController.php
@@ -13,14 +13,14 @@ use Symfony\Component\Routing\Annotation\Route;
 
 class HomeController extends AbstractController
 {
-    #[Cache(public: true, maxage: 600)]
+    #[Cache(public: true, maxage: 3600)]
     #[Route('/', name: 'home')]
     public function index(): Response
     {
         return $this->render('front/index.html.twig', []);
     }
 
-    #[Cache(public: true, maxage: 600)]
+    #[Cache(public: true, maxage: 3600)]
     #[Route('/signalement', name: 'app_front_signalement_type_list')]
     public function signalementList(ParameterBagInterface $parameterBag): Response
     {
@@ -29,7 +29,7 @@ class HomeController extends AbstractController
         ]);
     }
 
-    #[Cache(public: true, maxage: 600)]
+    #[Cache(public: true, maxage: 3600)]
     #[Route('/information', name: 'app_front_information')]
     public function information(): Response
     {
@@ -38,7 +38,7 @@ class HomeController extends AbstractController
         ]);
     }
 
-    #[Cache(public: true, maxage: 600)]
+    #[Cache(public: true, maxage: 3600)]
     #[Route('/mentions-legales', name: 'app_front_mentions_legales')]
     public function mentionsLegales(): Response
     {
@@ -46,7 +46,7 @@ class HomeController extends AbstractController
         ]);
     }
 
-    #[Cache(public: true, maxage: 600)]
+    #[Cache(public: true, maxage: 3600)]
     #[Route('/politique-de-confidentialite', name: 'app_front_politique_confidentialite')]
     public function politiqueConfidentialite(): Response
     {

--- a/src/Controller/Front/HomeController.php
+++ b/src/Controller/Front/HomeController.php
@@ -8,16 +8,19 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Attribute\Cache;
 use Symfony\Component\Routing\Annotation\Route;
 
 class HomeController extends AbstractController
 {
+    #[Cache(public: true, maxage: 600)]
     #[Route('/', name: 'home')]
     public function index(): Response
     {
         return $this->render('front/index.html.twig', []);
     }
 
+    #[Cache(public: true, maxage: 600)]
     #[Route('/signalement', name: 'app_front_signalement_type_list')]
     public function signalementList(ParameterBagInterface $parameterBag): Response
     {
@@ -26,6 +29,7 @@ class HomeController extends AbstractController
         ]);
     }
 
+    #[Cache(public: true, maxage: 600)]
     #[Route('/information', name: 'app_front_information')]
     public function information(): Response
     {
@@ -34,6 +38,7 @@ class HomeController extends AbstractController
         ]);
     }
 
+    #[Cache(public: true, maxage: 600)]
     #[Route('/mentions-legales', name: 'app_front_mentions_legales')]
     public function mentionsLegales(): Response
     {
@@ -41,6 +46,7 @@ class HomeController extends AbstractController
         ]);
     }
 
+    #[Cache(public: true, maxage: 600)]
     #[Route('/politique-de-confidentialite', name: 'app_front_politique_confidentialite')]
     public function politiqueConfidentialite(): Response
     {


### PR DESCRIPTION
## Ticket

#466   

## Description
Ajout de cache navigateur (10 minutes) sur les pages statiques :
- home
- informations
- mentions légales, etc.

## Tests
- [ ] Aller sur la page d'accueil, et ouvrir l'inspecteur de navigation
- [ ] Charger la page, regarder la route `/` et vérifier que le cache est bien défini sur 600 secondes
