### PR TITLE
[Accessibilité] Rendre le code HTML de toutes les pages valide

### DIFF
--- a/src/Form/ContactType.php
+++ b/src/Form/ContactType.php
@@ -66,7 +66,7 @@ class ContactType extends AbstractType
             'attr' => [
                 'id' => 'front_contact',
                 'class' => 'needs-validation',
-                'novalidate' => 'true',
+                'novalidate' => 'novalidate',
             ],
         ]);
     }

--- a/src/Form/SignalementFrontType.php
+++ b/src/Form/SignalementFrontType.php
@@ -52,7 +52,6 @@ class SignalementFrontType extends AbstractType
                     'class' => 'fr-input',
                     'placeholder' => '36',
                     'maxlength' => '10',
-                    'int' => true,
                 ],
                 'label_attr' => [
                     'class' => 'fr-label',
@@ -66,7 +65,6 @@ class SignalementFrontType extends AbstractType
                 ],
                 'label_attr' => [
                     'class' => 'fr-label',
-                    'maxlength' => '100',
                 ],
                 'label' => 'Adresse',
                 'required' => true,
@@ -91,7 +89,6 @@ class SignalementFrontType extends AbstractType
             ->add('codeInsee', HiddenType::class, [
                 'attr' => [
                     'class' => 'fr-hidden',
-                    'pattern' => '[0-9]{5}',
                 ],
                 'required' => false,
             ])
@@ -273,7 +270,6 @@ class SignalementFrontType extends AbstractType
             ->add('niveauInfestation', HiddenType::class, [
                 'attr' => [
                     'class' => 'fr-hidden',
-                    'pattern' => '[0-9]',
                 ],
                 'required' => false,
             ])
@@ -325,7 +321,6 @@ class SignalementFrontType extends AbstractType
                 'attr' => [
                     'class' => 'fr-hidden',
                 ],
-                'required' => true,
                 'empty_data' => false,
             ])
         ;

--- a/src/Form/SignalementHistoryType.php
+++ b/src/Form/SignalementHistoryType.php
@@ -41,7 +41,6 @@ class SignalementHistoryType extends AbstractType
                 ],
                 'label_attr' => [
                     'class' => 'fr-label',
-                    'maxlength' => '100',
                 ],
                 'label' => 'Adresse',
                 'required' => true,
@@ -66,7 +65,6 @@ class SignalementHistoryType extends AbstractType
             ->add('codeInsee', HiddenType::class, [
                 'attr' => [
                     'class' => 'fr-hidden',
-                    'pattern' => '[0-9]{5}',
                 ],
                 'required' => false,
             ])

--- a/templates/base-back.html.twig
+++ b/templates/base-back.html.twig
@@ -4,7 +4,7 @@
         <meta charset="UTF-8">
         <title>{% block title %}Welcome!{% endblock %}</title>
         
-        <link rel="stylesheet" href="{{ asset('build/dsfr/dsfr.min.css') }}"/>
+        <link rel="stylesheet" href="{{ asset('build/dsfr/dsfr.min.css') }}">
         <link rel="stylesheet" href="{{ asset('build/dsfr/utility/icons/icons-buildings/icons-buildings.min.css') }}">
         <link rel="stylesheet" href="{{ asset('build/dsfr/utility/icons/icons-design/icons-design.min.css') }}">
         <link rel="stylesheet" href="{{ asset('build/dsfr/utility/icons/icons-development/icons-development.min.css') }}">
@@ -25,7 +25,7 @@
         {% block custom_stylesheets %}{% endblock %}
 
         {% if 'app_cartographie' in app.request.get('_route') %}
-            <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"/>
+            <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">
             <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet-src.js"></script>
             <script src="https://unpkg.com/leaflet.heat@0.2.0/dist/leaflet-heat.js" ></script>
         {% endif %}

--- a/templates/base-back.html.twig
+++ b/templates/base-back.html.twig
@@ -3,19 +3,18 @@
     <head>
         <meta charset="UTF-8">
         <title>{% block title %}Welcome!{% endblock %}</title>
-        <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 128 128%22><text y=%221.2em%22 font-size=%2296%22>⚫️</text></svg>">
         
         <link rel="stylesheet" href="{{ asset('build/dsfr/dsfr.min.css') }}"/>
-        <link rel="stylesheet" href="{{ asset('build/dsfr/utility/icons/icons-buildings/icons-buildings.min.css') }}"/>
-        <link rel="stylesheet" href="{{ asset('build/dsfr/utility/icons/icons-design/icons-design.min.css') }}"/>
-        <link rel="stylesheet" href="{{ asset('build/dsfr/utility/icons/icons-development/icons-development.min.css') }}"/>
-        <link rel="stylesheet" href="{{ asset('build/dsfr/utility/icons/icons-device/icons-device.min.css') }}"/>
-        <link rel="stylesheet" href="{{ asset('build/dsfr/utility/icons/icons-document/icons-document.min.css') }}"/>
-        <link rel="stylesheet" href="{{ asset('build/dsfr/utility/icons/icons-map/icons-map.min.css') }}"/>
-        <link rel="stylesheet" href="{{ asset('build/dsfr/utility/icons/icons-system/icons-system.min.css') }}"/>
-        <link rel="stylesheet" href="{{ asset('build/dsfr/utility/icons/icons-user/icons-user.min.css') }}"/>
-        <link rel="stylesheet" href="{{ asset('build/dsfr/utility/icons/icons-business/icons-business.min.css') }}"/>
-        <link rel="stylesheet" href="{{ asset('build/datatables/jquery.dataTables.min.css') }}"/>
+        <link rel="stylesheet" href="{{ asset('build/dsfr/utility/icons/icons-buildings/icons-buildings.min.css') }}">
+        <link rel="stylesheet" href="{{ asset('build/dsfr/utility/icons/icons-design/icons-design.min.css') }}">
+        <link rel="stylesheet" href="{{ asset('build/dsfr/utility/icons/icons-development/icons-development.min.css') }}">
+        <link rel="stylesheet" href="{{ asset('build/dsfr/utility/icons/icons-device/icons-device.min.css') }}">
+        <link rel="stylesheet" href="{{ asset('build/dsfr/utility/icons/icons-document/icons-document.min.css') }}">
+        <link rel="stylesheet" href="{{ asset('build/dsfr/utility/icons/icons-map/icons-map.min.css') }}">
+        <link rel="stylesheet" href="{{ asset('build/dsfr/utility/icons/icons-system/icons-system.min.css') }}">
+        <link rel="stylesheet" href="{{ asset('build/dsfr/utility/icons/icons-user/icons-user.min.css') }}">
+        <link rel="stylesheet" href="{{ asset('build/dsfr/utility/icons/icons-business/icons-business.min.css') }}">
+        <link rel="stylesheet" href="{{ asset('build/datatables/jquery.dataTables.min.css') }}">
         
         <link rel="icon" href={{ asset('build/images/favicon.ico') }}>
 

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -5,16 +5,15 @@
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         
         <title>{% block title %}Welcome!{% endblock %}</title>
