### PR TITLE
[BO - Entreprises] Augmentation du temps avant que le token d'inscription ne soit plus valide

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -6,7 +6,7 @@
 parameters:
     .container.dumper.inline_factories: true
     from: '%env(resolve:NOTIFICATIONS_EMAIL)%'
-    token_lifetime: '10 minutes'
+    token_lifetime: '1 hour'
     base_url: '%env(resolve:APP_URL)%'
     uploads_tmp_dir: '%kernel.project_dir%/tmp/'
     url_bucket: '%env(resolve:S3_URL_BUCKET)%'


### PR DESCRIPTION
## Ticket

#471    

## Description
Augmentation du temps (1h au lieu de 10min) avant que le token d'inscription ne soit plus valide

## Tests
- [ ] En tant qu'admin, créer une entreprise
- [ ] Dans la BDD, vérifier la table USER, la colonne token_expired_at : elle doit être une heure plus tard (il se peut que l'heure soit simultanée avec les fuseaux horaires)
