### PR TITLE
[Accessibilité] Ajouter une balise alt à toutes les images

### DIFF
--- a/templates/bundles/TwigBundle/Exception/error.html.twig
+++ b/templates/bundles/TwigBundle/Exception/error.html.twig
@@ -15,7 +15,7 @@
                     </p>
                 </div>
                 <div class="fr-col-10 fr-col-md-5 fr-col-lg-4">
-                    <img src="{{ asset('build/images/loupe-punaise.png') }}" alt="illustration punaises" width="384" height="288">
+                    <img src="{{ asset('build/images/loupe-punaise.png') }}" alt="" width="384" height="288">
                 </div>
             </div>
         </section>

--- a/templates/bundles/TwigBundle/Exception/error403.html.twig
+++ b/templates/bundles/TwigBundle/Exception/error403.html.twig
@@ -13,7 +13,7 @@
                     </p>
                 </div>
                 <div class="fr-col-10 fr-col-md-5 fr-col-lg-4">
-                    <img src="{{ asset('build/images/loupe-punaise.png') }}" alt="illustration punaises" width="384"
+                    <img src="{{ asset('build/images/loupe-punaise.png') }}" alt="" width="384"
                          height="288">
                 </div>
             </div>

--- a/templates/bundles/TwigBundle/Exception/error404.html.twig
+++ b/templates/bundles/TwigBundle/Exception/error404.html.twig
@@ -13,7 +13,7 @@
                     </p>
                 </div>
                 <div class="fr-col-10 fr-col-md-5 fr-col-lg-4">
-                    <img src="{{ asset('build/images/loupe-punaise.png') }}" alt="illustration punaises" width="384"
+                    <img src="{{ asset('build/images/loupe-punaise.png') }}" alt="" width="384"
                          height="288">
                 </div>
             </div>

--- a/templates/common/components/signalement-detail.html.twig
+++ b/templates/common/components/signalement-detail.html.twig
@@ -82,7 +82,12 @@
                 {% for index,photo in photos %}
                     <div class="fr-col-6 fr-col-md-3">
                         <div style="background: url('{{ photo.url }}?_csrf_token={{ csrf_token('signalement_ext_file_view') }}')no-repeat center center/cover">
-                            <a class="fr-btn fr-icon-eye-line" href="{{ photo.url }}?_csrf_token={{ csrf_token('signalement_ext_file_view') }}" title="Voir la photo" target="_blank" rel="noopener"></a>
+                            <a class="fr-btn fr-icon-eye-line"
+                               href="{{ photo.url }}?_csrf_token={{ csrf_token('signalement_ext_file_view') }}"
+                               title="{{ 'Photo ' ~ (index + 1) ~ ' envoyée par l\'usager' }}"
+                               aria-label="{{ 'Photo ' ~ (index + 1) ~ 'envoyée par l\'usager' }}"
+                               target="_blank"
+                               rel="noopener"></a>
                         </div>
                     </div>
                 {% endfor %}

--- a/templates/common/header-back.html.twig
+++ b/templates/common/header-back.html.twig
@@ -16,7 +16,7 @@
                         <div class="fr-header__operator">
                             <a href="{{ path('home') }}" title="Accueil - Stop punaises - Ministère de la transition écologique">
                                 <p class="fr-header__service-title">
-                                    <img src="{{ asset('build/images/logo-stop-punaises.svg') }}" alt="" width="90">
+                                    <img src="{{ asset('build/images/logo-stop-punaises.svg') }}" alt="Stop punaises" width="90">
                                 </p>
                             </a>
                         </div>

--- a/templates/common/header.html.twig
+++ b/templates/common/header.html.twig
@@ -16,7 +16,7 @@
                         <div class="fr-header__operator">
                             <a href="{{ path('home') }}" title="Accueil - Stop punaises - Ministère de la transition écologique et de la cohésion des territoires">
                                 <p class="fr-header__service-title">
-                                    <img src="{{ asset('build/images/logo-stop-punaises.svg') }}" alt="" width="90">
+                                    <img src="{{ asset('build/images/logo-stop-punaises.svg') }}" alt="Stop punaises" width="90">
                                 </p>
                             </a>
                         </div>

