### PR TITLE
[Accessibilité] Mettre le poids des pdf à télécharger

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -13,6 +13,9 @@ parameters:
     doc_autotraitement: 'pdf/stop-punaises-protocole-auto-traitement.pdf'
     doc_domicile: 'pdf/stop-punaises-preparer-son-domicile.pdf'
     doc_conseil: 'pdf/stop-punaises-eviter-punaises-de-lit.pdf'
+    doc_autotraitement_size: 1040399
+    doc_domicile_size: 1135206
+    doc_conseil_size: 1286256
     admin_email: '%env(resolve:CONTACT_EMAIL)%'
     inconnu_email: '%env(resolve:INCONNU_EMAIL)%'
     feature_three_forms: '%env(bool:FEATURE_THREE_FORMS_ENABLE)%'

--- a/src/Command/InitSignalementEventsCommand.php
+++ b/src/Command/InitSignalementEventsCommand.php
@@ -80,6 +80,7 @@ class InitSignalementEventsCommand extends Command
             new SignalementAddedEvent(
                 $signalement,
                 $this->parameterBag->get('base_url').'/build/'.$this->parameterBag->get('doc_autotraitement'),
+                $this->parameterBag->get('doc_autotraitement_size'),
                 $signalement->getCreatedAt(),
             ),
             SignalementAddedEvent::NAME

--- a/src/Controller/Front/SignalementController.php
+++ b/src/Controller/Front/SignalementController.php
@@ -113,7 +113,8 @@ class SignalementController extends AbstractController
             $eventDispatcher->dispatch(
                 new SignalementAddedEvent(
                     $signalement,
-                    $this->getParameter('base_url').'/build/'.$this->getParameter('doc_autotraitement')
+                    $this->getParameter('base_url').'/build/'.$this->getParameter('doc_autotraitement'),
+                    $this->getParameter('doc_autotraitement_size')
                 ),
                 SignalementAddedEvent::NAME
             );

--- a/src/Controller/Front/SuiviUsagerViewController.php
+++ b/src/Controller/Front/SuiviUsagerViewController.php
@@ -57,10 +57,9 @@ class SuiviUsagerViewController extends AbstractController
         }
 
         $docFile = $signalement->isAutotraitement() ? $this->getParameter('doc_autotraitement') : $this->getParameter('doc_domicile');
