### PR TITLE
[DSFR] Ajout de contenu plus détaillé pour les deux images de la page Informations

### DIFF
--- a/templates/front/information.html.twig
+++ b/templates/front/information.html.twig
@@ -230,7 +230,9 @@
 
                 <div class="fr-col-12 fr-col-lg-4">
                     <a href="{{ asset('build/images/flyer-ou-se-cachent-elles.jpg') }}" target="_blank" rel="noopener" title="Voir l'image : Où se cachent les punaises de lit ?">
-                        <img src="{{ asset('build/images/flyer-ou-se-cachent-elles-resize.jpg') }}" alt="où se cachent les punaises de lit ?" width="500" height="954">
+                        <img src="{{ asset('build/images/flyer-ou-se-cachent-elles-resize.jpg') }}" width="500" height="954"
+                            alt="Où se cachent les punaises de lit ? Dans la chambre, dans les matelas et sommiers. Derrière les cadres, les raccords de papier peint, sous les meubles, dans les plinthes, sous les prises électriques. Dans les fissures et les fentes du parquet. Dans les canapés. Sous les tapis."
+                            >
                     </a>
                     <br>
                     <em>Crédit : Citizen</em>
@@ -479,7 +481,9 @@
 
                 <div class="fr-col-12 fr-col-lg-4">
                     <a href="{{ asset('build/images/flyer-comment-les-eviter.jpg') }}" target="_blank" rel="noopener" title="Voir l'image : Comment éviter les punaises de lit ?">
-                        <img src="{{ asset('build/images/flyer-comment-les-eviter.jpg') }}" alt="Comment éviter les punaises de lit ?" width="500" height="954">
+                        <img src="{{ asset('build/images/flyer-comment-les-eviter.jpg') }}" width="500" height="954"
+                            alt="Comment éviter les punaises de lit ? En voyage, ne posez pas votre bagage sur le lit, encore moins sous le lit. Contrôlez vos effets personnels à votre retour. Evitez d'encombrer les espaces. Attention aux achats d'occasion, lavez-les à 60°C. Nettoyez les meubles récupérés."
+                            >
                     </a>
                     <br>
                     <em>Crédit : Citizen</em>


### PR DESCRIPTION
## Ticket

#563   

## Description
Les deux images de la page Informations contiennent beaucoup de texte. On améliore le remplissage de la balise alt de ces deux images.

## Tests
- [ ] Vérifier le texte dans le code
- [ ] Vérifier l'affichage de la page http://localhost:8090/information
