### PR TITLE
[Sécurité] Commande de remise à zero des mots de passe administrateurs

### DIFF
--- a/src/Command/ReinitAdminPasswordsCommand.php
+++ b/src/Command/ReinitAdminPasswordsCommand.php
@@ -12,7 +12,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
-use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 #[AsCommand(
@@ -45,18 +44,7 @@ class ReinitAdminPasswordsCommand extends Command
         $users = $this->userRepository->findActiveAdmins();
 
         foreach ($users as $user) {
-            $password = $this->hasher->hashPassword($user, $this->tokenGenerator->generateToken());
-            $user->setPassword($password)->setStatus(Status::INACTIVE);
-
-            /** @var ConstraintViolationList $errors */
-            $errors = $this->validator->validate($user);
-
-            if (\count($errors) > 0) {
-                $this->io->error((string) $errors);
-
-                return Command::FAILURE;
-            }
-
+            $user->setPassword('')->setStatus(Status::INACTIVE);
             $this->userManager->save($user);
 
             $this->userManager->requestActivationFrom($user->getEmail());

--- a/src/Command/ReinitAdminPasswordsCommand.php
+++ b/src/Command/ReinitAdminPasswordsCommand.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Command;
+
+use App\Entity\Enum\Status;
+use App\Manager\UserManager;
+use App\Repository\UserRepository;
+use App\Service\Token\GeneratorToken;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Symfony\Component\Validator\ConstraintViolationList;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+#[AsCommand(
+    name: 'app:reinit-admin-passwords',
+    description: 'Reinitialize admin passwords'
+)]
+class ReinitAdminPasswordsCommand extends Command
+{
+    private SymfonyStyle $io;
+
+    public const ROLE_ADMIN = 'ROLE_ADMIN';
+
+    public function __construct(
+        private UserManager $userManager,
+        private ValidatorInterface $validator,
+        private UserPasswordHasherInterface $hasher,
+        private UserRepository $userRepository,
+        private GeneratorToken $tokenGenerator
+    ) {
+        parent::__construct();
+    }
+
+    protected function initialize(InputInterface $input, OutputInterface $output): void
+    {
+        $this->io = new SymfonyStyle($input, $output);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $users = $this->userRepository->findActiveAdmins();
+
+        foreach ($users as $user) {
+            $password = $this->hasher->hashPassword($user, $this->tokenGenerator->generateToken());
+            $user->setPassword($password)->setStatus(Status::INACTIVE);
+
+            /** @var ConstraintViolationList $errors */
+            $errors = $this->validator->validate($user);
+
+            if (\count($errors) > 0) {
+                $this->io->error((string) $errors);
+
+                return Command::FAILURE;
+            }
+
+            $this->userManager->save($user);
+
+            $this->userManager->requestActivationFrom($user->getEmail());
+        }
+
+        $this->io->success(sprintf(
+            '%s admin users were successfully reinitialized',
+            \count($users)
+        ));
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -2,6 +2,7 @@
 
 namespace App\Repository;
 
+use App\Entity\Enum\Status;
 use App\Entity\User;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
@@ -37,5 +38,18 @@ class UserRepository extends ServiceEntityRepository
         if ($flush) {
             $this->getEntityManager()->flush();
         }
+    }
+
+    public function findActiveAdmins(): ?array
+    {
+        $queryBuilder = $this->createQueryBuilder('u');
+
+        return $queryBuilder
+            ->andWhere('u.roles LIKE :role')
+            ->setParameter('role', '%"ROLE_ADMIN"%')
+            ->andWhere('u.status LIKE :active')
+            ->setParameter('active', Status::ACTIVE)
+            ->getQuery()
+            ->getResult();
     }
 }


### PR DESCRIPTION
## Ticket

#480    

## Description
Commande de remise à zero des mots de passe administrateurs

## Tests
- [ ] `make console app="reinit-admin-passwords"`
- [ ] L'admin ne peut plus se connecter
- [ ] Il a reçu un mail d'activation de compte et le lien dans le mail permet de saisir directement son mot de passe pour se réactiver