--- a/templates/front/index.html.twig
+++ b/templates/front/index.html.twig
@@ -14,7 +14,7 @@
                 <a href="{{ path('app_front_signalement_type_list') }}" class="fr-btn btn-next">Je signale un problème</a>
             </div>
             <div class="fr-col-12 fr-col-md-6 align-center">
-                <img src="{{ asset('build/images/loupe-punaise.png') }}" alt="illustration punaises" width="384" height="288">
+                <img src="{{ asset('build/images/loupe-punaise.png') }}" alt="" width="384" height="288">
             </div>
         </div>
     </section>
@@ -233,7 +233,7 @@
                     </p>
                 </div>
                 <div class="fr-col-12 fr-col-md-4">
-                    <img src="{{ asset('build/images/logo-stop-punaises.svg') }}" alt="Stop punaises">
+                    <img src="{{ asset('build/images/logo-stop-punaises.svg') }}" alt="">
                 </div>
             </div>
         </div>

--- a/templates/front/index.html.twig
+++ b/templates/front/index.html.twig
@@ -14,7 +14,7 @@
                 <a href="{{ path('app_front_signalement_type_list') }}" class="fr-btn btn-next">Je signale un problème</a>
             </div>
             <div class="fr-col-12 fr-col-md-6 align-center">
-                <img src="{{ asset('build/images/loupe-punaise.png') }}" alt="" width="384" height="288">
+                <img src="{{ asset('build/images/loupe-punaise.png') }}" alt="illustration punaises" width="384" height="288">
             </div>
         </div>
     </section>
@@ -233,7 +233,7 @@
                     </p>
                 </div>
                 <div class="fr-col-12 fr-col-md-4">
-                    <img src="{{ asset('build/images/logo-stop-punaises.svg') }}" alt="">
+                    <img src="{{ asset('build/images/logo-stop-punaises.svg') }}" alt="Stop punaises">
                 </div>
             </div>
         </div>

--- a/templates/signalement_view/tab-intervention.html.twig
+++ b/templates/signalement_view/tab-intervention.html.twig
@@ -68,8 +68,14 @@
             {% for index,photo in photos %}
                 <div class="fr-col-6 fr-col-md-3">
                     <div style="background: url('{{ photo.url }}?_csrf_token={{ csrf_token('signalement_ext_file_view') }}')no-repeat center center/cover">
-                        <a class="fr-btn fr-icon-eye-line" href="{{ photo.url }}?_csrf_token={{ csrf_token('signalement_ext_file_view') }}" title="Voir la photo" target="_blank" rel="noopener"></a>
-                        {% if is_granted('ROLE_ADMIN') or (is_granted('ROLE_ENTREPRISE') and signalement.entreprise is not null and signalement.entreprise.id == app.user.entreprise.id) %}
+                        <a class="fr-btn fr-icon-eye-line" href="{{ photo.url }}?_csrf_token={{ csrf_token('signalement_ext_file_view') }}"
+                           title="{{ 'Photo ' ~ (index + 1) ~ ' envoyée par l\'usager' }}"
+                           aria-label="{{ 'Photo ' ~ (index + 1) ~ 'envoyée par l\'usager'  }}"
+                           target="_blank"
+                           rel="noopener"></a>
+                        {% if is_granted('ROLE_ADMIN') or (is_granted('ROLE_ENTREPRISE')
+                            and signalement.entreprise is not null
+                            and signalement.entreprise.id == app.user.entreprise.id) %}
                             <form action="{{ path('app_delete_photo', {'uuid': signalement.uuid, 'filename': photo.file }) }}" method="POST">
                                 <input type="hidden" name="_csrf_token" value="{{ csrf_token('signalement_delete_file_'~signalement.id) }}">
                                 <button class="fr-btn fr-icon-delete-line" title="Supprimer la photo"></button>


### PR DESCRIPTION
## Ticket

#487    

## Description
Ajout des de texte alternatifs manquant sur les images dont le logo.
[D'après Web-Aim, l'organisation qui promeut l'accessibilité sur le Web](https://webaim.org/techniques/alttext/#logos), un texte pour le logo est à prévoir mais sans le mot logo.

## Changements apportés
* Ajout des textes sur les balises alt

## Pré-requis

## Tests
- [ ] Faire une recherche sur le projet sur la balise img dans le répertoire `templates/`
