### PR TITLE
[Ouverture] Ouverture nouveaux territoires et gestion ajout territoire intervention pour compte deja existant

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ load-migrations: ## Play migrations
 	@$(DOCKER_COMP) exec stopunaises_phpfpm sh -c "$(SYMFONY) --env=dev doctrine:migrations:migrate --no-interaction"
 
 execute-migration: ## Execute migration: make execute-migration name=Version20231117204437 direction=up
-	@$(DOCKER_COMP) exec stopunaises_phpfpm sh -c "$(SYMFONY) --env=dev doctrine:migrations:execute DoctrineMigrations\\\$(name) --$(direction)"
+	@$(DOCKER_COMP) exec stopunaises_phpfpm sh -c "$(SYMFONY) --env=dev doctrine:migrations:execute DoctrineMigrations\\\$(name) --$(direction) --no-interaction"
 
 load-fixtures: ## Load database from fixtures
 	@$(DOCKER_COMP) exec stopunaises_phpfpm sh -c "$(SYMFONY) --env=dev doctrine:fixtures:load --no-interaction"

--- a/migrations/Version20231117204437.php
+++ b/migrations/Version20231117204437.php
@@ -29,6 +29,9 @@ final class Version20231117204437 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
+        $territoires = $this->connection->fetchAssociative('SELECT * FROM territoire');
+        $this->skipIf(!$territoires, 'Territoire table does not exist yet, please execute migration manually');
+
         foreach (self::TERRITOIRES as $zipCode) {
             $this->addSql('UPDATE territoire SET active = 1 WHERE zip = :zip', ['zip' => $zipCode]);
         }

--- a/migrations/Version20231124140038.php
+++ b/migrations/Version20231124140038.php
@@ -20,6 +20,9 @@ final class Version20231124140038 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
+        $territoires = $this->connection->fetchAssociative('SELECT * FROM territoire');
+        $this->skipIf(!$territoires, 'Territoire table does not exist yet, please execute migration manually');
+
         foreach (self::TERRITOIRES as $zipCode) {
             $this->addSql('UPDATE territoire SET active = 1 WHERE zip = :zip', ['zip' => $zipCode]);
         }

--- a/migrations/Version20231213081418.php
+++ b/migrations/Version20231213081418.php
@@ -29,6 +29,9 @@ final class Version20231213081418 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
+        $territoires = $this->connection->fetchAssociative('SELECT * FROM territoire');
+        $this->skipIf(!$territoires, 'Territoire table does not exist yet, please execute migration manually');
+
         foreach (self::TERRITOIRES as $zipCode) {
             $this->addSql('UPDATE territoire SET active = 1 WHERE zip = :zip', ['zip' => $zipCode]);
         }