+        $docSize = 0;
         if (file_exists('./build/'.$docFile)) {
             $docSize = filesize('./build/'.$docFile);
-        } else {
-            $docSize = 0;
         }
 
         return $this->render('front_suivi_usager/index.html.twig', [
@@ -85,7 +84,7 @@ class SuiviUsagerViewController extends AbstractController
         EventDispatcherInterface $eventDispatcher,
         MailerProvider $mailerProvider,
         EntrepriseRepository $entrepriseRepository,
-        ): Response {
+    ): Response {
         if ($this->isCsrfTokenValid('signalement_switch_pro', $request->get('_csrf_token'))) {
             $this->addFlash('success', 'Votre signalement est transféré ! Les entreprises vont vous contacter au plus vite !');
             $signalement->setAutotraitement(false);
@@ -117,7 +116,7 @@ class SuiviUsagerViewController extends AbstractController
         SignalementManager $signalementManager,
         MailerProvider $mailerProvider,
         EventDispatcherInterface $eventDispatcher,
-        ): Response {
+    ): Response {
         if ($this->isCsrfTokenValid('signalement_switch_autotraitement', $request->get('_csrf_token'))) {
             $this->addFlash('success', 'Votre choix a été enregistré. Vous pouvez consulter le protocole d\'auto-traitement.');
             $signalement->setAutotraitement(true);
@@ -146,7 +145,7 @@ class SuiviUsagerViewController extends AbstractController
         InterventionRepository $interventionRepository,
         MailerProvider $mailerProvider,
         EventDispatcherInterface $eventDispatcher,
-        ): Response {
+    ): Response {
         if ($this->isCsrfTokenValid('signalement_resolve', $request->get('_csrf_token'))) {
             $this->addFlash('success', 'Votre procédure est terminée !');
 
@@ -181,7 +180,7 @@ class SuiviUsagerViewController extends AbstractController
         Signalement $signalement,
         MailerProvider $mailerProvider,
         EventDispatcherInterface $eventDispatcher,
-        ): Response {
+    ): Response {
         if ($this->isCsrfTokenValid('signalement_confirm_toujours_punaises', $request->get('_csrf_token'))) {
             $this->addFlash('success', 'Stop Punaises a été prévenu de votre retour.');
             $mailerProvider->sendAdminToujoursPunaises($this->getParameter('admin_email'), $signalement);
@@ -203,7 +202,7 @@ class SuiviUsagerViewController extends AbstractController
         Signalement $signalement,
         SignalementManager $signalementManager,
         EventDispatcherInterface $eventDispatcher,
-        ): Response {
+    ): Response {
         if ($this->isCsrfTokenValid('signalement_stop', $request->get('_csrf_token'))) {
             $this->addFlash('success', 'Votre procédure est terminée !');
             $signalement->setClosedAt(new \DateTimeImmutable());
@@ -228,7 +227,7 @@ class SuiviUsagerViewController extends AbstractController
         InterventionRepository $interventionRepository,
         MailerProvider $mailerProvider,
         EventDispatcherInterface $eventDispatcher,
-        ): Response {
+    ): Response {
         if ($this->isCsrfTokenValid('signalement_estimation_choice', $request->get('_csrf_token'))) {
             if ('accept' == $request->get('action')) {
                 $this->addFlash('success', 'L\'estimation a bien été acceptée');
@@ -279,8 +278,10 @@ class SuiviUsagerViewController extends AbstractController
         return $this->redirectToRoute('app_suivi_usager_view', ['uuidPublic' => $intervention->getSignalement()->getUuidPublic()]);
     }
 
-    #[Route('/signalements/{signalement_uuid}/messages-thread/{thread_uuid}',
-        name: 'app_suivi_usager_view_messages_thread')]
+    #[Route(
+        '/signalements/{signalement_uuid}/messages-thread/{thread_uuid}',
+        name: 'app_suivi_usager_view_messages_thread'
+    )]
     #[ParamConverter('signalement', options: ['mapping' => ['signalement_uuid' => 'uuid']])]
     #[ParamConverter('messageThread', options: ['mapping' => ['thread_uuid' => 'uuid']])]
     public function displayThreadMessages(Request $request, Signalement $signalement, MessageThread $messageThread): Response

--- a/src/Controller/Front/SuiviUsagerViewController.php
+++ b/src/Controller/Front/SuiviUsagerViewController.php
@@ -57,10 +57,7 @@ class SuiviUsagerViewController extends AbstractController
         }
 
         $docFile = $signalement->isAutotraitement() ? $this->getParameter('doc_autotraitement') : $this->getParameter('doc_domicile');
-        $docSize = 0;
-        if (file_exists('./build/'.$docFile)) {
-            $docSize = filesize('./build/'.$docFile);
-        }
+        $docSize = $signalement->isAutotraitement() ? $this->getParameter('doc_autotraitement_size') : $this->getParameter('doc_domicile_size');
 
         return $this->render('front_suivi_usager/index.html.twig', [
             'signalement' => $signalement,

--- a/src/Controller/Front/SuiviUsagerViewController.php
+++ b/src/Controller/Front/SuiviUsagerViewController.php
@@ -57,10 +57,16 @@ class SuiviUsagerViewController extends AbstractController
         }
 
         $docFile = $signalement->isAutotraitement() ? $this->getParameter('doc_autotraitement') : $this->getParameter('doc_domicile');
+        if (file_exists('./build/'.$docFile)) {
+            $docSize = filesize('./build/'.$docFile);
+        } else {
+            $docSize = 0;
+        }
 
         return $this->render('front_suivi_usager/index.html.twig', [
             'signalement' => $signalement,
             'link_pdf' => $this->getParameter('base_url').'/build/'.$docFile,
+            'size_pdf' => $docSize,
             'niveau_infestation' => $signalement->getNiveauInfestation() ? InfestationLevel::from($signalement->getNiveauInfestation())->label() : 'Non déterminée',
             'events' => $events,
             'accepted_interventions' => $acceptedInterventions,

--- a/src/Event/SignalementAddedEvent.php
+++ b/src/Event/SignalementAddedEvent.php
@@ -12,8 +12,9 @@ class SignalementAddedEvent extends Event
     public function __construct(
         private Signalement $signalement,
         private string $pdfUrl,
+        private int $pdfSize,
         private ?\DateTimeImmutable $createdAt = null,
-        ) {
+    ) {
     }
 
     public function getSignalement(): Signalement
@@ -29,5 +30,10 @@ class SignalementAddedEvent extends Event
     public function getCreatedAt(): ?\DateTimeImmutable
     {
         return $this->createdAt;
+    }
+
+    public function getPdfSize(): string
+    {
+        return $this->pdfSize;
     }
 }

--- a/src/EventSubscriber/SignalementAddedSubscriber.php
+++ b/src/EventSubscriber/SignalementAddedSubscriber.php
@@ -48,6 +48,7 @@ class SignalementAddedSubscriber implements EventSubscriberInterface
                 recipient: $signalement->getEmailOccupant(),
                 userId: null,
                 pdfUrl: $signalementAddedEvent->getPdfUrl(),
+                pdfSize: $signalementAddedEvent->getPdfSize(),
             );
             $this->eventRepository->updateCreatedAt($event, $signalementAddedEvent->getCreatedAt());
 
@@ -56,6 +57,7 @@ class SignalementAddedSubscriber implements EventSubscriberInterface
                 recipient: null,
                 userId: Event::USER_ALL,
                 pdfUrl: null,
+                pdfSize: null,
             );
             $this->eventRepository->updateCreatedAt($event, $signalementAddedEvent->getCreatedAt());
         }

--- a/src/Manager/EventManager.php
+++ b/src/Manager/EventManager.php
@@ -7,14 +7,16 @@ use App\Entity\MessageThread;
 use App\Entity\Signalement;
 use App\Factory\EventFactory;
 use App\Repository\EventRepository;
+use App\Utils\FileHelper;
 use Doctrine\Persistence\ManagerRegistry;
 
 class EventManager extends AbstractManager
 {
-    public function __construct(private EventFactory $eventFactory,
-                                private EventRepository $eventRepository,
-                                protected ManagerRegistry $managerRegistry,
-                                protected string $entityName = Event::class
+    public function __construct(
+        private EventFactory $eventFactory,
+        private EventRepository $eventRepository,
+        protected ManagerRegistry $managerRegistry,
+        protected string $entityName = Event::class
     ) {
         parent::__construct($managerRegistry, $entityName);
     }
@@ -66,7 +68,9 @@ class EventManager extends AbstractManager
         ?string $recipient,
         ?int $userId,
         ?string $pdfUrl,
+        ?int $pdfSize,
     ): Event {
+        $pdfSizeFormatted = $pdfSize ? ' ('.FileHelper::fileSizeFormatter($pdfSize, 2).')' : '';
         $event = $this->eventFactory->createInstance(
             domain: Event::DOMAIN_PROTOCOLE,
             title: 'Protocole envoyé',
@@ -74,7 +78,7 @@ class EventManager extends AbstractManager
             userId: $userId,
             recipient: $recipient,
             actionLink: $pdfUrl ? $pdfUrl : null,
-            actionLabel: $pdfUrl ? 'Télécharger le protocole' : null,
+            actionLabel: $pdfUrl ? 'Télécharger le protocole'.$pdfSizeFormatted : null,
             entityName: Signalement::class,
             entityUuid: $signalement->getUuid()
         );

--- a/src/Twig/AppExtension.php
+++ b/src/Twig/AppExtension.php
@@ -24,6 +24,7 @@ class AppExtension extends AbstractExtension
             new TwigFilter('reference_sortable', [$this, 'formatSortableReference']),
             new TwigFilter('signalement_type', [$this, 'formatSignalementType']),
             new TwigFilter('place_type', [$this, 'formatPlaceType']),
+            new TwigFilter('format_bytes', [$this, 'formatBytes']),
         ];
     }
 
@@ -108,5 +109,17 @@ class AppExtension extends AbstractExtension
         }
 
         return $referenceSplit[0].'-'.str_pad($referenceSplit[1], 10, 0, \STR_PAD_LEFT);
+    }
+
+    public function formatBytes($bytes, $precision = 2): string
+    {
+        $units = ['o', 'Ko', 'Mo', 'Go', 'To'];
+        $bytes = max($bytes, 0);
+        $pow = floor(($bytes ? log($bytes) : 0) / log(1024));
+        $pow = min($pow, \count($units) - 1);
+
+        $bytes /= 1024 ** $pow;
+
+        return round($bytes, $precision).' '.$units[$pow];
     }
 }

