### PR TITLE
[Accessibilité] Rendre les listes du BO responsive

### DIFF
--- a/assets/controllers/list_employes.js
+++ b/assets/controllers/list_employes.js
@@ -1,6 +1,7 @@
 import $ from 'jquery';
 import 'datatables.net';
 import 'datatables.net-dt';
+import 'datatables.net-responsive-dt';
 
 $(function() {
   if ($('div.sublist-employes').length > 0) {
@@ -10,7 +11,8 @@ $(function() {
 
 var listTable = null;
 function startListeEmployesApp() {
-  listTable = $('table#datatable').DataTable({
+  listTable = $('table#datatable').DataTable({    
+    responsive: true,
     pageLength: 20,
     searching: false,
     ordering: true,

--- a/assets/controllers/list_entreprises.js
+++ b/assets/controllers/list_entreprises.js
@@ -1,6 +1,7 @@
 import $ from 'jquery';
 import 'datatables.net';
 import 'datatables.net-dt';
+import 'datatables.net-responsive-dt';
 
 $(function() {
   if ($('div.liste-entreprises').length > 0) {
@@ -11,6 +12,7 @@ $(function() {
 var listTable = null;
 function startListeEntreprisesApp() {
   listTable = $('table#datatable').DataTable({
+    responsive: true,
     pageLength: 20,
     searching: true,
     ordering: true,

--- a/assets/controllers/list_signalement.js
+++ b/assets/controllers/list_signalement.js
@@ -1,6 +1,7 @@
 import $ from 'jquery';
 import 'datatables.net';
 import 'datatables.net-dt';
+import 'datatables.net-responsive-dt';
 
 $(function() {
   if ($('div.liste-signalements').length > 0) {
@@ -10,7 +11,8 @@ $(function() {
 
 var listTable = null;
 function startListeSignalementsApp() {
-  listTable = $('table#datatable').DataTable({
+  listTable = $('table#datatable').DataTable({    
+    responsive: true,
     pageLength: 20,
     searching: true,
     ordering: true,

--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -700,11 +700,6 @@ span.image-caption {
         table {
             tbody {
                 td{
-                    &:nth-child(1) {
-                        span {
-                            display: none;
-                        }
-                    }
                     &:nth-child(3) {
                         span {
                             display: inline-block;
@@ -784,11 +779,6 @@ span.image-caption {
         table {
             tbody {
                 td{
-                    &:nth-child(2) {
-                        span {
-                            display: none;
-                        }
-                    }
                     &:nth-child(5) {
                         span {
                             display: inline-block;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
                 "@gouvfr/dsfr": "^1.7.2",
                 "datatables.net": "^1.12.1",
                 "datatables.net-dt": "^1.12.1",
+                "datatables.net-responsive-dt": "^2.5.0",
                 "jquery": "^3.6.1",
                 "jquery-ui": "^1.13.2"
             },
@@ -3518,19 +3519,38 @@
             }
         },
         "node_modules/datatables.net": {
-            "version": "1.12.1",
-            "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-1.12.1.tgz",
-            "integrity": "sha512-e6XAMUoV41JdQPS/r9YRfRcmTPcCVvyZbWI+xog1Zg+kjVliMQbEkvWK5XFItmi64Cvwg+IqsZbTUJ1KSY3umA==",
+            "version": "1.13.8",
+            "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-1.13.8.tgz",
+            "integrity": "sha512-2pDamr+GUwPTby2OgriVB9dR9ftFKD2AQyiuCXzZIiG4d9KkKFQ7gqPfNmG7uj9Tc5kDf+rGj86do4LAb/V71g==",
             "dependencies": {
                 "jquery": ">=1.7"
             }
         },
         "node_modules/datatables.net-dt": {
-            "version": "1.12.1",
-            "resolved": "https://registry.npmjs.org/datatables.net-dt/-/datatables.net-dt-1.12.1.tgz",
-            "integrity": "sha512-HYsHbSYqOqlgsgjKMH/kkCB5455t51GmmtXRxgnDMRbjPLEIKo5CZmAlUe5mdD/RVPRtAUaj5K3SDlkEZ1bUmw==",
+            "version": "1.13.8",
+            "resolved": "https://registry.npmjs.org/datatables.net-dt/-/datatables.net-dt-1.13.8.tgz",
+            "integrity": "sha512-/ZPzr1hQ+domerlg/MbcQHqeeqxK9fsZmpRs1YeKxsdfr+UyHQTUiiOO7RqekppSLc7MPqxGnzKkCX9vAgqm0w==",
             "dependencies": {
-                "datatables.net": ">=1.11.3",
+                "datatables.net": "1.13.8",
+                "jquery": ">=1.7"
+            }
+        },
+        "node_modules/datatables.net-responsive": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/datatables.net-responsive/-/datatables.net-responsive-2.5.0.tgz",
+            "integrity": "sha512-GL7DFiRl5qqrp5ql54Psz92xTGPR0rMcrO3hzNxMfvcfpRGL5zFNTvMpTUh59Erm6u1+KoX+j+Ig1ZD3r0iFsA==",
+            "dependencies": {
+                "datatables.net": ">=1.13.4",
+                "jquery": ">=1.7"
+            }
+        },
+        "node_modules/datatables.net-responsive-dt": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/datatables.net-responsive-dt/-/datatables.net-responsive-dt-2.5.0.tgz",
+            "integrity": "sha512-u0oHqG1LLrFj+cBVYpyOO03nECUJJim4EovKhdQtB2g8X0fbH7jWvLAOdDFvyIzktCYWScObqR8uUEtm6J9O6Q==",
+            "dependencies": {
+                "datatables.net-dt": ">=1.13.4",
+                "datatables.net-responsive": ">=2.4.1",
                 "jquery": ">=1.7"
             }
         },
@@ -10286,19 +10306,38 @@
             }
         },
         "datatables.net": {
-            "version": "1.12.1",
-            "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-1.12.1.tgz",
-            "integrity": "sha512-e6XAMUoV41JdQPS/r9YRfRcmTPcCVvyZbWI+xog1Zg+kjVliMQbEkvWK5XFItmi64Cvwg+IqsZbTUJ1KSY3umA==",
+            "version": "1.13.8",
+            "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-1.13.8.tgz",
+            "integrity": "sha512-2pDamr+GUwPTby2OgriVB9dR9ftFKD2AQyiuCXzZIiG4d9KkKFQ7gqPfNmG7uj9Tc5kDf+rGj86do4LAb/V71g==",
             "requires": {
                 "jquery": ">=1.7"
             }
         },
         "datatables.net-dt": {
-            "version": "1.12.1",
-            "resolved": "https://registry.npmjs.org/datatables.net-dt/-/datatables.net-dt-1.12.1.tgz",
-            "integrity": "sha512-HYsHbSYqOqlgsgjKMH/kkCB5455t51GmmtXRxgnDMRbjPLEIKo5CZmAlUe5mdD/RVPRtAUaj5K3SDlkEZ1bUmw==",
+            "version": "1.13.8",
+            "resolved": "https://registry.npmjs.org/datatables.net-dt/-/datatables.net-dt-1.13.8.tgz",
+            "integrity": "sha512-/ZPzr1hQ+domerlg/MbcQHqeeqxK9fsZmpRs1YeKxsdfr+UyHQTUiiOO7RqekppSLc7MPqxGnzKkCX9vAgqm0w==",
             "requires": {
-                "datatables.net": ">=1.11.3",
+                "datatables.net": "1.13.8",
+                "jquery": ">=1.7"
+            }
+        },
+        "datatables.net-responsive": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/datatables.net-responsive/-/datatables.net-responsive-2.5.0.tgz",
+            "integrity": "sha512-GL7DFiRl5qqrp5ql54Psz92xTGPR0rMcrO3hzNxMfvcfpRGL5zFNTvMpTUh59Erm6u1+KoX+j+Ig1ZD3r0iFsA==",
+            "requires": {
+                "datatables.net": ">=1.13.4",
+                "jquery": ">=1.7"
+            }
+        },
+        "datatables.net-responsive-dt": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/datatables.net-responsive-dt/-/datatables.net-responsive-dt-2.5.0.tgz",
+            "integrity": "sha512-u0oHqG1LLrFj+cBVYpyOO03nECUJJim4EovKhdQtB2g8X0fbH7jWvLAOdDFvyIzktCYWScObqR8uUEtm6J9O6Q==",
+            "requires": {
+                "datatables.net-dt": ">=1.13.4",
+                "datatables.net-responsive": ">=2.4.1",
                 "jquery": ">=1.7"
             }
         },

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
         "@gouvfr/dsfr": "^1.7.2",
         "datatables.net": "^1.12.1",
         "datatables.net-dt": "^1.12.1",
+        "datatables.net-responsive-dt": "^2.5.0",
         "jquery": "^3.6.1",
         "jquery-ui": "^1.13.2"
     },

--- a/templates/base-back.html.twig
+++ b/templates/base-back.html.twig
@@ -15,6 +15,7 @@
         <link rel="stylesheet" href="{{ asset('build/dsfr/utility/icons/icons-user/icons-user.min.css') }}">
         <link rel="stylesheet" href="{{ asset('build/dsfr/utility/icons/icons-business/icons-business.min.css') }}">
         <link rel="stylesheet" href="{{ asset('build/datatables/jquery.dataTables.min.css') }}">
+        <link rel="stylesheet" href="{{ asset('build/datatables/responsive.dataTables.min.css') }}">
         
         <link rel="icon" href={{ asset('build/images/favicon.ico') }}>
 

--- a/templates/entreprise_list/index.html.twig
+++ b/templates/entreprise_list/index.html.twig
@@ -22,7 +22,7 @@
             <h2><span id="count-entreprise">{{ count_entreprises }}</span> entreprises trouvées</h2>
 
             {% if entreprises is not empty %}
-                <table id="datatable">
+                <table id="datatable" class="nowrap">
                     <thead>
                         <tr>
                             <th>ID</th>
@@ -38,7 +38,7 @@
                         {% for entreprise in entreprises %}
                             <tr>
                                 <td>{{ entreprise.id }}</td>
-                                <td>{{ entreprise.nom }} <span>{{ entreprise.numeroSiret }} {{ entreprise.numeroLabel }}</span></td>
+                                <td>{{ entreprise.nom }} <span class="fr-hidden">{{ entreprise.numeroSiret }} {{ entreprise.numeroLabel }}</span></td>
                                 <td>{{ entreprise.numeroSiret }}</span></td>
                                 <td>{{ entreprise.numeroLabel }}</td>
                                 <td><span>{{ entreprise.employes.count }}</span></td>

--- a/templates/entreprise_view/index.html.twig
+++ b/templates/entreprise_view/index.html.twig
@@ -57,7 +57,7 @@
             </div>
 
             {% if entreprise.employes is not empty %}
-                <table id="datatable">
+                <table id="datatable" class="nowrap">
                     <thead>
                         <tr>
                             <th>ID</th>

--- a/templates/signalement_list/erp-transports.html.twig
+++ b/templates/signalement_list/erp-transports.html.twig
@@ -37,7 +37,7 @@
         <h2><span id="count-signalement">{{ count_signalement }}</span> signalements trouvés</h2>
 
         {% if signalements is not empty %}
-            <table id="datatable" class="liste-signalements-erp-transports">
+            <table id="datatable" class="liste-signalements-erp-transports nowrap">
                 <thead>
                     <tr>
                         <th>ID</th>
@@ -52,7 +52,7 @@
                 <tbody>
                     {% for signalement in signalements %}
                         <tr>
-                            <td data-order="{{ signalement.reference|reference_sortable }}">{{ signalement.reference }} <span>{{ signalement.nomOccupant }} {{ signalement.prenomOccupant }} {{ signalement.emailOccupant }}</span></td>
+                            <td data-order="{{ signalement.reference|reference_sortable }}">{{ signalement.reference }} <span class="fr-hidden">{{ signalement.nomOccupant }} {{ signalement.prenomOccupant }} {{ signalement.emailOccupant }}</span></td>
                             <td data-order="{{ signalement.createdAt.format('Y-m-d') }}">{{ signalement.createdAt.format('d/m/Y') }}</td>
                             <td>{{ signalement.type|signalement_type }}</td>
                             {% if signalement.type is same as enum('App\\Entity\\Enum\\SignalementType').TYPE_TRANSPORT %}

--- a/templates/signalement_list/historique.html.twig
+++ b/templates/signalement_list/historique.html.twig
@@ -57,7 +57,7 @@
         <h2><span id="count-signalement">{{ count_signalement }}</span> signalements trouvés</h2>
 
         {% if signalements is not empty %}
-            <table id="datatable" class="liste-signalements-historique">
+            <table id="datatable" class="liste-signalements-historique nowrap">
                 <thead>
                     <tr>
                         <th>ID</th>
@@ -75,7 +75,7 @@
                 <tbody>
                     {% for signalement in signalements %}
                         <tr>
-                            <td data-order="{{ signalement.reference|reference_sortable }}">{{ signalement.reference }} <span>{{ signalement.nomOccupant }} {{ signalement.prenomOccupant }} {{ signalement.emailOccupant }}</span></td>
+                            <td data-order="{{ signalement.reference|reference_sortable }}">{{ signalement.reference }} <span class="fr-hidden">{{ signalement.nomOccupant }} {{ signalement.prenomOccupant }} {{ signalement.emailOccupant }}</span></td>
                             <td data-order="{{ signalement.createdAt.format('Y-m-d') }}">{{ signalement.createdAt.format('d/m/Y') }}</td>
                             <td><span>{{ signalement.typeIntervention|capitalize }}</span></td>
                             <td>{{ signalement.dateIntervention ? signalement.dateIntervention.format('d/m/Y') : '/' }}</td>

--- a/templates/signalement_list/hors-perimetre.html.twig
+++ b/templates/signalement_list/hors-perimetre.html.twig
@@ -33,7 +33,7 @@
         <h2><span id="count-signalement">{{ count_signalement }}</span> signalements trouvés</h2>
 
         {% if signalements is not empty %}
-            <table id="datatable" class="liste-signalements-hors-perimetres">
+            <table id="datatable" class="liste-signalements-hors-perimetres nowrap">
                 <thead>
                     <tr>
                         <th>ID</th>
@@ -46,7 +46,7 @@
                 <tbody>
                     {% for signalement in signalements %}
                         <tr>
-                            <td data-order="{{ signalement.reference|reference_sortable }}">{{ signalement.reference }} <span>{{ signalement.nomOccupant }} {{ signalement.prenomOccupant }} {{ signalement.emailOccupant }}</span></td>
+                            <td data-order="{{ signalement.reference|reference_sortable }}">{{ signalement.reference }} <span class="fr-hidden">{{ signalement.nomOccupant }} {{ signalement.prenomOccupant }} {{ signalement.emailOccupant }}</span></td>
                             <td data-order="{{ signalement.createdAt.format('Y-m-d') }}">{{ signalement.createdAt.format('d/m/Y') }}</td>
                             <td>{{ signalement.territoire.nomComplet }}</td>
                             <td>{{ signalement.codePostal }}</td>

--- a/templates/signalement_list/signalements.html.twig
+++ b/templates/signalement_list/signalements.html.twig
@@ -89,7 +89,7 @@
         <h2><span id="count-signalement">{{ count_signalement }}</span> signalements trouvés</h2>
 
         {% if signalements is not empty %}
-            <table id="datatable" class="liste-signalements-usagers">
+            <table id="datatable" class="liste-signalements-usagers nowrap">
                 <thead>
                     <tr>
                         <th>Statut</th>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,6 +27,10 @@ Encore
         to: 'datatables/[path][name].[ext]'
     })
     .copyFiles({
+        from: './node_modules/datatables.net-responsive-dt/css/',
+        to: 'datatables/[path][name].[ext]'
+    })
+    .copyFiles({
         from: './node_modules/jquery-ui/dist/themes/base/',
         to: 'jquery-ui/[path][name].[ext]'
     })


### PR DESCRIPTION
## Ticket

#502   

## Description
Rendre les listes du BO responsive (signalements, entreprises, usagers)

## Changements apportés
* Utilisation du package datatables.net-responsive-dt
* Ajout de l'option `responsive: true,` sur les 3 types de listes
* Ajout de la classe nowrap sur toutes les datatables
* Ajout d'une classe fr-hidden sur les <span> cachés servant à la recherche (pour compenser la suppression du `display: none;` dans app.scss qui ne permettait pas la visibilité des infos supplémentaires d'une ligne)

## Pré-requis
```
make npm-install
npm run watch
```

## Tests
- [ ] Tester toutes les listes du BO en version mobile
- [ ] Vérifier que la flèche apparait bien et qu'au clic les infos supplémentaires apparaissent
- [ ] vérifier que la recherche fonctionne toujours sur les infos des champs cachés et qu'ils restent cachés
