### PR TITLE
[Accessibilité] Rendre la hiérarchie des titres cohérente (H1 sur toutes la pages et pas de saut)

### DIFF
--- a/templates/cartographie/curseur.html.twig
+++ b/templates/cartographie/curseur.html.twig
@@ -1,7 +1,7 @@
 <div style="position: absolute;z-index: 10000;overflow: hidden;left: 50px" class="fr-rounded fr-background--white fr-m-2v">
         <div class="fr-pt-5v fr-px-5v">
-    <h6>Evolution des foyers d'infestation <br>
-    de punaises de lit en France</h6>
+    <h1 class="fr-h6">Evolution des foyers d'infestation <br>
+    de punaises de lit en France</h1>
         </div>
     <form action="#" name="bo-carto-filter" id="bo_carto_filter" method="POST" class="fr-background--white" style="overflow: hidden">
         <div class="fr-pb-5v fr-px-5v">

--- a/templates/common/components/progression-signalement.html.twig
+++ b/templates/common/components/progression-signalement.html.twig
@@ -36,7 +36,7 @@
 
 <div class="fr-stepper">
     <div class="fr-stepper__steps" data-fr-current-step="{{ stepIndex }}" data-fr-steps="{{ stepMax }}"></div>
-    <h2 class="fr-stepper__title">
+    <h3 class="fr-stepper__title">
         {{ stepLabel }}
-    </h2>
+    </h3>
 </div>

--- a/templates/dashboard/index.html.twig
+++ b/templates/dashboard/index.html.twig
@@ -24,9 +24,9 @@
                             </li>
                         </ul>
                         <div class="fr-card__content">
-                            <h3 class="fr-card__title">
+                            <h2 class="fr-card__title">
                                 <a href="{{ path('app_signalement_list') }}">Signalements à traiter</a>
-                            </h3>
+                            </h2>
                             <p class="fr-card__desc">Consultez et traitez les signalements déposés par les particuliers !</p>
                         </div>
                     </div>
@@ -43,9 +43,9 @@
                             </li>
                         </ul>
                             <div class="fr-card__content">
-                                <h3 class="fr-card__title">
+                                <h2 class="fr-card__title">
                                     <a href="{{ path('app_horsperimetre_list') }}">Hors périmètre</a>
-                                </h3>
+                                </h2>
                                 <p class="fr-card__desc">Consultez les signalements déposés sur les territoires non déployés.</p>
                             </div>
                         </div>
@@ -63,9 +63,9 @@
                             </li>
                         </ul>
                             <div class="fr-card__content">
-                                <h3 class="fr-card__title">
+                                <h2 class="fr-card__title">
                                     <a href="{{ path('app_erptransports_list') }}">ERP & Transports</a>
-                                </h3>
+                                </h2>
                                 <p class="fr-card__desc">Consultez les signalements sur les lieux publics et transports en commun.</p>
                             </div>
                         </div>
@@ -77,9 +77,9 @@
                 <div class="fr-card fr-enlarge-link">
                     <div class="fr-card__body">
                         <div class="fr-card__content">
-                            <h3 class="fr-card__title">
+                            <h2 class="fr-card__title">
                                 <a href="{{ path('app_historique_list') }}">Données historiques</a>
-                            </h3>
+                            </h2>
                             <p class="fr-card__desc">Consultez et gérez la liste des interventions réalisées avant d'utiliser Stop Punaises.</p>
                         </div>
                     </div>
@@ -91,9 +91,9 @@
                     <div class="fr-card fr-enlarge-link">
                         <div class="fr-card__body">
                             <div class="fr-card__content">
-                                <h3 class="fr-card__title">
+                                <h2 class="fr-card__title">
                                     <a href="{{ path('app_entreprise_list') }}">Les entreprises</a>
-                                </h3>
+                                </h2>
                                 <p class="fr-card__desc">Gérez les entreprises enregistrées sur la plateforme Stop Punaises.</p>
                             </div>
                         </div>
