### PR TITLE
[DSFR] Couleur bleue pour 2 liens

### DIFF
--- a/templates/front/index.html.twig
+++ b/templates/front/index.html.twig
@@ -35,7 +35,7 @@
                         Dans tous les cas, il faut agir vite pour éviter leur prolifération dans le foyer.
                     </p>
                     <p class="button-container">
-                        <a href="{{ path('app_front_information') }}">En savoir plus</a>
+                        <a class="fr-link" href="{{ path('app_front_information') }}">En savoir plus</a>
                     </p>
                 </div>
                 <div class="fr-col-12 fr-col-lg-6 video-container fr-mt-3w">

--- a/templates/security/login.html.twig
+++ b/templates/security/login.html.twig
@@ -43,7 +43,7 @@
                 </div>
                 
                 <div class="fr-input-group">
-                    <a href="{{ path('request_password') }}">Mot de passe oublié ?</a>
+                    <a class="fr-link" href="{{ path('request_password') }}">Mot de passe oublié ?</a>
                 </div>
                 
                 <div class="fr-checkbox-group">


### PR DESCRIPTION
## Ticket

#576   

## Description
Selon le DSFR
- si un lien est au milieu du texte, il doit être gris comme le texte
- si un lien est esseulé, il doit être bleu

## Changements apportés
* Sur la page d'accueil, le lien "En savoir plus" devient bleu
* Sur la page connexion, le lien "Mot de passe oublié" devient bleu

## Tests
- [ ] Tester l'affichage des deux liens
- [ ] Faire un passage rapide sur différentes pages pour vérifier si il n'y a pas d'autres liens oubliés
