### PR TITLE
[Accessibilité] Implémenter le quick-fix sur le contraste élevé

### DIFF
--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -1020,3 +1020,24 @@ span.image-caption {
         color: var(--blue-france-sun-113-625);
     }
 }
+
+// improve readability in Windows High Contrast Mode
+@media screen and (forced-colors: active) {
+    .fr-input,
+    .fr-select,
+    .fr-btn {
+      border: 2px solid var(--border-action-high-grey);
+    }
+  
+    .fr-radio-group input[type="radio"] {
+      opacity: 1;
+    }
+  
+    .fr-tabs__tab[aria-selected=true]:not(:disabled) {
+      border: 5px solid var(--border-action-high-grey);
+    }
+  
+    .fr-tabs__tab {
+      border: 2px solid var(--border-action-high-grey);
+    }
+  }

--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -1037,7 +1037,36 @@ span.image-caption {
       border: 5px solid var(--border-action-high-grey);
     }
   
-    .fr-tabs__tab {
+    .fr-tabs__tab, .fr-modal__body {
       border: 2px solid var(--border-action-high-grey);
     }
+
+    .fr-header{
+        border-bottom: 2px solid var(--border-action-high-grey);
+    }
+
+    .fr-footer {
+        border-top: 2px solid var(--border-action-high-grey);
+    }
+    .fr-footer__bottom-list{
+        border-top: 1px solid var(--border-action-high-grey);
+    }
+
+    .fr-accordion{
+        border-bottom: 1px solid var(--border-action-high-grey);
+    }
+
+    .fr-alert, 
+    .fr-card,
+    .fr-tile,
+    .fiche-signalement .fr-tabs__panel .edit-zone,
+    .fr-checkbox-group input[type="checkbox"] + label::before{
+        border: 1px solid var(--border-action-high-grey);
+    }
+
+    .fr-input::placeholder {
+        font-weight: 300;
+    }
+
+
   }


### PR DESCRIPTION
## Ticket

#507 

## Description
Amélioration de l'affichage de pages lors de la navigation en mode contraste élevé de Windows

## Changements apportés
* Ajout du quick fix et autres règles CSS

## Tests
- [ ] Passer Windows en thème contrasté et vérifier l'affichage des différentes pages

## Aperçu avant/après
![Capture_prefix](https://github.com/MTES-MCT/stop-punaises/assets/7130780/53bed730-b4ab-4764-84d4-d435addb27b1)
![Capture_postfix](https://github.com/MTES-MCT/stop-punaises/assets/7130780/b39467d0-38b0-43ab-9218-be28c587e0c9)