--- a/migrations/Version20231213081418.php
+++ b/migrations/Version20231213081418.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20231213081418 extends AbstractMigration
+{
+    private const TERRITOIRES = [
+        '03', '05', '10', '11',
+        '14', '15', '16', '22',
+        '25', '26', '27', '30',
+        '32', '36', '39', '41',
+        '53', '56', '57', '61',
+        '65', '68', '74', '76',
+        '77', '78', '79', '80',
+        '82', '83', '85', '86',
+        '88', '90', '91', '94',
+        '95',
+    ];
+
+    public function getDescription(): string
+    {
+        return 'Open new territories';
+    }
+
+    public function up(Schema $schema): void
+    {
+        foreach (self::TERRITOIRES as $zipCode) {
+            $this->addSql('UPDATE territoire SET active = 1 WHERE zip = :zip', ['zip' => $zipCode]);
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        foreach (self::TERRITOIRES as $zipCode) {
+            $this->addSql('UPDATE territoire SET active = 0 WHERE zip = :zip', ['zip' => $zipCode]);
+        }
+    }
+}

--- a/src/Service/Import/CompteUtilisateur/CompteUtilisateurLoader.php
+++ b/src/Service/Import/CompteUtilisateur/CompteUtilisateurLoader.php
@@ -2,8 +2,10 @@
 
 namespace App\Service\Import\CompteUtilisateur;
 
+use App\Entity\User;
 use App\Factory\EntrepriseFactory;
 use App\Manager\EntrepriseManager;
+use App\Manager\UserManager;
 use App\Repository\EntrepriseRepository;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Helper\ProgressBar;
@@ -14,11 +16,15 @@ class CompteUtilisateurLoader
 {
     private const FLUSH_COUNT = 250;
     public const METADATA_NB_USERS_CREATED = 'nb_users_created';
+    public const METADATA_NB_USERS_UPDATED = 'nb_users_updated';
+    public const METADATA_NB_USERS_EXISTS = 'nb_users_exists';
     public const METADATA_ERRORS = 'errors';
     public const METADATA_ENTREPRISE_ACCOUNT_TO_CREATE = 'account_exists';
 
     private array $metadata = [
         self::METADATA_NB_USERS_CREATED => 0,
+        self::METADATA_NB_USERS_UPDATED => 0,
+        self::METADATA_NB_USERS_EXISTS => 0,
         self::METADATA_ERRORS => null,
         self::METADATA_ENTREPRISE_ACCOUNT_TO_CREATE => null,
     ];
@@ -30,6 +36,7 @@ class CompteUtilisateurLoader
         private EntrepriseRepository $entrepriseRepository,
         private ValidatorInterface $validator,
         private LoggerInterface $logger,
+        private UserManager $userManager,
     ) {
     }
 
@@ -41,7 +48,7 @@ class CompteUtilisateurLoader
         }
 
         $countEntreprise = 0;
-        $lineNumber = 2;
+        $lineNumber = 1;
         foreach ($data as $item) {
             $dataMapped = $this->compteUtilisateurMapper->map($headers, $item);
             if (!empty($dataMapped)) {
@@ -51,6 +58,27 @@ class CompteUtilisateurLoader
                 }
 
                 $entreprise = $this->entrepriseFactory->createFromArray($dataMapped);
+                /** @var User $user */
+                $user = $this->userManager->findOneBy(['email' => $entreprise->getEmail()]);
+                $updatedWithNewTerritory = false;
+                if (null !== $user) {
+                    foreach ($entreprise->getTerritoires() as $territoire) {
+                        $updatedWithNewTerritory = false;
+                        if (!$user->getEntreprise()->getTerritoires()->contains($territoire)) {
+                            $user->getEntreprise()->addTerritoire($territoire);
+                            $this->userManager->persist($user);
+                            $updatedWithNewTerritory = true;
+                        }
+                    }
+                    if ($updatedWithNewTerritory) {
+                        ++$this->metadata[self::METADATA_NB_USERS_UPDATED];
+                    } else {
+                        ++$this->metadata[self::METADATA_NB_USERS_EXISTS];
+                    }
+                    $this->userManager->flush();
+                    continue;
+                }
+
                 $errors = $this->validator->validate($entreprise);
 
                 if (null !== $entreprise && 0 === $errors->count()) {
@@ -63,7 +91,11 @@ class CompteUtilisateurLoader
                         $this->entrepriseManager->flush();
                     }
                 } elseif ($errors->count() > 0) {
-                    $this->metadata[self::METADATA_ERRORS][] = sprintf('line %d : %s', $lineNumber, (string) $errors);
+                    $this->metadata[self::METADATA_ERRORS][] = sprintf(
+                        'line %d : %s - %s',
+                        $lineNumber,
+                        (string) $errors,
+                        $entreprise->getEmail());
                 }
             }
             ++$lineNumber;

--- a/tests/Functionnal/Service/Import/CompteUtilisateur/CompteUtilisateurLoaderTest.php
+++ b/tests/Functionnal/Service/Import/CompteUtilisateur/CompteUtilisateurLoaderTest.php
@@ -5,6 +5,7 @@ namespace App\Tests\Functionnal\Service\Import\CompteUtilisateur;
 use App\Entity\Entreprise;
 use App\Factory\EntrepriseFactory;
 use App\Manager\EntrepriseManager;
