### PR TITLE
[BO - Signalement] Anonymisation des noms d'entreprise pour les autres entreprises

### DIFF
--- a/src/EventSubscriber/InterventionEntrepriseCanceledSubscriber.php
+++ b/src/EventSubscriber/InterventionEntrepriseCanceledSubscriber.php
@@ -58,18 +58,20 @@ class InterventionEntrepriseCanceledSubscriber implements EventSubscriberInterfa
         );
         $this->eventRepository->updateCreatedAt($event, $interventionEntrepriseCanceledEvent->getCreatedAt());
 
-        $event = $this->eventManager->createEventEstimationSent(
-            signalement: $signalement,
-            title: 'Estimation '.$intervention->getEntreprise()->getNom(),
-            description: 'L\'entreprise sélectionnée a annulé son intervention',
-            recipient: null,
-            userId: Event::USER_ALL,
-            userIdExcluded: $intervention->getEntreprise()->getUser()->getId(),
-            label: self::LABEL_CANCELED,
-            actionLabel: null,
-            actionLink: null,
-        );
-        $this->eventRepository->updateCreatedAt($event, $interventionEntrepriseCanceledEvent->getCreatedAt());
+        if ($intervention->isAcceptedByUsager()) {
+            $event = $this->eventManager->createEventEstimationSent(
+                signalement: $signalement,
+                title: 'Estimation autre entreprise',
+                description: 'L\'entreprise sélectionnée a annulé son intervention',
+                recipient: null,
+                userId: Event::USER_ALL,
+                userIdExcluded: $intervention->getEntreprise()->getUser()->getId(),
+                label: self::LABEL_CANCELED,
+                actionLabel: null,
+                actionLink: null,
+            );
+            $this->eventRepository->updateCreatedAt($event, $interventionEntrepriseCanceledEvent->getCreatedAt());
+        }
 
         $event = $this->eventManager->createEventEstimationSent(
             signalement: $signalement,

--- a/src/EventSubscriber/InterventionEntrepriseCanceledSubscriber.php
+++ b/src/EventSubscriber/InterventionEntrepriseCanceledSubscriber.php
@@ -61,7 +61,7 @@ class InterventionEntrepriseCanceledSubscriber implements EventSubscriberInterfa
         $event = $this->eventManager->createEventEstimationSent(
             signalement: $signalement,
             title: 'Estimation '.$intervention->getEntreprise()->getNom(),
-            description: 'L\'entreprise '.$intervention->getEntreprise()->getNom().' a annulé son intervention',
+            description: 'L\'entreprise sélectionnée a annulé son intervention',
             recipient: null,
             userId: Event::USER_ALL,
             userIdExcluded: $intervention->getEntreprise()->getUser()->getId(),

--- a/src/EventSubscriber/InterventionUsagerAcceptedSubscriber.php
+++ b/src/EventSubscriber/InterventionUsagerAcceptedSubscriber.php
@@ -43,8 +43,8 @@ class InterventionUsagerAcceptedSubscriber implements EventSubscriberInterface
 
         $event = $this->eventManager->createEventEstimationSent(
             signalement: $signalement,
-            title: 'Estimation '.$intervention->getEntreprise()->getNom(),
-            description: 'L\'entreprise '.$intervention->getEntreprise()->getNom().' a envoyé une estimation',
+            title: 'Estimation autre entreprise',
+            description: 'L\'usager a accepté l\'estimation d\'une entreprise',
             recipient: null,
             userId: Event::USER_ALL,
             userIdExcluded: $intervention->getEntreprise()->getUser()->getId(),

--- a/src/Repository/EventRepository.php
+++ b/src/Repository/EventRepository.php
@@ -65,6 +65,7 @@ class EventRepository extends ServiceEntityRepository
             ->andWhere('e.userId = :userIdAdmin OR e.userId = :userIdAll')
             ->setParameter('userIdAll', Event::USER_ALL)
             ->setParameter('userIdAdmin', Event::USER_ADMIN)
+            ->andWhere('e.title NOT LIKE \'Estimation autre entreprise\'')
             ->andWhere('e.active = 1')
             ->orderBy('e.createdAt', 'DESC');
 


### PR DESCRIPTION
## Ticket

#250    

## Description
Lorsqu'un usager accepte une estimation, on ne souhaite pas que les autres entreprises aient accès au nom de l'entreprise acceptée.
Lorsqu'une entreprise annule son intervention, on ne souhaite pas que les autres entreprises y aient accès non plus.

## Tests
Conseil : utiliser 2 navigateurs et navigateurs privés pour faciliter les tests

- [ ] Créer un signalement dans un territoire ouvert (ex: 13)

Pour les 2 points suivants, si besoin, changer le territoire d'intervention de l'entreprise une fois connecté, pour pouvoir traiter le signalement, selon l'adresse.
- [ ] Se connecter en tant que company-01@punaises.fr, valider le signalement, faire une estimation
- [ ] Pareil en tant que company-02

- [ ] En tant qu'usager, accéder à la page de suivi, et accepter une des estimations (ex : celle de company 1)
- [ ] En tant qu'usager, je vois les noms d'entreprise
- [ ] En tant qu'admin, je vois tous les événements
- [ ] En tant que company 1, je vois mon nom avec l'acceptation
- [ ] En tant que company 2, je vois mon nom pour l'événement de refus, je ne vois pas le nom de l'entreprise acceptée
- [ ] En tant que company 3, je ne vois pas le nom de l'entreprise acceptée

- [ ] En tant que company 1, annuler mon intervention
- [ ] En tant que company 1, je vois mon nom qui a annulé
- [ ] En tant que company 2 et 3, je ne vois pas le nom de l'entreprise qui a annulé
- [ ] En tant qu'admin, je vois tous les événements
- [ ] En tant qu'usager, je vois les noms d'entreprise