-        <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 128 128%22><text y=%221.2em%22 font-size=%2296%22>⚫️</text></svg>">
         
-        <link rel="stylesheet" href="{{ asset('build/dsfr/dsfr.min.css') }}"/>
-        <link rel="stylesheet" href="{{ asset('build/dsfr/utility/icons/icons-buildings/icons-buildings.min.css') }}"/>
-        <link rel="stylesheet" href="{{ asset('build/dsfr/utility/icons/icons-business/icons-business.min.css') }}"/>
-        <link rel="stylesheet" href="{{ asset('build/dsfr/utility/icons/icons-device/icons-device.min.css') }}"/>
-        <link rel="stylesheet" href="{{ asset('build/dsfr/utility/icons/icons-map/icons-map.min.css') }}"/>
-        <link rel="stylesheet" href="{{ asset('build/dsfr/utility/icons/icons-system/icons-system.min.css') }}"/>
-        <link rel="stylesheet" href="{{ asset('build/dsfr/utility/icons/icons-map/icons-map.min.css') }}"/>
-        <link rel="stylesheet" href="{{ asset('build/dsfr/utility/icons/icons-user/icons-user.min.css') }}"/>
+        <link rel="stylesheet" href="{{ asset('build/dsfr/dsfr.min.css') }}">
+        <link rel="stylesheet" href="{{ asset('build/dsfr/utility/icons/icons-buildings/icons-buildings.min.css') }}">
+        <link rel="stylesheet" href="{{ asset('build/dsfr/utility/icons/icons-business/icons-business.min.css') }}">
+        <link rel="stylesheet" href="{{ asset('build/dsfr/utility/icons/icons-device/icons-device.min.css') }}">
+        <link rel="stylesheet" href="{{ asset('build/dsfr/utility/icons/icons-map/icons-map.min.css') }}">
+        <link rel="stylesheet" href="{{ asset('build/dsfr/utility/icons/icons-system/icons-system.min.css') }}">
+        <link rel="stylesheet" href="{{ asset('build/dsfr/utility/icons/icons-map/icons-map.min.css') }}">
+        <link rel="stylesheet" href="{{ asset('build/dsfr/utility/icons/icons-user/icons-user.min.css') }}">
         
         <link rel="icon" href={{ asset('build/images/favicon.ico') }}>
 

--- a/templates/cartographie/curseur.html.twig
+++ b/templates/cartographie/curseur.html.twig
@@ -6,7 +6,7 @@
     <form action="#" name="bo-carto-filter" id="bo_carto_filter" method="POST" class="fr-background--white" style="overflow: hidden">
         <div class="fr-pb-5v fr-px-5v">
             <div class="fr-pb-3v">
-                <label for="filter-date">Voir l'évolution hebdomadaire :</label>
+                <label>Voir l'évolution hebdomadaire :</label>
                 <input type="hidden" name="filter-date" value="">
             </div>
             <div id="weekly-slider"></div>

--- a/templates/cartographie/index.html.twig
+++ b/templates/cartographie/index.html.twig
@@ -8,9 +8,9 @@
 
 {% block body %}
     {% include 'cartographie/curseur.html.twig' %}
-    <section class="fr-grid-row fr-pt-0 fr-h-100">
+    <div class="fr-grid-row fr-pt-0 fr-h-100">
         <div class="fr-col-12 signalement-invalid" id="container_map">
             <div class="fr-h-100 fr-w-100" id="map-signalements-view"></div>
         </div>
-    </section>
+    </div>
 {% endblock %}

--- a/templates/cartographie/index.html.twig
+++ b/templates/cartographie/index.html.twig
@@ -1,7 +1,7 @@
 {% extends 'base-back.html.twig' %}
 
 {% block custom_stylesheets %}
-    <link rel="stylesheet" href="{{ asset('build/jquery-ui/jquery-ui.min.css') }}"/>
+    <link rel="stylesheet" href="{{ asset('build/jquery-ui/jquery-ui.min.css') }}">
 {% endblock %}
 
 {% block title %}Stop punaises - Cartographie des signalements{% endblock %}
@@ -10,7 +10,6 @@
     {% include 'cartographie/curseur.html.twig' %}
     <section class="fr-grid-row fr-pt-0 fr-h-100">
         <div class="fr-col-12 signalement-invalid" id="container_map">