--- a/src/Twig/AppExtension.php
+++ b/src/Twig/AppExtension.php
@@ -6,6 +6,7 @@ use App\Entity\Enum\InfestationLevel;
 use App\Entity\Enum\PlaceType;
 use App\Entity\Enum\SignalementType;
 use App\Entity\Signalement;
+use App\Utils\FileHelper;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
 
@@ -113,13 +114,6 @@ class AppExtension extends AbstractExtension
 
     public function formatBytes($bytes, $precision = 2): string
     {
-        $units = ['o', 'Ko', 'Mo', 'Go', 'To'];
-        $bytes = max($bytes, 0);
-        $pow = floor(($bytes ? log($bytes) : 0) / log(1024));
-        $pow = min($pow, \count($units) - 1);
-
-        $bytes /= 1024 ** $pow;
-
-        return round($bytes, $precision).' '.$units[$pow];
+        return FileHelper::fileSizeFormatter($bytes, $precision);
     }
 }

--- a/src/Utils/FileHelper.php
+++ b/src/Utils/FileHelper.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Utils;
+
+class FileHelper
+{
+    public static function fileSizeFormatter($bytes, $precision = 2): string
+    {
+        $units = ['o', 'Ko', 'Mo', 'Go', 'To'];
+        $bytes = max($bytes, 0);
+        $pow = floor(($bytes ? log($bytes) : 0) / log(1024));
+        $pow = min($pow, \count($units) - 1);
+
+        $bytes /= 1024 ** $pow;
+
+        return round($bytes, $precision).' '.$units[$pow];
+    }
+}