+use App\Manager\UserManager;
 use App\Repository\EntrepriseRepository;
 use App\Service\Import\CompteUtilisateur\CompteUtilisateurLoader;
 use App\Service\Import\CompteUtilisateur\CompteUtilisateurMapper;
@@ -21,6 +22,7 @@ class CompteUtilisateurLoaderTest extends KernelTestCase
     private EntrepriseRepository $entrepriseRepository;
     private LoggerInterface $logger;
     private ValidatorInterface $validator;
+    private UserManager $userManager;
 
     protected function setUp(): void
     {
@@ -31,6 +33,7 @@ class CompteUtilisateurLoaderTest extends KernelTestCase
         $this->entrepriseRepository = self::getContainer()->get(EntrepriseRepository::class);
         $this->logger = self::getContainer()->get(LoggerInterface::class);
         $this->validator = self::getContainer()->get(ValidatorInterface::class);
+        $this->userManager = self::getContainer()->get(UserManager::class);
     }
 
     public function testLoad(): void
@@ -42,6 +45,7 @@ class CompteUtilisateurLoaderTest extends KernelTestCase
             $this->entrepriseRepository,
             $this->validator,
             $this->logger,
+            $this->userManager,
         );
 
         $compteUtilisateurLoader->load($this->getData(), [
@@ -55,6 +59,7 @@ class CompteUtilisateurLoaderTest extends KernelTestCase
 
         $metadata = $compteUtilisateurLoader->getMetadata();
         $this->assertEquals(20, $metadata['nb_users_created']);
+        $this->assertEquals(0, $metadata['nb_users_updated']);
         $this->assertNull($metadata['errors']);
         $this->assertContainsOnlyInstancesOf(Entreprise::class, $metadata['account_exists']);
     }


### PR DESCRIPTION
## Ticket

#519    

## Description
Dans le cadre du déploiement nationale, de nouveaux territoires doivent être ouvert et de nouveaux compte entreprises doivent être ajouté ou **mise à jour si nouveaux territoire** sur la plateforme

Les nouveaux territoires
03, 05, 10, 11, 14, 15, 16, 22, 25, 26, 27, 30, 32, 36, 39, 41, 53, 56, 57, 61, 65, 68, 74, 76, 77, 78, 79, 80, 82, 83, 85, 86, 88, 90, 91, 94, 95

## Changements apportés
* Mise à jour de la commande d'import de compte entreprise
* Ajout d'une migration pour l'ouverture de nouveaux territoires

## Pré-requis
Le nouveau CSV est deja sur staging `entreprises-utilisateurs-1.csv`

Vider la base de donnée et exécution de la nouvelle migration
```bash
make create-db
```
Une fois la table territoire crée, exécutez cette migration
```
make execute-migration name=Version20231213081418 direction=down
make execute-migration name=Version20231213081418 direction=up
```
## Tests
- [ ] Importer les comptes du premier déploiement  `entreprises-utilisateurs.csv`
```bash
 make console app="import-compte-utilisateur"` 
 ```
- [ ] Importer les comptes du nouveau déploiement `entreprises-utilisateurs-1.csv`
```bash
 make console app="import-compte-utilisateur --file-version=1"` 
 ```
![image](https://github.com/MTES-MCT/stop-punaises/assets/5757116/b18d65f2-f233-427a-97c3-e20447e6f1de)
79 + 46 + 2 = 127 ligne csv

- [ ] Exécuter une seconde fois la commande du nouveau déploiement afin de vérifier qu'il n'est pas possible d'ajouter des doublons de compte
- [ ] Déposer un signalement sur un nouveau territoire le 30 par exemple :-)

```bash
 make console app="import-compte-utilisateur --file-version=1"` 
 ```