-            <div class="fr-hidden" data-token="{{ csrf_token('load_markers_'~''|date('dmYhi')) }}" id="carto__js"></div> 
             <div class="fr-h-100 fr-w-100" id="map-signalements-view"></div>
         </div>
     </section>

--- a/templates/common/footer.html.twig
+++ b/templates/common/footer.html.twig
@@ -1,4 +1,4 @@
-<footer class="fr-footer" role="contentinfo" id="footer">
+<footer class="fr-footer" id="footer">
     <div class="fr-container">
         <div class="fr-footer__body">
             <div class="fr-footer__brand fr-enlarge-link">

--- a/templates/common/header-back.html.twig
+++ b/templates/common/header-back.html.twig
@@ -1,4 +1,4 @@
-<header role="banner" class="fr-header">
+<header class="fr-header">
     <div class="fr-header__body">
         <div class="fr-container">
             <div class="fr-header__body-row">

--- a/templates/common/header.html.twig
+++ b/templates/common/header.html.twig
@@ -1,4 +1,4 @@
-<header role="banner" class="fr-header">
+<header class="fr-header">
     <div class="fr-header__body">
         <div class="fr-container">
             <div class="fr-header__body-row">

--- a/templates/dashboard/nav.html.twig
+++ b/templates/dashboard/nav.html.twig
@@ -1,6 +1,6 @@
 <div class="dashboard-menu">
     <div class="fr-container">
-        <nav class="fr-nav" id="header-navigation" role="navigation" aria-label="Menu du tableau de bord">
+        <nav class="fr-nav" id="header-navigation" aria-label="Menu du tableau de bord">
             <ul class="fr-nav__list">
                 <li class="fr-nav__item">
                     <a class="fr-nav__link" href="{{ path('app_signalement_list') }}" target="_self" {% if app.request.get('_route') == 'app_signalement_list' or app.request.get('_route') == 'app_signalement_view' %}aria-current="page"{% endif %}>Signalements</a>

--- a/templates/entreprise_list/modal-create-entreprise.html.twig
+++ b/templates/entreprise_list/modal-create-entreprise.html.twig
@@ -1,4 +1,4 @@
-<dialog aria-labelledby="fr-modal-title-modal-create-entreprise" role="dialog" id="fr-modal-create-entreprise" class="fr-modal fr-sidemodal">
+<dialog aria-labelledby="fr-modal-title-modal-create-entreprise" id="fr-modal-create-entreprise" class="fr-modal fr-sidemodal">
     <div class="fr-container fr-container--fluid fr-container-md">
         <div class="fr-grid-row fr-grid-row--center">
             <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">

--- a/templates/entreprise_view/modal-create-employe.html.twig
+++ b/templates/entreprise_view/modal-create-employe.html.twig
@@ -1,4 +1,4 @@
-<dialog aria-labelledby="fr-modal-title-modal-create-employe" role="dialog" id="fr-modal-create-employe" class="fr-modal fr-sidemodal">
+<dialog aria-labelledby="fr-modal-title-modal-create-employe" id="fr-modal-create-employe" class="fr-modal fr-sidemodal">
     <div class="fr-container fr-container--fluid fr-container-md">
         <div class="fr-grid-row fr-grid-row--center">
             <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">

--- a/templates/entreprise_view/modal-edit-employe.html.twig
+++ b/templates/entreprise_view/modal-edit-employe.html.twig
@@ -1,4 +1,4 @@
-<dialog aria-labelledby="fr-modal-title-modal-edit-employe-{{employeUuid}}" role="dialog" id="fr-modal-edit-employe-{{employeUuid}}" class="fr-modal fr-sidemodal">
+<dialog aria-labelledby="fr-modal-title-modal-edit-employe-{{employeUuid}}" id="fr-modal-edit-employe-{{employeUuid}}" class="fr-modal fr-sidemodal">
     <div class="fr-container fr-container--fluid fr-container-md">
         <div class="fr-grid-row fr-grid-row--center">
             <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
@@ -11,7 +11,7 @@
                         <p>Modifiez les informations en complétant les champs ci-dessous.</p>
 
                         <form action="{{ path('app_entreprise_view',{uuid:entreprise.uuid}) }}" method="POST" class="fr-my-5w">
-                            {{ form_row(formEditEmploye._token) }}
+                            {{ form_row(formEditEmploye._token, { 'id': 'employe_token_'~employeUuid }) }}
 
                             <input type="hidden" name="editEmploye" value="{{employeUuid}}">
 

--- a/templates/entreprise_view/modal-edit-entreprise.html.twig
+++ b/templates/entreprise_view/modal-edit-entreprise.html.twig
@@ -1,4 +1,4 @@
-<dialog aria-labelledby="fr-modal-title-modal-edit-entreprise" role="dialog" id="fr-modal-edit-entreprise" class="fr-modal fr-sidemodal">
+<dialog aria-labelledby="fr-modal-title-modal-edit-entreprise" id="fr-modal-edit-entreprise" class="fr-modal fr-sidemodal">
     <div class="fr-container fr-container--fluid fr-container-md">
         <div class="fr-grid-row fr-grid-row--center">
             <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">

--- a/templates/front/contact.html.twig
+++ b/templates/front/contact.html.twig
@@ -16,7 +16,7 @@
         <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--center fr-py-5w fr-py-md-10w">
             <h1 class="fr-col-11 fr-col-md-8">Contact</h1>
 
-            <section class="information-contact fr-col-11 fr-col-md-8">
+            <div class="information-contact fr-col-11 fr-col-md-8">
                 <p>
                     <span class="all-questions">
                         Le réseau des ADIL vous informe gratuitement sur toutes les problématiques logement et habitat.