--- a/templates/front/index.html.twig
+++ b/templates/front/index.html.twig
@@ -69,7 +69,7 @@
                         Les punaises de lit peuvent infester n'importe qui et il est parfois compliqué de savoir d'où elles viennent.
                     </p>
                     <p>
-                        D'après <a href="https://www.anses.fr/fr/system/files/BIOCIDES2021SA0147Ra.pdf" target="_blank" rel="noopener">le rapport de l'Anses</a> 
+                        D'après <a href="https://www.anses.fr/fr/system/files/BIOCIDES2021SA0147Ra.pdf" target="_blank" rel="noopener">le rapport de l'Anses (6,3 Mo)</a> 
                         (l’Agence nationale de sécurité sanitaire de l’alimentation, de l’environnement et du travail) publié en juillet 2023, 
                         11 % des ménages français auraient été infestés par les punaises de lit entre 2017 et 2022.
                         <br>

--- a/templates/front_suivi_usager/index.html.twig
+++ b/templates/front_suivi_usager/index.html.twig
@@ -55,7 +55,7 @@
             {% if not signalement.resolvedAt and not signalement.closedAt %}
             <div class="fr-grid-row fr-grid-row--gutters align-center">
                 <div class="fr-col fr-col-12 fr-col-lg-6 fr-mb-3v">
-                    <a class="fr-btn fr-btn--icon-left fr-icon-download-line" href="{{ link_pdf }}" target="_blank">Télécharger le protocole</a>
+                    <a class="fr-btn fr-btn--icon-left fr-icon-download-line" href="{{ link_pdf }}" target="_blank">Télécharger le protocole ({{size_pdf|format_bytes}})</a>
                 </div>
 
                 <div class="fr-col fr-col-12 fr-col-lg-6 fr-mb-3v">

--- a/tests/Unit/Utils/FileHelperTest.php
+++ b/tests/Unit/Utils/FileHelperTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Tests\Unit\Utils;
+
+use App\Utils\FileHelper;
+use PHPUnit\Framework\TestCase;
+
+class FileHelperTest extends TestCase
+{
+    /**
+     * @dataProvider provideData
+     */
+    public function testFileSizeFormatter($data, $expectedResult): void
+    {
+        $formattedData = FileHelper::fileSizeFormatter($data[0], $data[1]);
+
+        $this->assertEquals($expectedResult, $formattedData);
+    }
+
+    public function provideData(): \Generator
+    {
+        yield '1024 sans décimale' => [
+            [1024, 0],
+            '1 Ko',
+        ];
+
+        yield '2000 sans décimale' => [
+            [2000, 0],
+            '2 Ko',
+        ];
+
+        yield '2000 avec 2 décimales' => [
+            [2000, 2],
+            '1.95 Ko',
+        ];
+
+        yield "367\u{202f}127 avec 1 décimale" => [
+            [367127, 1],
+            '358.5 Ko',
+        ];
+        yield "4\u{202f}132\u{202f}973 avec 3 décimales" => [
+            [4132973, 3],
+            '3.942 Mo',
+        ];
+    }
+}


### PR DESCRIPTION
## Ticket

#500    

## Description
Ajouter le poids des pdfs. La plupart des pdf sont envoyés par mail, j'ai ajouté le poids sur la page de suivi usager.

## Changements apportés
* Modification du controller et du twig pour afficher le poids
* Ajout d'une extension Twig  pour le formatage du poids

## Pré-requis

## Tests
- [ ] Faire un signalement en autotraitement, vérifier que dans la page de suivi le poids du pdf d'autotreaitement est bien affiché
- [ ] Faire un signalement en traitement pro, vérifier que dans la page de suivi usager le poids du pdf de préparation est bien affiché