@@ -105,9 +105,9 @@
                     <div class="fr-card fr-enlarge-link">
                         <div class="fr-card__body">
                             <div class="fr-card__content">
-                                <h3 class="fr-card__title">
+                                <h2 class="fr-card__title">
                                     <a href="{{ path('app_entreprise_view',{uuid:app.user.entreprise.uuid}) }}">Mon entreprise</a>
-                                </h3>
+                                </h2>
                                 <p class="fr-card__desc">Gérez les informations de votre entreprise et vos fiches employés.</p>
                             </div>
                         </div>

--- a/templates/front/contact.html.twig
+++ b/templates/front/contact.html.twig
@@ -30,9 +30,9 @@
                 </p>
             </section>
 
-            <p class="fr-col-11 fr-col-md-8 fr-h6 fr-mt-5w">
+            <h2 class="fr-col-11 fr-col-md-8 fr-h6 fr-mt-5w">
                 Une question ? Une précision ? N'hésitez pas à nous envoyer un message !
-            </p>
+            </h2>
 
             <p class="fr-col-11 fr-col-md-8">
                 <strong>Attention :</strong>

--- a/templates/front_signalement_erp/index.html.twig
+++ b/templates/front_signalement_erp/index.html.twig
@@ -12,12 +12,12 @@
                     <a href="{{ path('app_front_signalement_type_list') }}"
                        class="fr-link fr-link--icon-left fr-icon-arrow-left-s-line">Retour</a>
                 </div>
-                <h2>Signaler des punaises de lit dans un lieu public</h2>
+                <h1 class="fr-h2">Signaler des punaises de lit dans un lieu public</h1>
                 <p>Remplissez les champs ci-dessous puis valider votre signalement. Tous les champs sont obligatoires,
                     sauf
                     mention contraire.</p>
 
-                <h3>Date et heure</h3>
+                <h2 class="fr-h3">Date et heure</h2>
                 <p>Renseignez la date et l'heure à laquelle vous avez vu des punaises de lit.</p>
                 <div class="fr-form-group display-if-diagnostic display-if-traitement">
                     <div class="fr-input-group">
@@ -39,7 +39,7 @@
                         </p>
                     </div>
                 </div>
-                <h3>L'établissement</h3>
+                <h2 class="fr-h3">L'établissement</h2>
                 <div class="fr-form-group">
                     <div class="fr-select-group">
                         {{ form_label(form.nomProprietaire) }}
@@ -51,7 +51,7 @@
                 </div>
                 <div class="fr-form-group">
                     <div class="fr-input-group search-address">
-                        <label for="">Adresse de l'établissement</label>
+                        <label for="rechercheAdresse">Adresse de l'établissement</label>
                         <span class="fr-hint-text help-text">Tapez l'adresse puis selectionnez-la dans la liste</span>
                         <div class="fr-input-wrap fr-icon-map-pin-2-line">
                             <input id="rechercheAdresse" type="text" class="fr-input">
@@ -133,7 +133,7 @@
                     </div>
                 </div>
 
-                <h3>Informations complémentaires</h3>
+                <h2 class="fr-h3">Informations complémentaires</h2>
 
 
                 <div id="form-group-photos" class="fr-form-group">
@@ -166,7 +166,7 @@
                     </p>
                 </div>
 
-                <h3>Vos coordonnées</h3>
+                <h2 class="fr-h3">Vos coordonnées</h2>
                 <p>Renseignez vos coordonnées pour recevoir nos conseils pour éviter de ramener des punaises chez vous
                     par email.</p>
                 <div class="fr-form-group">

--- a/templates/front_signalement_transport/index.html.twig
+++ b/templates/front_signalement_transport/index.html.twig
@@ -13,12 +13,12 @@
                     <a href="{{ path('app_front_signalement_type_list') }}"
                        class="fr-link fr-link--icon-left fr-icon-arrow-left-s-line">Retour</a>
                 </div>
