### PR TITLE
[FO - Signalement] Modification lien plus d'informations

### DIFF
--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -905,15 +905,8 @@ span.image-caption {
             }
 
             a.info {
-                display: inline-block;
-                width: 20px;
-                height: 20px;
-                line-height: 20px;
-                border-radius: 10px;
-                font-size: 11px;
-                text-align: center;
+                font-size: 0.8em;
                 color: var(--blue-france-sun-113-625);
-                border: 1px solid var(--blue-france-sun-113-625);
             }
         }
     }

--- a/templates/common/components/signalement-detail-evenements.html.twig
+++ b/templates/common/components/signalement-detail-evenements.html.twig
@@ -18,7 +18,7 @@
                 {% set modalToOpen = event.actionLink[12:] %}
             {% endif %}
             <div class="event-item-action fr-mt-3v">
-                <a href="#" class="info" data-fr-opened="{% if modalToOpen is same as 'probleme-resolu' or modalToOpen is same as 'probleme-resolu-pro' %}true{% else %}false{% endif %}" aria-controls="fr-modal-{{ modalToOpen }}">{{ event.actionLabel }}</a>
+                <a href="#" data-fr-opened="{% if modalToOpen is same as 'probleme-resolu' or modalToOpen is same as 'probleme-resolu-pro' %}true{% else %}false{% endif %}" aria-controls="fr-modal-{{ modalToOpen }}">{{ event.actionLabel }}</a>
             </div>
         {% elseif event.actionLink is defined and event.actionLink is not null %}
             {% if 'link-send-message' == event.actionLink %}

--- a/templates/front_signalement/_partial_step_insectes_larves_oeufs.html.twig
+++ b/templates/front_signalement/_partial_step_insectes_larves_oeufs.html.twig
@@ -45,8 +45,12 @@
     
     <div class="fr-form-group">
         <div class="fr-select-group">
-            <label class="fr-label required">J'ai trouvé des <span class="underline">oeufs et larves</span> <a href="#" class="info" data-fr-opened="false" aria-controls="fr-modal-oeufsetlarves">i</a></label>
-            <div id="signalement_front_oeufsEtLarvesTrouves" class="fr-radio">
+            <label class="fr-label required">
+                J'ai trouvé des <span class="underline">oeufs et larves</span>
+                <br>
+                <a href="#" class="info" data-fr-opened="false" aria-controls="fr-modal-oeufsetlarves">Plus d'informations</a>
+            </label>
+            <div id="signalement_front_oeufsEtLarvesTrouves" class="fr-radio fr-mt-3v">
                 <input type="radio" id="signalement_front_oeufsEtLarvesTrouves_0" name="signalement_front[oeufsEtLarvesTrouves]" required="required" value="true">
                 <label for="signalement_front_oeufsEtLarvesTrouves_0" class="required">Oui</label>
                 <input type="radio" id="signalement_front_oeufsEtLarvesTrouves_1" name="signalement_front[oeufsEtLarvesTrouves]" required="required" value="false">

--- a/templates/front_signalement/_partial_step_insectes_punaises.html.twig
+++ b/templates/front_signalement/_partial_step_insectes_punaises.html.twig
@@ -45,8 +45,12 @@
 
     <div class="fr-form-group">
         <div class="fr-select-group">
-            <label class="fr-label required">Il y a des punaises dans mon logement <a href="#" class="info" data-fr-opened="false" aria-controls="fr-modal-punaises">i</a></label>
-            <div id="signalement_front_punaisesTrouvees" class="fr-radio">
+            <label class="fr-label required">
+                Il y a des punaises dans mon logement
+                <br>
+                <a href="#" class="info" data-fr-opened="false" aria-controls="fr-modal-punaises">Plus d'informations</a>
+            </label>
+            <div id="signalement_front_punaisesTrouvees" class="fr-radio fr-mt-3v">
                 <input type="radio" id="signalement_front_punaisesTrouvees_0" name="signalement_front[punaisesTrouvees]" required="required" value="true">
                 <label for="signalement_front_punaisesTrouvees_0" class="required">Oui</label>
                 <input type="radio" id="signalement_front_punaisesTrouvees_1" name="signalement_front[punaisesTrouvees]" required="required" value="false">

--- a/templates/front_signalement/_partial_step_traces_punaises_dejections.html.twig
+++ b/templates/front_signalement/_partial_step_traces_punaises_dejections.html.twig
@@ -46,8 +46,12 @@
 
     <div class="fr-form-group">
         <div class="fr-select-group">
-            <label class="fr-label required">J'ai trouvé des <span class="underline">déjections</span> de punaises <a href="#" class="info" data-fr-opened="false" aria-controls="fr-modal-dejections">i</a></label>
-            <div id="signalement_front_dejectionsTrouvees" class="fr-radio">
+            <label class="fr-label required">
+                J'ai trouvé des <span class="underline">déjections</span> de punaises
+                <br>
+                <a href="#" class="info" data-fr-opened="false" aria-controls="fr-modal-dejections">Plus d'informations</a>
+            </label>
+            <div id="signalement_front_dejectionsTrouvees" class="fr-radio fr-mt-3v">
                 <input type="radio" id="signalement_front_dejectionsTrouvees_0" name="signalement_front[dejectionsTrouvees]" required="required" value="true">
                 <label for="signalement_front_dejectionsTrouvees_0" class="required">Oui</label>
                 <input type="radio" id="signalement_front_dejectionsTrouvees_1" name="signalement_front[dejectionsTrouvees]" required="required" value="false">

--- a/templates/front_signalement/_partial_step_traces_punaises_piqures.html.twig
+++ b/templates/front_signalement/_partial_step_traces_punaises_piqures.html.twig
@@ -47,11 +47,17 @@
 
     <div class="fr-form-group">
         <div class="fr-select-group">
-            <label class="fr-label required">J'ai des <span class="underline">piqûres</span> de punaises de lit <a href="#" class="info" data-fr-opened="false" aria-controls="fr-modal-piqures">i</a></label>
-            {{ form_widget(form.piquresExistantes) }}
-            <p class="fr-error-text fr-hidden">
-                Veuillez renseigner si vous avez des piqûres de punaises de lit.
-            </p>
+            <label class="fr-label required">
+                J'ai des <span class="underline">piqûres</span> de punaises de lit
+                <br>
+                <a href="#" class="info" data-fr-opened="false" aria-controls="fr-modal-piqures">Plus d'informations</a>
+            </label>
+            <div class="fr-mt-3v">
+                {{ form_widget(form.piquresExistantes) }}
+                <p class="fr-error-text fr-hidden">
+                    Veuillez renseigner si vous avez des piqûres de punaises de lit.
+                </p>
+            </div>
         </div>
     </div>
 


### PR DESCRIPTION
## Ticket

#503    

## Description
Sur Firefox, quand on passait en `Zoom Text Only`, le `i` qui affiche la modale "plus d'informations" s'affichait mal.
Avec le recul, en terme d'accessibilité, ça ne semblait de toute façon pas le plus évident des liens.
J'ai vu avec Mathilde pour remplacer par un lien `Plus d'informations` complet. 

## Tests
- [ ] Parcourir le formulaire de signalement et cliquer sur les liens `Plus d'informations`