@@ -28,7 +28,7 @@
                     <br>
                     <span class="local-phone-price">Prix d'un appel local</span>
                 </p>
-            </section>
+            </div>
 
             <p class="fr-col-11 fr-col-md-8 fr-h6 fr-mt-5w">
                 Une question ? Une précision ? N'hésitez pas à nous envoyer un message !

--- a/templates/front/index.html.twig
+++ b/templates/front/index.html.twig
@@ -137,23 +137,19 @@
                         Les punaises n'aiment pas le mouvement : elles viennent sur vous quand vous dormez
                         ou que vous restez longtemps immobiles au même endroit.
                     </p>
-                    <p>
-                        Par précaution, prenez l'habitude de :
-                        <br>
-                        <ul>
-                            <li>Si vous le pouvez, rester debout dans les transports</li>
-                            <li>Ne pas poser vos sacs par terre ni sur les sièges</li>
-                        </ul>
-                    </p>
-                    <p>
-                        En cas de doute, lorsque vous rentrez chez vous :
-                        <ul>
-                            <li>Retirez vos vêtements dans une pièce avec du carrelage</li>
-                            <li>Lavez-les en machine à 60°C pendant 1 heure</li>
-                            <li>OU placez-les au congélateur dans un sac fermé pendant 72 heures (3 jours)</li>
-                            <li>OU mettez-les au sèche linge à la plus haute température pendant au moins 30 minutes</li>
-                        </ul>
-                    </p>
+                    <p>Par précaution, prenez l'habitude de :</p>
+                    <ul>
+                        <li>Si vous le pouvez, rester debout dans les transports</li>
+                        <li>Ne pas poser vos sacs par terre ni sur les sièges</li>
+                    </ul>
+                    <br>
+                    <p>En cas de doute, lorsque vous rentrez chez vous :</p>
+                    <ul>
+                        <li>Retirez vos vêtements dans une pièce avec du carrelage</li>
+                        <li>Lavez-les en machine à 60°C pendant 1 heure</li>
+                        <li>OU placez-les au congélateur dans un sac fermé pendant 72 heures (3 jours)</li>
+                        <li>OU mettez-les au sèche linge à la plus haute température pendant au moins 30 minutes</li>
+                    </ul>
                 </div>
             </section>
 
@@ -180,18 +176,15 @@
                         <br>
                         Si vous êtes allocataire, la CAF peut dans certains cas vous aider. N'hésitez pas à contacter votre CAF.
                     </p>
-                    <p>
-                        Pour garantir les meilleures relations possibles avec votre bailleur, nous vous recommandons de suivre les étapes suivantes :
-                        <br>
-                        <ol>
-                            <li>Informez votre propriétaire de votre problème dès les premiers signes d’infestation et demandez-lui d’intervenir au plus vite</li>
-                            <li>
-                                Recommandez-lui de passer par le site stop-punaises.beta.gouv.fr pour accéder aux entreprises labellisées,
-                                ou proposez-lui de faire la démarche à sa place.
-                            </li>
-                            <li>Sélectionnez ensemble une société labellisée.</li>
-                        </ol>
-                    </p>
+                    <p>Pour garantir les meilleures relations possibles avec votre bailleur, nous vous recommandons de suivre les étapes suivantes :</p>
+                    <ol>
+                        <li>Informez votre propriétaire de votre problème dès les premiers signes d’infestation et demandez-lui d’intervenir au plus vite</li>
+                        <li>
+                            Recommandez-lui de passer par le site stop-punaises.beta.gouv.fr pour accéder aux entreprises labellisées,
+                            ou proposez-lui de faire la démarche à sa place.
+                        </li>
+                        <li>Sélectionnez ensemble une société labellisée.</li>
+                    </ol>
                 </div>
             </section>
 

--- a/templates/front/information.html.twig
+++ b/templates/front/information.html.twig
@@ -492,7 +492,7 @@
 
 
     <section class="information-contact fr-mt-3w fr-mt-md-5w fr-py-3w">
-        <h2>Vous n'avez pas trouvé la réponse à votre question ?</h1>
+        <h2>Vous n'avez pas trouvé la réponse à votre question ?</h2>
         <p>
             <span class="all-questions">
                 Le réseau des ADIL vous informe gratuitement sur toutes les problématiques logement et habitat.

--- a/templates/front/mentions-legales.html.twig
+++ b/templates/front/mentions-legales.html.twig
@@ -39,7 +39,7 @@
 
         <h2>3 – Définitions</h2>
 
-        <p>
+
             <ul>
                 <li>
                     « L’Utilisateur » est la personne habitant un logement privé ou public qui signale
@@ -71,7 +71,6 @@
                     « L’éditeur » est la startup d’Etat Histologe. 
                 </li>
             </ul>
-        </p>
 
         <h2>4 – Fonctionnalités</h2>
 
@@ -80,6 +79,7 @@
         <p>
             Chaque utilisateur peut signaler un problème lié à une infestation de punaises de lit.
             Il devra :
+        </p>
             <ul>
                 <li>
                     Détailler le problème vécu :
@@ -96,7 +96,6 @@
                     L’Utilisateur devra remplir un questionnaire permettant d’affiner la mesure de l’infestation en fournissant des précisions sur le logement et devra également renseigner des informations permettant de l’identifier et de le contacter.
                 </li>
             </ul>
-        </p>
 
         <h3>4.2 – Calcul du niveau d’infestation et transfert du signalement aux entreprises/partenaires concernés</h3>
 
@@ -191,8 +190,7 @@
 
         <h3 id="donnees-personnelles">6.2 – Données personnelles traitées</h3>
 