-                <h2>Signaler des punaises de lit dans les transports en commun</h2>
+                <h1 class="fr-h2">Signaler des punaises de lit dans les transports en commun</h1>
                 <p>Remplissez les champs ci-dessous puis valider votre signalement. Tous les champs sont obligatoires,
                     sauf
                     mention contraire.</p>
 
-                <h3>Date et heure</h3>
+                <h2 class="fr-h3">Date et heure</h2>
                 <p>Renseignez la date et l'heure à laquelle vous avez vu des punaises de lit.</p>
                 <div class="fr-form-group display-if-diagnostic display-if-traitement">
                     <div class="fr-input-group">
@@ -40,7 +40,7 @@
                         </p>
                     </div>
                 </div>
-                <h3>Détails du problème</h3>
+                <h2 class="fr-h3">Détails du problème</h2>
                 <div class="fr-form-group">
                     <div class="fr-select-group search-commune">
                         {{ form_label(form.ville) }}
@@ -95,7 +95,7 @@
                     </div>
                 </div>
 
-                <h3>Informations complémentaires</h3>
+                <h2 class="fr-h3">Informations complémentaires</h2>
                 <div id="form-group-photos" class="fr-form-group">
                     <div class="fr-upload-group">
                         <label class="fr-label">Photos (facultatif)</label>
@@ -128,7 +128,7 @@
                     </p>
                 </div>
 
-                <h3>Vos coordonnées</h3>
+                <h2 class="fr-h3">Vos coordonnées</h2>
                 <p>Renseignez vos coordonnées pour recevoir nos conseils pour éviter de ramener des punaises chez vous
                     par email.</p>
                 <div class="fr-form-group">

--- a/templates/front_suivi_usager/index.html.twig
+++ b/templates/front_suivi_usager/index.html.twig
@@ -37,8 +37,8 @@
 
     <div class="fr-grid-row fr-grid-row--gutters">
         <div class="fr-col fr-col-12 fr-col-lg-6">
-            <h2>Bonjour {{ signalement.prenomOccupant }},</h2>
-            <h3>Votre signalement #{{ signalement.reference }}</h3>
+            <h1 class="fr-h2">Bonjour {{ signalement.prenomOccupant }},</h1>
+            <h2 class="fr-h3">Votre signalement #{{ signalement.reference }}</h2>
 
             {% include "common/components/progression-signalement.html.twig" %}
 

--- a/templates/signalement_view/tab-intervention.html.twig
+++ b/templates/signalement_view/tab-intervention.html.twig
@@ -13,8 +13,7 @@
     <div class="fr-container fr-px-2w">
         <div class="fr-grid-row fr-grid fr-grid-row--gutters">
             <div class="fr-col-12 fr-col-lg-5 fr-mr-3v fr-mb-3v edit-zone">
-                <strong>Infos générales</strong>
-                <br>
+                <h3 class="fr-tile__title fr-mb-1v">Infos générales</h3>
                 Entreprise : {{ signalement.entreprise }}
                 <br>
                 Agent : {{ signalement.agent }}
@@ -26,7 +25,7 @@
                 Prix facturé : {{ signalement.prixFactureHT }} €
             </div>
             <div class="fr-col-12 fr-col-lg-5 fr-mb-3v edit-zone">
-                <strong>Détails de l'intervention</strong>
+                <h3 class="fr-tile__title fr-mb-1v">Détails de l'intervention</h3>
                 <br>
 
                 {% if 'traitement' in signalement.typeIntervention %}

--- a/templates/signalement_view/tab-logement.html.twig
+++ b/templates/signalement_view/tab-logement.html.twig
@@ -6,8 +6,7 @@
 <div class="fr-container fr-px-2w fr-mb-15w">
     <div class="fr-grid-row fr-grid fr-grid-row--gutters">
         <div class="fr-col-12 fr-col-lg-5 fr-mr-3v edit-zone">
-            <strong>Le logement</strong>
-            <br>
+            <h3 class="fr-tile__title fr-mb-1v">Le logement</h3>
             {% if can_display_adresse %}
                 Adresse : {{ signalement.adresse }}
                 <br>
