### PR TITLE
[Front - Formulaire] Ajout d'un message d'erreur quand le code postal n'est pas renseigné

### DIFF
--- a/assets/controllers/form_signalement_front.js
+++ b/assets/controllers/form_signalement_front.js
@@ -88,10 +88,6 @@ class PunaisesFrontSignalementController {
     $('.link-back-back').on('click', function(){
       self.refreshStep(-2);
     });
-    if (self.checkCodePostal('code-postal')) {
-      $('#code-postal').val($('form.front-signalement').data('code-postal'));
-      $('#step-home button').click();
-    }
   }
 
   async fetchTerritoireOpened() {
@@ -109,8 +105,10 @@ class PunaisesFrontSignalementController {
         return false;
       }
     } else {
+      $('input#' + idInput).siblings('.fr-error-text').removeClass('fr-hidden');
       return false;
     }
+    $('input#' + idInput).siblings('.fr-error-text').addClass('fr-hidden');
     return true;
 
   }


### PR DESCRIPTION
## Ticket

#504   

## Description
Ajout d'un message d'erreur dans le formulaire front quand le code postal n'est pas renseigné

## Tests
- [ ] Faire un signalement mais ne pas remplir le code postal : un message d'erreur s'affiche
- [ ] Changer pour un code postal non-réel : un message d'erreur s'affiche
- [ ] Changer pour un code postal réel : on passe à l'écran suivant
- [ ] On revient en arrière, le message d'erreur a disparu
