### PR TITLE
[DSFR] Modification de l'affichage des boutons

### DIFF
--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -878,9 +878,6 @@ span.image-caption {
 .suivi-usager,
 .signalement-punaises {
     .fr-btn {
-        width: 100%;
-        justify-content: center;
-
         &::after {
             --icon-size: 0rem;
         }

--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -255,10 +255,6 @@ span.statut-infestation {
         max-width: 100%;
         height: auto;
     }
-    .btn-next {
-        width: 100%;
-        justify-content: center;
-    }
 }
 
 .index-tout-le-monde {
@@ -814,7 +810,6 @@ span.image-caption {
         }
 
         .btn-next, .btn-next-next {
-            width: 100%;
             justify-content: center;
         }
 

--- a/templates/front_signalement/_partial_signalement_navigation_container.html.twig
+++ b/templates/front_signalement/_partial_signalement_navigation_container.html.twig
@@ -1,9 +1,9 @@
-<nav class="fr-mt-3v">
+<nav class="fr-mt-3v align-center">
     <div class="fr-input-group group-next">
         <button type="button" class="fr-btn btn-next">{{ next }}</button>
     </div>
 
     <div class="fr-input-group group-previous">
-        <span>&lt;</span> <a href="#" class="link-back">{{ previous }}</a>
+        <button type="button" class="fr-btn fr-btn--tertiary-no-outline link-back">{{ previous }}</button>
     </div>
 </nav>

--- a/templates/front_signalement/_partial_step_autotraitement_info.html.twig
+++ b/templates/front_signalement/_partial_step_autotraitement_info.html.twig
@@ -30,7 +30,7 @@
         </div>
 
         <div class="fr-input-group group-previous">
-            <span>&lt;</span> <a href="#" class="link-back-back">Retour</a>
+            <button type="button" class="fr-btn fr-btn--tertiary-no-outline link-back-back">Retour</a>
         </div>
     </nav>
 {% endblock %}

--- a/templates/front_signalement/_partial_step_home.html.twig
+++ b/templates/front_signalement/_partial_step_home.html.twig
@@ -15,12 +15,12 @@
                 </p>
             </div>
 
-            <div class="fr-input-group">
+            <div class="fr-input-group align-center">
                 <button type="button" class="fr-btn btn-next">
                     C'est parti !
                 </button>
 
-                <p class="align-center fr-mt-3v">
+                <p class="fr-mt-3v">
                     <a href="{{ path('app_front_signalement_type_list') }}" class="fr-link fr-link--icon-left fr-icon-arrow-left-s-line">Retour au choix de signalement</a>
                 </p>
             </div>

--- a/templates/front_signalement/_partial_step_professionnel_info.html.twig
+++ b/templates/front_signalement/_partial_step_professionnel_info.html.twig
@@ -26,7 +26,7 @@
         </div>
 
         <div class="fr-input-group group-previous">
-            <span>&lt;</span> <a href="#" class="link-back">Retour</a>
+            <button type="button" class="fr-btn fr-btn--tertiary-no-outline link-back">Retour</a>
         </div>
     </nav>
 {% endblock %}

--- a/templates/front_signalement/_partial_step_recommandation.html.twig
+++ b/templates/front_signalement/_partial_step_recommandation.html.twig
@@ -45,7 +45,7 @@
         </div>
 
         <div class="fr-input-group group-previous">
-            <span>&lt;</span> <a href="#" class="link-back">Retour</a>
+            <button type="button" class="fr-btn fr-btn--tertiary-no-outline link-back">Retour</a>
         </div>
     </nav>
 


### PR DESCRIPTION
## Ticket

#561    

## Description
Modification de l'affichage des boutons suite aux retours concernant l'audit DSFR : les boutons ne doivent pas prendre toute la largeur mais s'ajuster à la taille du texte.
Dans les formulaires, les boutons Suivant / Précédent ne doivent pas être des liens.

## Tests
- [ ] Vérifier bouton de la page d'accueil
- [ ] Vérifier boutons des formulaires
