### PR TITLE
[OPS] Ajout de K6 pour faire des tests de montée en charge

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,8 @@ test-coverage: ## Generate phpunit coverage report in html
 e2e: ## Run E2E tests
 	@$(NPX) cypress open
 
+k6: ## Run K6 tests
+	@$(DOCKER_COMP) run --rm -T stopunaises_k6 run -<tools/k6/k6-50000.js --env "URL=$(URL)"
 
 stan: ## Run PHPStan
 	@$(DOCKER_COMP) exec -it stopunaises_phpfpm composer stan

--- a/docker-compose.tools.yml
+++ b/docker-compose.tools.yml
@@ -1,0 +1,11 @@
+# docker-compose.yml
+version: "3.8"
+
+services:
+  stopunaises_k6:
+    container_name: stopunaises_k6
+    image: grafana/k6:latest
+    ports:
+      - 6565:6565
+    volumes:
+      - ./samples:/scripts

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,13 +64,5 @@ services:
     image: redis:7.0-alpine
     container_name: stopunaises_redis
 
-  stopunaises_k6:
-    container_name: stopunaises_k6
-    image: grafana/k6:latest
-    ports:
-      - 6565:6565
-    volumes:
-      - ./samples:/scripts
-
 volumes:
   dbdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,5 +64,13 @@ services:
     image: redis:7.0-alpine
     container_name: stopunaises_redis
 
+  stopunaises_k6:
+    container_name: stopunaises_k6
+    image: grafana/k6:latest
+    ports:
+      - 6565:6565
+    volumes:
+      - ./samples:/scripts
+
 volumes:
   dbdata:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "stop-punaises",
+    "name": "app",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {

--- a/tools/k6/k6-50000.js
+++ b/tools/k6/k6-50000.js
@@ -1,0 +1,14 @@
+import http from 'k6/http';
+import { sleep } from 'k6';
+
+const urlToTest = __ENV.URL; // URL transmise en cli
+
+export let options = {
+  vus: 50000, // nombre d’utilisateurs virtuels concurrents
+  iterations: 50000, // nombre de fois que le test doit s’exécuter
+};
+
+export default function() {
+  http.get(urlToTest);
+  sleep(1);
+}


### PR DESCRIPTION
## Ticket

#468   

## Description
Ajout de K6 pour faire des tests de montée en charge

## Changements apportés
* Ajout du docker de K6
* Modification du fichier `Makefile`
* Fichier js de configuration faisant 50 000 requêtes

## Pré-requis

`make build`

## Tests
- [ ] Récupérer l'url de staging et la mettre à la place des `...`
- [ ] `make k6 URL="..."`
- [ ] Vérifier la montée en charge dans l'onglet Métriques de Scalingo