-        <p>
-            La présente Plateforme traite les données personnelles des utilisateurs suivantes :
+        <p>La présente Plateforme traite les données personnelles des utilisateurs suivantes :</p>
             <ul>
                 <li>
                     Données relatives au signalement du problème d’infestation (nom, prénom, adresse-email, 
@@ -210,7 +208,6 @@
                     Cookies nécessaires au fonctionnement de la plateforme.
                 </li>
             </ul>
-        </p>
 
         <h3>6.3 – Finalités des traitements</h3>
 
@@ -220,8 +217,7 @@
             d’étiquette énergie, permettra d’identifier plus facilement les possibilités de traitement disponibles. 
         </p>
 
-        <p>
-            Ses finalités visent à :
+        <p>Ses finalités visent à :</p>
             <ul>
                 <li>
                     signaler et suivre les problèmes liés à l’infestation de punaises de lit
@@ -238,7 +234,6 @@
                     d’infestation de punaises de lit rencontrés sur le territoire 
                 </li>
             </ul>
-        </p>
 
         <h3>6.4 – Bases juridiques des traitements de données</h3>
 
@@ -332,7 +327,7 @@
             il est rappelé à chaque utilisateur dont les données sont collectées dans le cadre de l’utilisation 
             ou de la connexion de Stop-Punaises, qu’il dispose des droits suivants concernant ses données 
             à caractère personnel :
-
+        </p>
             <ul>
                 <li>Droit d’information ;</li>
                 <li>Droit d’accès aux données ;</li>
@@ -342,7 +337,6 @@
 
             Vous pouvez exercer ces droits en écrivant 
             <strong>par mail</strong> à dpd.daj.sg@developpement-durable.gouv.fr 
-        </p>
 
         <p>
             En raison de l’obligation de sécurité et de confidentialité dans le traitement des données 
@@ -381,7 +375,7 @@
             Le responsable de traitement s’est assuré de la mise en œuvre par ses sous-traitants 
             de garanties adéquates et du respect de conditions strictes de confidentialité, d’usage 
             et de protection des données. 
-
+        </p>
             <table>
                 <thead>
                     <tr>
@@ -404,7 +398,6 @@
                     </tr>
                 </tbody>
             </table>
-        </p>
 
         <h3 id="cookies">6.10 – Cookies</h3>
 
@@ -421,7 +414,7 @@
             <br>
             Ces cookies permettent d’établir des mesures statistiques de fréquentation et 
             d’utilisation du site pouvant être utilisées à des fins de suivi et d’amélioration du service :
-
+        </p>
             <ul>
                 <li>Les données collectées ne sont pas recoupées avec d’autres traitements.</li>
                 <li>Le cookie déposé sert uniquement à la production de statistiques anonymes.</li>
@@ -429,7 +422,6 @@
             </ul>
 
             Les traceurs ont vocation à être conservés sur le poste informatique de l’Internaute pour une durée allant jusqu’à 13 mois. 
-        </p>
 
         <h2>7 – Mise à jour des conditions d'utilisation</h2>
 

--- a/templates/front/politique-de-confidentialite.html.twig
+++ b/templates/front/politique-de-confidentialite.html.twig
@@ -114,15 +114,16 @@
                 </ul>
                 <p>Pour les exercer, contactez-nous :
                     Email : <a href="mailto:dpd.daj.sg@developpement-durable.gouv.fr">dpd.daj.sg@developpement-durable.gouv.fr</a>
-                    <br><br></p>
-                <p><address>
+                    <br><br>
+                </p>
+                <address>
                     Ou par voie postale :<br><br>
                     Ministère de la Transition écologique et solidaire<br>
                     Direction Générale de l’Aménagement, du Logement et de la Nature<br>
                     Direction de l’habitat, de l’urbanisme et des paysages<br>
                     Pôle Habitat – Service Stop-Punaises<br>
                     1 place Carpeaux, 92800 Puteaux
-                    </address></p>
+                </address>
                 <p>Puisque ce sont des droits personnels, nous ne traiterons votre demande que si nous sommes en mesure
                     de vous identifier. Dans le cas où nous ne parvenons pas à vous identifier, nous pouvons être 
                     amenés à vous demander une preuve de votre identité.</p>

--- a/templates/front/signalement-type-list.html.twig
+++ b/templates/front/signalement-type-list.html.twig
@@ -29,7 +29,7 @@
 
             {% if feature_three_forms %}
             <div class="fr-col-12 fr-col-md-4 fr-mt-5w fr-mt-md-3v">
-                <div class="fr-tile fr-tile--sm fr-tile--horizontal fr-enlarge-link" id="tile-logement">
+                <div class="fr-tile fr-tile--sm fr-tile--horizontal fr-enlarge-link" id="tile-transport">
                     <div class="fr-tile__body">
                         <div class="fr-tile__content">
                             <h3 class="fr-tile__title fr-h6">
@@ -44,7 +44,7 @@
             </div>
 
             <div class="fr-col-12 fr-col-md-4 fr-mt-5w fr-mt-md-3v">
-                <div class="fr-tile fr-tile--sm fr-tile--horizontal fr-enlarge-link" id="tile-logement">
+                <div class="fr-tile fr-tile--sm fr-tile--horizontal fr-enlarge-link" id="tile-public">
                     <div class="fr-tile__body">
                         <div class="fr-tile__content">
                             <h3 class="fr-tile__title fr-h6">

--- a/templates/front_signalement/_partial_step_home.html.twig
+++ b/templates/front_signalement/_partial_step_home.html.twig
@@ -9,7 +9,7 @@
 
             <div class="fr-input-group">
                 <label class="fr-label" for="code-postal">Code postal</label>
-                <input class="fr-input" id="code-postal" name="code-postal" placeholder="Exemple : 69002" required type="numeric" maxlength=5 minlength=5>
+                <input class="fr-input" id="code-postal" name="code-postal" placeholder="Exemple : 69002" required type="text" maxlength=5 minlength=5>
                 <p class="fr-error-text fr-hidden">
                     Veuillez renseigner votre code postal.
                 </p>

--- a/templates/front_signalement/_partial_step_home.html.twig
+++ b/templates/front_signalement/_partial_step_home.html.twig
@@ -1,4 +1,4 @@
-<section id="step-home" class="step-item current-step">
+<div id="step-home" class="step-item current-step">
     <div class="fr-grid-row fr-grid-row--center">
         <div class="fr-col-12 fr-col-md-6">
             <h1 class="fr-h4">J'ai un problème de punaises de lit dans mon logement</h1>
@@ -26,4 +26,4 @@
             </div>
         </div>
     </div>
-</section>
+</div>

--- a/templates/front_signalement/_partial_step_insectes_larves_oeufs.html.twig
+++ b/templates/front_signalement/_partial_step_insectes_larves_oeufs.html.twig
@@ -5,7 +5,7 @@
         <div class="fr-stepper__steps" data-fr-current-step="5" data-fr-steps="8"></div>
     </div>
 
-    <dialog aria-labelledby="fr-modal-title-modal-oeufsetlarves" role="dialog" id="fr-modal-oeufsetlarves" class="fr-modal">
+    <dialog aria-labelledby="fr-modal-title-modal-oeufsetlarves" id="fr-modal-oeufsetlarves" class="fr-modal">
         <div class="fr-container fr-container--fluid fr-container-md">
             <div class="fr-grid-row fr-grid-row--center">
                 <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">

--- a/templates/front_signalement/_partial_step_insectes_punaises.html.twig
+++ b/templates/front_signalement/_partial_step_insectes_punaises.html.twig
@@ -5,7 +5,7 @@
         <div class="fr-stepper__steps" data-fr-current-step="6" data-fr-steps="8"></div>
     </div>
 
-    <dialog aria-labelledby="fr-modal-title-modal-punaises" role="dialog" id="fr-modal-punaises" class="fr-modal">
+    <dialog aria-labelledby="fr-modal-title-modal-punaises" id="fr-modal-punaises" class="fr-modal">
         <div class="fr-container fr-container--fluid fr-container-md">
             <div class="fr-grid-row fr-grid-row--center">
                 <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">

--- a/templates/front_signalement/_partial_step_traces_punaises_dejections.html.twig
+++ b/templates/front_signalement/_partial_step_traces_punaises_dejections.html.twig
@@ -5,7 +5,7 @@
         <div class="fr-stepper__steps" data-fr-current-step="4" data-fr-steps="8"></div>
     </div>
 
-    <dialog aria-labelledby="fr-modal-title-modal-dejections" role="dialog" id="fr-modal-dejections" class="fr-modal">
+    <dialog aria-labelledby="fr-modal-title-modal-dejections" id="fr-modal-dejections" class="fr-modal">
         <div class="fr-container fr-container--fluid fr-container-md">
             <div class="fr-grid-row fr-grid-row--center">
                 <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">

--- a/templates/front_signalement/_partial_step_traces_punaises_piqures.html.twig
+++ b/templates/front_signalement/_partial_step_traces_punaises_piqures.html.twig
@@ -5,7 +5,7 @@
         <div class="fr-stepper__steps" data-fr-current-step="3" data-fr-steps="8"></div>
     </div>
 
-    <dialog aria-labelledby="fr-modal-title-modal-piqures" role="dialog" id="fr-modal-piqures" class="fr-modal">
+    <dialog aria-labelledby="fr-modal-title-modal-piqures" id="fr-modal-piqures" class="fr-modal">
         <div class="fr-container fr-container--fluid fr-container-md">
             <div class="fr-grid-row fr-grid-row--center">
                 <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">

--- a/templates/front_signalement/base_step.html.twig
+++ b/templates/front_signalement/base_step.html.twig
@@ -1,7 +1,7 @@
-<section id="step-{{ step }}" class="step-item">
+<div id="step-{{ step }}" class="step-item">
     <div class="fr-grid-row fr-grid-row--center">
         <div class="fr-col-12 fr-col-md-6">
             {% block content %}{% endblock %}
         </div>
     </div>
-</section>
+</div>

--- a/templates/front_signalement_erp/index.html.twig
+++ b/templates/front_signalement_erp/index.html.twig
@@ -51,7 +51,7 @@
                 </div>
                 <div class="fr-form-group">
                     <div class="fr-input-group search-address">
-                        <label for="">Adresse de l'établissement</label>
+                        <label for="rechercheAdresse">Adresse de l'établissement</label>
                         <span class="fr-hint-text help-text">Tapez l'adresse puis selectionnez-la dans la liste</span>
                         <div class="fr-input-wrap fr-icon-map-pin-2-line">
                             <input id="rechercheAdresse" type="text" class="fr-input">

--- a/templates/front_suivi_usager/messages_thread.html.twig
+++ b/templates/front_suivi_usager/messages_thread.html.twig
@@ -28,7 +28,7 @@
                         <label for="message">Votre message</label>
                         <div class="fr-hint-text help-text">10 caractères minimum</div>
                         <textarea class="fr-input edit-zone" name="message" id="message" cols="10" rows="3" required minlength="10"></textarea>
-                        <input type="hidden" name="_token" value="{{ csrf_token('send_message') }}"/>
+                        <input type="hidden" name="_token" value="{{ csrf_token('send_message') }}">
                     </div>
                     <div class="fr-col-12 fr-text--center">
                         <button type="submit" class="fr-btn fr-rounded fr-btn--icon-left fr-icon-send-plane-fill"> Envoyer le

--- a/templates/front_suivi_usager/modal-choice-estimation.html.twig
+++ b/templates/front_suivi_usager/modal-choice-estimation.html.twig
@@ -1,4 +1,4 @@
-<dialog aria-labelledby="fr-modal-title-modal-choice-estimation-{{ intervention.id }}" role="dialog" id="fr-modal-choice-estimation-{{ intervention.id }}" class="fr-modal fr-sidemodal">
+<dialog aria-labelledby="fr-modal-title-modal-choice-estimation-{{ intervention.id }}" id="fr-modal-choice-estimation-{{ intervention.id }}" class="fr-modal fr-sidemodal">
     <div class="fr-container fr-container--fluid fr-container-md">
         <div class="fr-grid-row fr-grid-row--center">
             <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">

--- a/templates/front_suivi_usager/modal-close-signalement.html.twig
+++ b/templates/front_suivi_usager/modal-close-signalement.html.twig
@@ -1,4 +1,4 @@
-<dialog aria-labelledby="fr-modal-title-modal-close-signalement" role="dialog" id="fr-modal-close-signalement" class="fr-modal">
+<dialog aria-labelledby="fr-modal-title-modal-close-signalement" id="fr-modal-close-signalement" class="fr-modal">
     <div class="fr-container fr-container--fluid fr-container-md">
         <div class="fr-grid-row fr-grid-row--center">
             <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">

--- a/templates/front_suivi_usager/modal-empty-estimations.html.twig
+++ b/templates/front_suivi_usager/modal-empty-estimations.html.twig
@@ -1,4 +1,4 @@
-<dialog aria-labelledby="fr-modal-title-modal-empty-estimations" role="dialog" id="fr-modal-empty-estimations" class="fr-modal fr-sidemodal">
+<dialog aria-labelledby="fr-modal-title-modal-empty-estimations" id="fr-modal-empty-estimations" class="fr-modal fr-sidemodal">
     <div class="fr-container fr-container--fluid fr-container-md">
         <div class="fr-grid-row fr-grid-row--center">
             <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">

--- a/templates/front_suivi_usager/modal-estimation-accepted.html.twig
+++ b/templates/front_suivi_usager/modal-estimation-accepted.html.twig
@@ -1,4 +1,4 @@
-<dialog aria-labelledby="fr-modal-title-modal-estimation-accepted-{{ intervention_accepted_by_usager.id }}" role="dialog" id="fr-modal-estimation-accepted-{{ intervention_accepted_by_usager.id }}" class="fr-modal fr-sidemodal">
+<dialog aria-labelledby="fr-modal-title-modal-estimation-accepted-{{ intervention_accepted_by_usager.id }}" id="fr-modal-estimation-accepted-{{ intervention_accepted_by_usager.id }}" class="fr-modal fr-sidemodal">
     <div class="fr-container fr-container--fluid fr-container-md">
         <div class="fr-grid-row fr-grid-row--center">
             <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">

--- a/templates/front_suivi_usager/modal-probleme-resolu-pro.html.twig
+++ b/templates/front_suivi_usager/modal-probleme-resolu-pro.html.twig
@@ -1,4 +1,4 @@
-<dialog aria-labelledby="fr-modal-title-modal-probleme-resolu-pro" role="dialog" id="fr-modal-probleme-resolu-pro" class="fr-modal">
+<dialog aria-labelledby="fr-modal-title-modal-probleme-resolu-pro" id="fr-modal-probleme-resolu-pro" class="fr-modal">
     <div class="fr-container fr-container--fluid fr-container-md">
         <div class="fr-grid-row fr-grid-row--center">
             <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">

--- a/templates/front_suivi_usager/modal-probleme-resolu.html.twig
+++ b/templates/front_suivi_usager/modal-probleme-resolu.html.twig
@@ -1,4 +1,4 @@
-<dialog aria-labelledby="fr-modal-title-modal-probleme-resolu" role="dialog" id="fr-modal-probleme-resolu" class="fr-modal">
+<dialog aria-labelledby="fr-modal-title-modal-probleme-resolu" id="fr-modal-probleme-resolu" class="fr-modal">
     <div class="fr-container fr-container--fluid fr-container-md">
         <div class="fr-grid-row fr-grid-row--center">
             <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">

--- a/templates/front_suivi_usager/modal-toujours-punaises-pro.html.twig
+++ b/templates/front_suivi_usager/modal-toujours-punaises-pro.html.twig
@@ -1,4 +1,4 @@
-<dialog aria-labelledby="fr-modal-title-modal-toujours-punaises-pro" role="dialog" id="fr-modal-toujours-punaises-pro" class="fr-modal">
+<dialog aria-labelledby="fr-modal-title-modal-toujours-punaises-pro" id="fr-modal-toujours-punaises-pro" class="fr-modal">
     <div class="fr-container fr-container--fluid fr-container-md">
         <div class="fr-grid-row fr-grid-row--center">
             <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">

--- a/templates/front_suivi_usager/modal-toujours-punaises.html.twig
+++ b/templates/front_suivi_usager/modal-toujours-punaises.html.twig
@@ -1,4 +1,4 @@
-<dialog aria-labelledby="fr-modal-title-modal-toujours-punaises" role="dialog" id="fr-modal-toujours-punaises" class="fr-modal">
+<dialog aria-labelledby="fr-modal-title-modal-toujours-punaises" id="fr-modal-toujours-punaises" class="fr-modal">
     <div class="fr-container fr-container--fluid fr-container-md">
         <div class="fr-grid-row fr-grid-row--center">
             <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">

--- a/templates/signalement_list/modal-signalement-erp-transports.html.twig
+++ b/templates/signalement_list/modal-signalement-erp-transports.html.twig
@@ -1,4 +1,4 @@
-<dialog aria-labelledby="fr-modal-title-modal-signalement-erp-transports-{{signalement.uuid}}" role="dialog" id="fr-modal-signalement-erp-transports-{{signalement.uuid}}" class="fr-modal fr-sidemodal">
+<dialog aria-labelledby="fr-modal-title-modal-signalement-erp-transports-{{signalement.uuid}}" id="fr-modal-signalement-erp-transports-{{signalement.uuid}}" class="fr-modal fr-sidemodal">
     <div class="fr-container fr-container--fluid fr-container-md">
         <div class="fr-grid-row fr-grid-row--center">
             <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">

--- a/templates/signalement_list/modal-signalement-hors-perimetre.html.twig
+++ b/templates/signalement_list/modal-signalement-hors-perimetre.html.twig
@@ -1,4 +1,4 @@
-<dialog aria-labelledby="fr-modal-title-modal-signalement-hors-perimetre-{{signalement.uuid}}" role="dialog" id="fr-modal-signalement-hors-perimetre-{{signalement.uuid}}" class="fr-modal fr-sidemodal">
+<dialog aria-labelledby="fr-modal-title-modal-signalement-hors-perimetre-{{signalement.uuid}}" id="fr-modal-signalement-hors-perimetre-{{signalement.uuid}}" class="fr-modal fr-sidemodal">
     <div class="fr-container fr-container--fluid fr-container-md">
         <div class="fr-grid-row fr-grid-row--center">
             <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">

--- a/templates/signalement_view/historique.html.twig
+++ b/templates/signalement_view/historique.html.twig
@@ -13,7 +13,7 @@
                 {% include "common/components/niveau-infestation.html.twig" %}
                 <span class="date-info">entregistré le <strong>{{ signalement.createdAt.format('d/m/Y') }}</strong></span>
                 {% if signalement.dateIntervention %}
-                    <span class="date-info">intervention le <strong>{{ signalement.dateIntervention.format('d/m/Y') }}<strong></span>
+                    <span class="date-info">intervention le <strong>{{ signalement.dateIntervention.format('d/m/Y') }}</strong></span>
                 {% endif %}
             </div>
         </div>

--- a/templates/signalement_view/modal-refuse-signalement.html.twig
+++ b/templates/signalement_view/modal-refuse-signalement.html.twig
@@ -1,4 +1,4 @@
-<dialog aria-labelledby="fr-modal-title-modal-refuse-signalement" role="dialog" id="fr-modal-refuse-signalement" class="fr-modal fr-sidemodal">
+<dialog aria-labelledby="fr-modal-title-modal-refuse-signalement" id="fr-modal-refuse-signalement" class="fr-modal fr-sidemodal">
     <div class="fr-container fr-container--fluid fr-container-md">
         <div class="fr-grid-row fr-grid-row--center">
             <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">

--- a/templates/signalement_view/modal-send-estimation.html.twig
+++ b/templates/signalement_view/modal-send-estimation.html.twig
@@ -1,4 +1,4 @@
-<dialog aria-labelledby="fr-modal-title-modal-send-estimation" role="dialog" id="fr-modal-send-estimation" class="fr-modal fr-sidemodal">
+<dialog aria-labelledby="fr-modal-title-modal-send-estimation" id="fr-modal-send-estimation" class="fr-modal fr-sidemodal">
     <div class="fr-container fr-container--fluid fr-container-md">
         <div class="fr-grid-row fr-grid-row--center">
             <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">

--- a/templates/signalement_view/modal-view-estimation.html.twig
+++ b/templates/signalement_view/modal-view-estimation.html.twig
@@ -1,4 +1,4 @@
-<dialog aria-labelledby="fr-modal-title-modal-view-estimation-{{ intervention.id }}" role="dialog" id="fr-modal-view-estimation-{{ intervention.id }}" class="fr-modal fr-sidemodal">
+<dialog aria-labelledby="fr-modal-title-modal-view-estimation-{{ intervention.id }}" id="fr-modal-view-estimation-{{ intervention.id }}" class="fr-modal fr-sidemodal">
     <div class="fr-container fr-container--fluid fr-container-md">
         <div class="fr-grid-row fr-grid-row--center">
             <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">

--- a/templates/signalement_view/tab-messages.html.twig
+++ b/templates/signalement_view/tab-messages.html.twig
@@ -30,7 +30,7 @@
                         <label for="message">Votre message</label>
                         <div class="fr-hint-text help-text">10 caractères minimum</div>
                         <textarea class="fr-input edit-zone" name="message" id="message" cols="10" rows="3" required minlength="10"></textarea>
-                        <input type="hidden" name="_token" value="{{ csrf_token('send_message') }}"/>
+                        <input type="hidden" name="_token" value="{{ csrf_token('send_message') }}">
                     </div>
                     <div class="fr-col-12 fr-text--center">
                         <button type="submit" class="fr-btn fr-rounded fr-btn--icon-left fr-icon-send-plane-fill"> Envoyer le


### PR DESCRIPTION
## Ticket

#493 

## Description
Modifications HTML pour corriger les erreurs indiqué par l'outil https://validator.w3.org/nu/
Exemples : 
* L'élément `<p>` ne peux pas contenir l'élément `<ul>`
* Un input de type `hidden` ne peux pas contenir d'attribut `pattern`
* L'attribut `label for` ne peux pas pointer sur un élément non visible
* les attributs `id` doivent être unique
* L'attribut `role` avec la valeur `dialog` n'st pas permis sur un élément `dialog`
* ....

## Tests
- [ ] Tester le code source des différentes page sur l'outil https://validator.w3.org/nu/ et vérifier qu'il n'y à plus d'erreur (quelques warnings persistes)