@@ -25,8 +24,7 @@
             {% endif %}
         </div>
         <div class="fr-col-12 fr-col-lg-5 edit-zone">
-            <strong>L'occupant</strong>
-            <br>
+            <h3 class="fr-tile__title fr-mb-1v">L'occupant</h3>
             {% if can_display_adresse %}
                 Nom : {{ signalement.nomOccupant }}
                 <br>

--- a/tests/Functionnal/Controller/Front/SuiviUsagerViewControllerTest.php
+++ b/tests/Functionnal/Controller/Front/SuiviUsagerViewControllerTest.php
@@ -31,7 +31,7 @@ class SuiviUsagerViewControllerTest extends WebTestCase
         $client->loginUser($user);
         $client->request('GET', $route);
         $this->assertResponseIsSuccessful($signalement->getId());
-        $this->assertSelectorTextContains('.suivi-usager h3',
+        $this->assertSelectorTextContains('.suivi-usager h2',
             'Votre signalement #'.$signalement->getReference()
         );
     }


### PR DESCRIPTION
## Ticket

#490    

## Description
Revue de toutes les pages afin de vérifier la hiérarchie des titres: 
Que chaque pages aient un titre `<h1>` et qu'une hiérarchie soit bien respectée et que les modales aient un titre (`<h1>` en l'occurrence)

### FO
- [https://stop-punaises.beta.gouv.fr/](https://stop-punaises.beta.gouv.fr/)
- [https://stop-punaises.beta.gouv.fr/information](https://stop-punaises.beta.gouv.fr/information)
- [https://stop-punaises.beta.gouv.fr/contact](https://stop-punaises.beta.gouv.fr/contact)
- [https://stop-punaises.beta.gouv.fr/login](https://stop-punaises.beta.gouv.fr/login)
- [https://stop-punaises.beta.gouv.fr/signalement](https://stop-punaises.beta.gouv.fr/signalement) 
- [https://stop-punaises.beta.gouv.fr/mentions-legales](https://stop-punaises.beta.gouv.fr/mentions-legales) 
- [https://stop-punaises.beta.gouv.fr/politique-de-confidentialite](https://stop-punaises.beta.gouv.fr/politique-de-confidentialite)
- [https://stop-punaises.beta.gouv.fr/mot-de-passe-perdu](https://stop-punaises.beta.gouv.fr/mot-de-passe-perdu)
- [https://stop-punaises.beta.gouv.fr/activation-compte](https://stop-punaises.beta.gouv.fr/activation-compte)
- [https://stop-punaises.beta.gouv.fr/signalement/logement](https://stop-punaises.beta.gouv.fr/signalement/logement)
- [Fiche usager](https://stop-punaises.beta.gouv.fr/signalements/6571a7f76b69d)

### BO
- https://stop-punaises.beta.gouv.fr/bo
- https://stop-punaises.beta.gouv.fr/bo/cartographie
- https://stop-punaises.beta.gouv.fr/bo/signalements
     - https://stop-punaises.beta.gouv.fr/bo/signalements/fc51fe0c-7989-4262-978a-0f5bee4729f3
- https://stop-punaises.beta.gouv.fr/bo/hors-perimetre
- https://stop-punaises.beta.gouv.fr/bo/erp-transports
- https://stop-punaises.beta.gouv.fr/bo/historique 
     - https://stop-punaises.beta.gouv.fr/bo/historique/0f4464f9-7bd4-4158-b0f8-d936ea91c017
- https://stop-punaises.beta.gouv.fr/bo/entreprises
     - https://stop-punaises.beta.gouv.fr/bo/entreprises/63b55480d6c78

#### BO - Modal


## Changements apportés
- Ajout d'un titre h1 à la page Cartographie
- Correction hiérarchie sur le tableau de bord (Passage de h1 à h3)
- Correction hiérarchie formulaire ERP
- Correction hiérarchie formulaire transport
- Remplacement texte d'en tête par titre h3 dans l'onglet Intervention et logement
 
## Pré-requis

## Tests
- [ ] Inspecter chaque page
