### PR TITLE
[Sécurité] Sécurisation des cookies

### DIFF
--- a/.env
+++ b/.env
@@ -25,6 +25,8 @@ MESSENGER_TRANSPORT_DSN=doctrine://default
 REDIS_URL=redis://stopunaises_redis:6379
 FEATURE_THREE_FORMS_ENABLE=1
 SECURITY_CSP_HEADER_VALUE="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.matomo.cloud https://unpkg.com; style-src 'self' 'unsafe-inline' https://unpkg.com; img-src 'self' data: blob: https://*.tile.openstreetmap.org https://unpkg.com; connect-src 'self' https://api-adresse.data.gouv.fr https://cdn.matomo.cloud; font-src 'self'; frame-src 'none'; object-src 'none'"
+MATOMO_ENABLE=0
+MATOMO_SITE_ID=
 
 ###> sentry/sentry-symfony ###
 SENTRY_DSN=

--- a/.env.sample
+++ b/.env.sample
@@ -25,6 +25,8 @@ MESSENGER_TRANSPORT_DSN=doctrine://default
 REDIS_URL=redis://stopunaises_redis:6379
 FEATURE_THREE_FORMS_ENABLE=1
 SECURITY_CSP_HEADER_VALUE="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.matomo.cloud https://unpkg.com; style-src 'self' 'unsafe-inline' https://unpkg.com; img-src 'self' data: blob: https://*.tile.openstreetmap.org https://unpkg.com; connect-src 'self' https://api-adresse.data.gouv.fr https://cdn.matomo.cloud; font-src 'self'; frame-src 'none'; object-src 'none'"
+MATOMO_ENABLE=0
+MATOMO_SITE_ID=
 
 ###> sentry/sentry-symfony ###
 SENTRY_DSN=

--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -21,6 +21,12 @@ framework:
     php_errors:
         log: true
 
+when@prod:
+    framework:
+        session:
+            cookie_secure: true
+            cookie_httponly: true
+
 when@test:
     framework:
         test: true

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -45,6 +45,15 @@ security:
          - { path: ^/bo, roles: ROLE_ENTREPRISE }
         # - { path: ^/profile, roles: ROLE_USER }
 
+when@prod:
+    security:
+        firewalls:
+            main:
+                remember_me:
+                    secure: true
+                    httponly: true
+
+
 when@test:
     security:
         password_hashers:

--- a/config/packages/twig.yaml
+++ b/config/packages/twig.yaml
@@ -9,6 +9,9 @@ when@dev:
     twig:
         globals:
             matomo:
+                url: null
+                cdn: null
+                site_id: '%matomo_site_id%'
                 enable: '%matomo_enable%'
 
 when@test:

--- a/config/packages/twig.yaml
+++ b/config/packages/twig.yaml
@@ -2,6 +2,14 @@ twig:
     default_path: '%kernel.project_dir%/templates'
     globals:
         feature_three_forms: '%feature_three_forms%'
+        platform:
+            url: '%base_url%'
+
+when@dev:
+    twig:
+        globals:
+            matomo:
+                enable: '%matomo_enable%'
 
 when@test:
     twig:
@@ -13,4 +21,5 @@ when@prod:
             matomo:
                 url: https://histologe.matomo.cloud/
                 cdn: //cdn.matomo.cloud/histologe.matomo.cloud/matomo.js
-                site_id: 16
+                site_id: '%matomo_site_id%'
+                enable: '%matomo_enable%'

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -19,6 +19,8 @@ parameters:
     admin_email: '%env(resolve:CONTACT_EMAIL)%'
     inconnu_email: '%env(resolve:INCONNU_EMAIL)%'
     feature_three_forms: '%env(bool:FEATURE_THREE_FORMS_ENABLE)%'
+    matomo_enable: '%env(bool:MATOMO_ENABLE)%'
+    matomo_site_id: '%env(resolve:MATOMO_SITE_ID)%'
 
 services:
     # default configuration for services in *this* file

--- a/templates/common/analytics.html.twig
+++ b/templates/common/analytics.html.twig
@@ -1,4 +1,4 @@
-{% if matomo is defined %}
+{% if matomo is defined and matomo.enable == 1 %}
     <!-- Matomo -->
     <script>
         var _paq = window._paq = window._paq || [];

--- a/templates/common/analytics.html.twig
+++ b/templates/common/analytics.html.twig
@@ -2,6 +2,9 @@
     <!-- Matomo -->
     <script>
         var _paq = window._paq = window._paq || [];
+        {% if platform.url starts with 'https' %}
+            _paq.push(['setSecureCookie', true]);
+        {% endif %}
         /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
         _paq.push(['trackPageView']);
         _paq.push(['enableLinkTracking']);


### PR DESCRIPTION
## Ticket

#1953    

## Description
Ajout du flag Secure sur tous les cookie utilisé sur la plateforme
Le comportement reste le même en local

## Changements apportés
* Ajout du flag pour les cookies déposé par Matomo
* Ajout du flag pour les cookies déposé par Symfony 

## Pré-requis
L'environnement local reste en http et le comportement en environnement local reste le même. 
Test à effectuer sur la review app qui est en [https://stop-punaises-staging-pr573.osc-fr1.scalingo.io/)](https://stop-punaises-staging-pr573.osc-fr1.scalingo.io/) 

Nouvelle variable d'environnement (doit rester à l'identique en dev)
```
MATOMO_ENABLE=0
MATOMO_SITE_ID=
```
Mise à jour des variables d'environnements effectuées sur les différents applications (prod, staging)

## Tests
- [ ] Naviguer sur la review app et ouvrir l'inspecteur
- [ ] Se connecter en tant qu'utilisateur et cliquer sur `Garder ma session pendant 1mois` et ouvrir l'inspecter
![image](https://github.com/MTES-MCT/stop-punaises/assets/5757116/5273da38-dbd8-4d99-8151-c8477aaa50ee)

![image](https://github.com/MTES-MCT/stop-punaises/assets/5757116/0391e03d-3222-4602-bd97-0235d5d148ea)

## Documentation
https://matomo.org/faq/general/faq_25936/
