### PR TITLE
[FO - Signalement] Correction des boutons radio et cases à cocher

### DIFF
--- a/assets/controllers/form_signalement_front.js
+++ b/assets/controllers/form_signalement_front.js
@@ -235,7 +235,7 @@ class PunaisesFrontSignalementController {
   }  
 
   checkChoicesInput(idInput, count) {
-    $('div#signalement_front_' + idInput).siblings('.fr-error-text').addClass('fr-hidden');
+    $('#signalement_front_' + idInput + '_legend').siblings('.fr-error-text').addClass('fr-hidden');
 
     let canGoNext = false;
     for (let i = 0; i < count; i++) {
@@ -245,7 +245,7 @@ class PunaisesFrontSignalementController {
     }
 
     if (!canGoNext) {
-      $('div#signalement_front_' + idInput).siblings('.fr-error-text').removeClass('fr-hidden');
+      $('#signalement_front_' + idInput + '_legend').siblings('.fr-error-text').removeClass('fr-hidden');
     }
     
     return canGoNext;

--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -836,14 +836,8 @@ span.image-caption {
         .fr-form-group {
             margin-top: 1.5rem;
         }
-
-        .fr-checkbox-group, .fr-radio-group {
-            label {
-                margin-bottom: 4px;
-            }
-        }
         
-        label {
+        label, .fr-fieldset__legend {
             span.underline {
                 text-decoration: underline;
             }

--- a/templates/common/components/form/list-radio-buttons.html.twig
+++ b/templates/common/components/form/list-radio-buttons.html.twig
@@ -1,0 +1,18 @@
+<fieldset class="fr-fieldset" id="signalement_front_{{ name }}" aria-labelledby="signalement_front_{{ name }}_legend">
+    <legend class="fr-fieldset__legend--regular fr-fieldset__legend" id="signalement_front_{{ name }}_legend">
+        {% if displayLabel %}
+            {{ form_label(formObject) }}
+        {% endif %}
+    </legend>
+    {% for key, choice in formObject.children %}
+        <div class="fr-fieldset__element">
+            <div class="fr-radio-group">
+                {{ form_widget(choice) }}
+                {{ form_label(choice) }}
+            </div>
+        </div>
+    {% endfor %}
+    <p class="fr-error-text fr-hidden">
+        {{ errorLabel }}
+    </p>
+</fieldset>

--- a/templates/front_signalement/_partial_step_info_locataire.html.twig
+++ b/templates/front_signalement/_partial_step_info_locataire.html.twig
@@ -12,15 +12,12 @@
         </p>
     </div>
 
-    <div class="fr-form-group">
-        <div class="fr-select-group">
-            {{ form_label(form.locataire) }}
-            {{ form_widget(form.locataire) }}
-            <p class="fr-error-text fr-hidden">
-                Veuillez renseigner si vous êtes propriétaire ou locataire.
-            </p>
-        </div>
-    </div>
+    {% include 'common/components/form/list-radio-buttons.html.twig' with {
+        'name': 'locataire',
+        'displayLabel': true,
+        'formObject': form.locataire,
+        'errorLabel': 'Veuillez renseigner si vous êtes propriétaire ou locataire.'
+    } %}
 
     <div id="form-group-nomProprietaire" class="fr-form-group">
         <div class="fr-input-group">
@@ -32,25 +29,19 @@
         </div>
     </div>
 
-    <div class="fr-form-group">
-        <div class="fr-select-group">
-            {{ form_label(form.logementSocial) }}
-            {{ form_widget(form.logementSocial) }}
-            <p class="fr-error-text fr-hidden">
-                Veuillez renseigner si vous vivez dans un logement social.
-            </p>
-        </div>
-    </div>
+    {% include 'common/components/form/list-radio-buttons.html.twig' with {
+        'name': 'logementSocial',
+        'displayLabel': true,
+        'formObject': form.logementSocial,
+        'errorLabel': 'Veuillez renseigner si vous vivez dans un logement social.'
+    } %}
 
-    <div class="fr-form-group">
-        <div class="fr-select-group">
-            {{ form_label(form.allocataire) }}
-            {{ form_widget(form.allocataire) }}
-            <p class="fr-error-text fr-hidden">
-                Veuillez renseigner si vous touchez une allocation logement.
-            </p>
-        </div>
-    </div>
+    {% include 'common/components/form/list-radio-buttons.html.twig' with {
+        'name': 'allocataire',
+        'displayLabel': true,
+        'formObject': form.allocataire,
+        'errorLabel': 'Veuillez renseigner si vous touchez une allocation logement.'
+    } %}
 
     <div id="form-group-numeroAllocataire" class="fr-form-group">
         <div class="fr-input-group">

--- a/templates/front_signalement/_partial_step_info_logement.html.twig
+++ b/templates/front_signalement/_partial_step_info_logement.html.twig
@@ -12,22 +12,12 @@
         </p>
     </div>
 
-    <fieldset class="fr-fieldset" id="signalement_front_typeLogement" aria-labelledby="signalement_front_typeLogement_legend">
-        <legend class="fr-fieldset__legend--regular fr-fieldset__legend" id="signalement_front_typeLogement_legend">
-            {{ form_label(form.typeLogement) }}
-        </legend>
-        {% for key, choice in form.typeLogement.children %}
-            <div class="fr-fieldset__element">
-                <div class="fr-radio-group">
-                    {{ form_widget(choice) }}
-                    {{ form_label(choice) }}
-                </div>
-            </div>
-        {% endfor %}
-        <p class="fr-error-text fr-hidden">
-            Veuillez renseigner le type de logement.
-        </p>
-    </fieldset>
+    {% include 'common/components/form/list-radio-buttons.html.twig' with {
+        'name': 'typeLogement',
+        'displayLabel': true,
+        'formObject': form.typeLogement,
+        'errorLabel': 'Veuillez renseigner le type de logement.'
+    } %}
 
     <div class="fr-form-group">
         <div class="fr-input-group">

--- a/templates/front_signalement/_partial_step_info_logement.html.twig
+++ b/templates/front_signalement/_partial_step_info_logement.html.twig
@@ -12,15 +12,22 @@
         </p>
     </div>
 
-    <div class="fr-form-group">
-        <div class="fr-select-group">
+    <fieldset class="fr-fieldset" id="signalement_front_typeLogement" aria-labelledby="signalement_front_typeLogement_legend">
+        <legend class="fr-fieldset__legend--regular fr-fieldset__legend" id="signalement_front_typeLogement_legend">
             {{ form_label(form.typeLogement) }}
-            {{ form_widget(form.typeLogement) }}
-            <p class="fr-error-text fr-hidden">
-                Veuillez renseigner le type de logement.
-            </p>
-        </div>
-    </div>
+        </legend>
+        {% for key, choice in form.typeLogement.children %}
+            <div class="fr-fieldset__element">
+                <div class="fr-radio-group">
+                    {{ form_widget(choice) }}
+                    {{ form_label(choice) }}
+                </div>
+            </div>
+        {% endfor %}
+        <p class="fr-error-text fr-hidden">
+            Veuillez renseigner le type de logement.
+        </p>
+    </fieldset>
 
     <div class="fr-form-group">
         <div class="fr-input-group">

--- a/templates/front_signalement/_partial_step_info_problemes.html.twig
+++ b/templates/front_signalement/_partial_step_info_problemes.html.twig
@@ -12,25 +12,19 @@
         </p>
     </div>
 
-    <div class="fr-form-group">
-        <div class="fr-select-group">
-            {{ form_label(form.dureeInfestation) }}
-            {{ form_widget(form.dureeInfestation) }}
-            <p class="fr-error-text fr-hidden">
-                Veuillez renseigner la durée d'infestation.
-            </p>
-        </div>
-    </div>
+    {% include 'common/components/form/list-radio-buttons.html.twig' with {
+        'name': 'dureeInfestation',
+        'displayLabel': true,
+        'formObject': form.dureeInfestation,
+        'errorLabel': 'Veuillez renseigner la durée d\'infestation.'
+    } %}
 
-    <div class="fr-form-group">
-        <div class="fr-select-group">
-            {{ form_label(form.infestationLogementsVoisins) }}
-            {{ form_widget(form.infestationLogementsVoisins) }}
-            <p class="fr-error-text fr-hidden">
-                Veuillez renseigner si il y a une infestation dans les logements voisins.
-            </p>
-        </div>
-    </div>
+    {% include 'common/components/form/list-radio-buttons.html.twig' with {
+        'name': 'infestationLogementsVoisins',
+        'displayLabel': true,
+        'formObject': form.infestationLogementsVoisins,
+        'errorLabel': 'Veuillez renseigner si il y a une infestation dans les logements voisins.'
+    } %}
 
     {% include 'front_signalement/_partial_signalement_navigation_container.html.twig' with {'next': 'Suivant', 'previous': 'Précédent' } %}
 {% endblock %}

--- a/templates/front_signalement/_partial_step_insectes_larves_oeufs.html.twig
+++ b/templates/front_signalement/_partial_step_insectes_larves_oeufs.html.twig
@@ -49,73 +49,127 @@
             </div>
         </div>
     </dialog>
-    
-    <div class="fr-form-group">
-        <div class="fr-select-group">
-            <label class="fr-label required">
+
+    <fieldset class="fr-fieldset" id="signalement_front_oeufsEtLarvesTrouves" aria-labelledby="signalement_front_oeufsEtLarvesTrouves_legend">
+        <legend class="fr-fieldset__legend--regular fr-fieldset__legend" id="signalement_front_oeufsEtLarvesTrouves_legend">
+            <label class="fr-label">
                 J'ai trouvé des <span class="underline">oeufs et larves</span>
                 <br>
                 <a href="#" class="info" data-fr-opened="false" aria-controls="fr-modal-oeufsetlarves">Plus d'informations</a>
             </label>
-            <div id="signalement_front_oeufsEtLarvesTrouves" class="fr-radio-group fr-mt-3v">
+        </legend>
+        <div class="fr-fieldset__element">
+            <div class="fr-radio-group">
                 <input type="radio" id="signalement_front_oeufsEtLarvesTrouves_0" name="signalement_front[oeufsEtLarvesTrouves]" required="required" value="true">
                 <label for="signalement_front_oeufsEtLarvesTrouves_0" class="required">Oui</label>
+            </div>
+        </div>
+        <div class="fr-fieldset__element">
+            <div class="fr-radio-group">
                 <input type="radio" id="signalement_front_oeufsEtLarvesTrouves_1" name="signalement_front[oeufsEtLarvesTrouves]" required="required" value="false">
                 <label for="signalement_front_oeufsEtLarvesTrouves_1" class="required">Non</label>
             </div>
-            <p class="fr-error-text fr-hidden">
-                Veuillez renseigner si vous avez trouvé des oeufs et larves.
-            </p>
         </div>
-    </div>
+        <p class="fr-error-text fr-hidden">
+            Veuillez renseigner si vous avez trouvé des oeufs et larves.
+        </p>
+    </fieldset>
 
-    <div id="form-group-oeufsEtLarvesNombrePiecesConcernees" class="fr-form-group">
-        <div class="fr-select-group">
-            <label class="fr-label required">Dans combien de pièces ?</label>
-            <div id="signalement_front_oeufsEtLarvesNombrePiecesConcernees" class="fr-radio-group">
-                <input type="radio" id="signalement_front_oeufsEtLarvesNombrePiecesConcernees_0" name="signalement_front[oeufsEtLarvesNombrePiecesConcernees]" required="required" value="1">
-                <label for="signalement_front_oeufsEtLarvesNombrePiecesConcernees_0" class="required">1 pièce</label>
-                <input type="radio" id="signalement_front_oeufsEtLarvesNombrePiecesConcernees_1" name="signalement_front[oeufsEtLarvesNombrePiecesConcernees]" required="required" value="2">
-                <label for="signalement_front_oeufsEtLarvesNombrePiecesConcernees_1" class="required">2 pièces ou +</label>
+    <div id="form-group-oeufsEtLarvesNombrePiecesConcernees">
+        <fieldset class="fr-fieldset" id="signalement_front_oeufsEtLarvesNombrePiecesConcernees" aria-labelledby="signalement_front_oeufsEtLarvesNombrePiecesConcernees_legend">
+            <legend class="fr-fieldset__legend--regular fr-fieldset__legend" id="signalement_front_oeufsEtLarvesNombrePiecesConcernees_legend">
+                <label class="fr-label">
+                    Dans combien de pièces ?
+                </label>
+            </legend>
+            <div class="fr-fieldset__element">
+                <div class="fr-radio-group">
+                    <input type="radio" id="signalement_front_oeufsEtLarvesNombrePiecesConcernees_0" name="signalement_front[oeufsEtLarvesNombrePiecesConcernees]" required="required" value="1">
+                    <label for="signalement_front_oeufsEtLarvesNombrePiecesConcernees_0" class="required">1 pièce</label>
+                </div>
+            </div>
+            <div class="fr-fieldset__element">
+                <div class="fr-radio-group">
+                    <input type="radio" id="signalement_front_oeufsEtLarvesNombrePiecesConcernees_1" name="signalement_front[oeufsEtLarvesNombrePiecesConcernees]" required="required" value="2">
+                    <label for="signalement_front_oeufsEtLarvesNombrePiecesConcernees_1" class="required">2 pièces ou +</label>
+                </div>
             </div>
             <p class="fr-error-text fr-hidden">
                 Veuillez renseigner le nombre de pièces concernées.
             </p>
-        </div>
+        </fieldset>
     </div>
 
-    <div id="form-group-oeufsEtLarvesFaciliteDetections" class="fr-form-group">
-        <div class="fr-select-group">
-            <label class="fr-label required">Je trouve les oeufs et les larves...</label>
-            <div id="signalement_front_oeufsEtLarvesFaciliteDetections" class="fr-radio-group">
-                <input type="radio" id="signalement_front_oeufsEtLarvesFaciliteDetections_0" name="signalement_front[oeufsEtLarvesFaciliteDetections]" required="required" value="FACILE">
-                <label for="signalement_front_oeufsEtLarvesFaciliteDetections_0" class="required">Facilement</label>
-                <input type="radio" id="signalement_front_oeufsEtLarvesFaciliteDetections_1" name="signalement_front[oeufsEtLarvesFaciliteDetections]" required="required" value="RECHERCHE">
-                <label for="signalement_front_oeufsEtLarvesFaciliteDetections_1" class="required">En cherchant bien</label>
+    <div id="form-group-oeufsEtLarvesFaciliteDetections">
+        <fieldset class="fr-fieldset" id="signalement_front_oeufsEtLarvesFaciliteDetections" aria-labelledby="signalement_front_oeufsEtLarvesFaciliteDetections_legend">
+            <legend class="fr-fieldset__legend--regular fr-fieldset__legend" id="signalement_front_oeufsEtLarvesFaciliteDetections_legend">
+                <label class="fr-label">
+                    Je trouve les oeufs et les larves...
+                </label>
+            </legend>
+            <div class="fr-fieldset__element">
+                <div class="fr-radio-group">
+                    <input type="radio" id="signalement_front_oeufsEtLarvesFaciliteDetections_0" name="signalement_front[oeufsEtLarvesFaciliteDetections]" required="required" value="FACILE">
+                    <label for="signalement_front_oeufsEtLarvesFaciliteDetections_0" class="required">Facilement</label>
+                </div>
+            </div>
+            <div class="fr-fieldset__element">
+                <div class="fr-radio-group">
+                    <input type="radio" id="signalement_front_oeufsEtLarvesFaciliteDetections_1" name="signalement_front[oeufsEtLarvesFaciliteDetections]" required="required" value="RECHERCHE">
+                    <label for="signalement_front_oeufsEtLarvesFaciliteDetections_1" class="required">En cherchant bien</label>
+                </div>
             </div>
             <p class="fr-error-text fr-hidden">
                 Veuillez renseigner comment vous trouvez les oeufs et les larves.
             </p>
-        </div>
+        </fieldset>
     </div>
 
     <div id="form-group-oeufsEtLarvesLieuxObservations" class="fr-form-group">
-        <div class="fr-select-group">
-            <label class="fr-label required">Je les vois sur...</label>
-            <div id="signalement_front_oeufsEtLarvesLieuxObservations" class="fr-checkbox-group">
-                <input type="checkbox" id="signalement_front_oeufsEtLarvesLieuxObservations_0" name="signalement_front[oeufsEtLarvesLieuxObservations][]" value="LIT">
-                <label for="signalement_front_oeufsEtLarvesLieuxObservations_0">Le lit</label>
-                <input type="checkbox" id="signalement_front_oeufsEtLarvesLieuxObservations_1" name="signalement_front[oeufsEtLarvesLieuxObservations][]" value="CANAPE">
-                <label for="signalement_front_oeufsEtLarvesLieuxObservations_1">Le canapé</label>
-                <input type="checkbox" id="signalement_front_oeufsEtLarvesLieuxObservations_2" name="signalement_front[oeufsEtLarvesLieuxObservations][]" value="MEUBLES">
-                <label for="signalement_front_oeufsEtLarvesLieuxObservations_2">Des meubles</label>
-                <input type="checkbox" id="signalement_front_oeufsEtLarvesLieuxObservations_3" name="signalement_front[oeufsEtLarvesLieuxObservations][]" value="MURS">
-                <label for="signalement_front_oeufsEtLarvesLieuxObservations_3">Les murs</label>
+        <fieldset class="fr-fieldset" id="signalement_front_oeufsEtLarvesLieuxObservations_checkboxes" aria-labelledby="signalement_front_oeufsEtLarvesLieuxObservations_legend">
+            <legend class="fr-fieldset__legend" id="signalement_front_oeufsEtLarvesLieuxObservations_legend">
+                Je les vois sur...
+                <br>
+                <em class="fr-fieldset__legend--regular">Plusieurs réponses possibles</em>
+            </legend>
+            <div id="signalement_front_oeufsEtLarvesLieuxObservations">
+                <div class="fr-fieldset__element">
+                    <div class="fr-checkbox-group">
+                        <input name="signalement_front[oeufsEtLarvesLieuxObservations][]" id="signalement_front_oeufsEtLarvesLieuxObservations_0" type="checkbox" value="LIT">
+                        <label for="signalement_front_oeufsEtLarvesLieuxObservations_0">
+                            Le lit
+                        </label>
+                    </div>
+                </div>
+                <div class="fr-fieldset__element">
+                    <div class="fr-checkbox-group">
+                        <input name="signalement_front[oeufsEtLarvesLieuxObservations][]" id="signalement_front_oeufsEtLarvesLieuxObservations_1" type="checkbox" value="CANAPE">
+                        <label for="signalement_front_oeufsEtLarvesLieuxObservations_1">
+                            Le canapé
+                        </label>
+                    </div>
+                </div>
+                <div class="fr-fieldset__element">
+                    <div class="fr-checkbox-group">
+                        <input name="signalement_front[oeufsEtLarvesLieuxObservations][]" id="signalement_front_oeufsEtLarvesLieuxObservations_2" type="checkbox" value="MEUBLES">
+                        <label for="signalement_front_oeufsEtLarvesLieuxObservations_2">
+                            Des meubles
+                        </label>
+                    </div>
+                </div>
+                <div class="fr-fieldset__element">
+                    <div class="fr-checkbox-group">
+                        <input name="signalement_front[oeufsEtLarvesLieuxObservations][]" id="signalement_front_oeufsEtLarvesLieuxObservations_3" type="checkbox" value="MURS">
+                        <label for="signalement_front_oeufsEtLarvesLieuxObservations_3">
+                            Les murs
+                        </label>
+                    </div>
+                </div>
             </div>
-            <p class="fr-error-text fr-hidden">
+            <p class="fr-error-text fr-messages-group fr-hidden">
                 Veuillez renseigner les endroits où vous les voyez.
             </p>
-        </div>
+        </fieldset>
     </div>
 
     {% include 'front_signalement/_partial_signalement_navigation_container.html.twig' with {'next': 'Suivant', 'previous': 'Précédent' } %}

--- a/templates/front_signalement/_partial_step_insectes_punaises.html.twig
+++ b/templates/front_signalement/_partial_step_insectes_punaises.html.twig
@@ -50,72 +50,126 @@
         </div>
     </dialog>
 
-    <div class="fr-form-group">
-        <div class="fr-select-group">
-            <label class="fr-label required">
+    <fieldset class="fr-fieldset" id="signalement_front_punaisesTrouvees" aria-labelledby="signalement_front_punaisesTrouvees_legend">
+        <legend class="fr-fieldset__legend--regular fr-fieldset__legend" id="signalement_front_punaisesTrouvees_legend">
+            <label class="fr-label">
                 Il y a des punaises dans mon logement
                 <br>
                 <a href="#" class="info" data-fr-opened="false" aria-controls="fr-modal-punaises">Plus d'informations</a>
             </label>
-            <div id="signalement_front_punaisesTrouvees" class="fr-radio-group fr-mt-3v">
+        </legend>
+        <div class="fr-fieldset__element">
+            <div class="fr-radio-group">
                 <input type="radio" id="signalement_front_punaisesTrouvees_0" name="signalement_front[punaisesTrouvees]" required="required" value="true">
                 <label for="signalement_front_punaisesTrouvees_0" class="required">Oui</label>
+            </div>
+        </div>
+        <div class="fr-fieldset__element">
+            <div class="fr-radio-group">
                 <input type="radio" id="signalement_front_punaisesTrouvees_1" name="signalement_front[punaisesTrouvees]" required="required" value="false">
                 <label for="signalement_front_punaisesTrouvees_1" class="required">Non</label>
             </div>
-            <p class="fr-error-text fr-hidden">
-                Veuillez renseigner si vous avez trouvé des punaises de lit.
-            </p>
         </div>
-    </div>
+        <p class="fr-error-text fr-hidden">
+            Veuillez renseigner si vous avez trouvé des punaises de lit.
+        </p>
+    </fieldset>
 
-    <div id="form-group-punaisesNombrePiecesConcernees" class="fr-form-group">
-        <div class="fr-select-group">
-            <label class="fr-label required">Dans combien de pièces ?</label>
-            <div id="signalement_front_punaisesNombrePiecesConcernees" class="fr-radio-group">
-                <input type="radio" id="signalement_front_punaisesNombrePiecesConcernees_0" name="signalement_front[punaisesNombrePiecesConcernees]" required="required" value="1">
-                <label for="signalement_front_punaisesNombrePiecesConcernees_0" class="required">1 pièce</label>
-                <input type="radio" id="signalement_front_punaisesNombrePiecesConcernees_1" name="signalement_front[punaisesNombrePiecesConcernees]" required="required" value="2">
-                <label for="signalement_front_punaisesNombrePiecesConcernees_1" class="required">2 pièces ou +</label>
+    <div id="form-group-punaisesNombrePiecesConcernees">
+        <fieldset class="fr-fieldset" id="signalement_front_punaisesNombrePiecesConcernees" aria-labelledby="signalement_front_punaisesNombrePiecesConcernees_legend">
+            <legend class="fr-fieldset__legend--regular fr-fieldset__legend" id="signalement_front_punaisesNombrePiecesConcernees_legend">
+                <label class="fr-label">
+                    Dans combien de pièces ?
+                </label>
+            </legend>
+            <div class="fr-fieldset__element">
+                <div class="fr-radio-group">
+                    <input type="radio" id="signalement_front_punaisesNombrePiecesConcernees_0" name="signalement_front[punaisesNombrePiecesConcernees]" required="required" value="1">
+                    <label for="signalement_front_punaisesNombrePiecesConcernees_0" class="required">1 pièce</label>
+                </div>
+            </div>
+            <div class="fr-fieldset__element">
+                <div class="fr-radio-group">
+                    <input type="radio" id="signalement_front_punaisesNombrePiecesConcernees_1" name="signalement_front[punaisesNombrePiecesConcernees]" required="required" value="2">
+                    <label for="signalement_front_punaisesNombrePiecesConcernees_1" class="required">2 pièces ou +</label>
+                </div>
             </div>
             <p class="fr-error-text fr-hidden">
                 Veuillez renseigner le nombre de pièces concernées.
             </p>
-        </div>
+        </fieldset>
     </div>
 
-    <div id="form-group-punaisesFaciliteDetections" class="fr-form-group">
-        <div class="fr-select-group">
-            <label class="fr-label required">Je trouve des punaises de lit...</label>
-            <div id="signalement_front_punaisesFaciliteDetections" class="fr-radio-group">
-                <input type="radio" id="signalement_front_punaisesFaciliteDetections_0" name="signalement_front[punaisesFaciliteDetections]" required="required" value="FACILE">
-                <label for="signalement_front_punaisesFaciliteDetections_0" class="required">Facilement</label>
-                <input type="radio" id="signalement_front_punaisesFaciliteDetections_1" name="signalement_front[punaisesFaciliteDetections]" required="required" value="RECHERCHE">
-                <label for="signalement_front_punaisesFaciliteDetections_1" class="required">En cherchant bien</label>
+    <div id="form-group-punaisesFaciliteDetections">
+        <fieldset class="fr-fieldset" id="signalement_front_punaisesFaciliteDetections" aria-labelledby="signalement_front_punaisesFaciliteDetections_legend">
+            <legend class="fr-fieldset__legend--regular fr-fieldset__legend" id="signalement_front_punaisesFaciliteDetections_legend">
+                <label class="fr-label">
+                    Je trouve des punaises de lit...
+                </label>
+            </legend>
+            <div class="fr-fieldset__element">
+                <div class="fr-radio-group">
+                    <input type="radio" id="signalement_front_punaisesFaciliteDetections_0" name="signalement_front[punaisesFaciliteDetections]" required="required" value="FACILE">
+                    <label for="signalement_front_punaisesFaciliteDetections_0" class="required">Facilement</label>
+                </div>
+            </div>
+            <div class="fr-fieldset__element">
+                <div class="fr-radio-group">
+                    <input type="radio" id="signalement_front_punaisesFaciliteDetections_1" name="signalement_front[punaisesFaciliteDetections]" required="required" value="RECHERCHE">
+                    <label for="signalement_front_punaisesFaciliteDetections_1" class="required">En cherchant bien</label>
+                </div>
             </div>
             <p class="fr-error-text fr-hidden">
                 Veuillez renseigner comment vous trouvez les punaises de lit.
             </p>
-        </div>
+        </fieldset>
     </div>
 
     <div id="form-group-punaisesLieuxObservations" class="fr-form-group">
-        <div class="fr-select-group">
-            <label class="fr-label required">Je les vois sur...</label>
-            <div id="signalement_front_punaisesLieuxObservations" class="fr-checkbox-group">
-                <input type="checkbox" id="signalement_front_punaisesLieuxObservations_0" name="signalement_front[punaisesLieuxObservations][]" value="LIT">
-                <label for="signalement_front_punaisesLieuxObservations_0">Le lit</label>
-                <input type="checkbox" id="signalement_front_punaisesLieuxObservations_1" name="signalement_front[punaisesLieuxObservations][]" value="CANAPE">
-                <label for="signalement_front_punaisesLieuxObservations_1">Le canapé</label>
-                <input type="checkbox" id="signalement_front_punaisesLieuxObservations_2" name="signalement_front[punaisesLieuxObservations][]" value="MEUBLES">
-                <label for="signalement_front_punaisesLieuxObservations_2">Des meubles</label>
-                <input type="checkbox" id="signalement_front_punaisesLieuxObservations_3" name="signalement_front[punaisesLieuxObservations][]" value="MURS">
-                <label for="signalement_front_punaisesLieuxObservations_3">Les murs</label>
+        <fieldset class="fr-fieldset" id="signalement_front_punaisesLieuxObservations_checkboxes" aria-labelledby="signalement_front_punaisesLieuxObservations_legend">
+            <legend class="fr-fieldset__legend" id="signalement_front_punaisesLieuxObservations_legend">
+                Je les vois sur...
+                <br>
+                <em class="fr-fieldset__legend--regular">Plusieurs réponses possibles</em>
+            </legend>
+            <div id="signalement_front_punaisesLieuxObservations">
+                <div class="fr-fieldset__element">
+                    <div class="fr-checkbox-group">
+                        <input name="signalement_front[punaisesLieuxObservations][]" id="signalement_front_punaisesLieuxObservations_0" type="checkbox" value="LIT">
+                        <label for="signalement_front_punaisesLieuxObservations_0">
+                            Le lit
+                        </label>
+                    </div>
+                </div>
+                <div class="fr-fieldset__element">
+                    <div class="fr-checkbox-group">
+                        <input name="signalement_front[punaisesLieuxObservations][]" id="signalement_front_punaisesLieuxObservations_1" type="checkbox" value="CANAPE">
+                        <label for="signalement_front_punaisesLieuxObservations_1">
+                            Le canapé
+                        </label>
+                    </div>
+                </div>
+                <div class="fr-fieldset__element">
+                    <div class="fr-checkbox-group">
+                        <input name="signalement_front[punaisesLieuxObservations][]" id="signalement_front_punaisesLieuxObservations_2" type="checkbox" value="MEUBLES">
+                        <label for="signalement_front_punaisesLieuxObservations_2">
+                            Des meubles
+                        </label>
+                    </div>
+                </div>
+                <div class="fr-fieldset__element">
+                    <div class="fr-checkbox-group">
+                        <input name="signalement_front[punaisesLieuxObservations][]" id="signalement_front_punaisesLieuxObservations_3" type="checkbox" value="MURS">
+                        <label for="signalement_front_punaisesLieuxObservations_3">
+                            Les murs
+                        </label>
+                    </div>
+                </div>
             </div>
-            <p class="fr-error-text fr-hidden">
+            <p class="fr-error-text fr-messages-group fr-hidden">
                 Veuillez renseigner les endroits où vous les voyez.
             </p>
-        </div>
+        </fieldset>
     </div>
 
     {% include 'front_signalement/_partial_signalement_navigation_container.html.twig' with {'next': 'Suivant', 'previous': 'Précédent' } %}

--- a/templates/front_signalement/_partial_step_traces_punaises_dejections.html.twig
+++ b/templates/front_signalement/_partial_step_traces_punaises_dejections.html.twig
@@ -51,73 +51,126 @@
         </div>
     </dialog>
 
-    <div class="fr-form-group">
-        <div class="fr-select-group">
-            <label class="fr-label required">
+    <fieldset class="fr-fieldset" id="signalement_front_dejectionsTrouvees" aria-labelledby="signalement_front_dejectionsTrouvees_legend">
+        <legend class="fr-fieldset__legend--regular fr-fieldset__legend" id="signalement_front_dejectionsTrouvees_legend">
+            <label class="fr-label">
                 J'ai trouvé des <span class="underline">déjections</span> de punaises
                 <br>
                 <a href="#" class="info" data-fr-opened="false" aria-controls="fr-modal-dejections">Plus d'informations</a>
             </label>
-            <div id="signalement_front_dejectionsTrouvees" class="fr-radio-group fr-mt-3v">
+        </legend>
+        <div class="fr-fieldset__element">
+            <div class="fr-radio-group">
                 <input type="radio" id="signalement_front_dejectionsTrouvees_0" name="signalement_front[dejectionsTrouvees]" required="required" value="true">
                 <label for="signalement_front_dejectionsTrouvees_0" class="required">Oui</label>
+            </div>
+        </div>
+        <div class="fr-fieldset__element">
+            <div class="fr-radio-group">
                 <input type="radio" id="signalement_front_dejectionsTrouvees_1" name="signalement_front[dejectionsTrouvees]" required="required" value="false">
                 <label for="signalement_front_dejectionsTrouvees_1" class="required">Non</label>
             </div>
-            <p class="fr-error-text fr-hidden">
-                Veuillez renseigner si vous avez trouvé des déjections.
-            </p>
         </div>
-    </div>
+        <p class="fr-error-text fr-hidden">
+            Veuillez renseigner si vous avez trouvé des déjections.
+        </p>
+    </fieldset>
 
-    <div id="form-group-dejectionsNombrePiecesConcernees" class="fr-form-group">
-        <div class="fr-select-group">
-            <label class="fr-label required">Dans combien de pièces ?</label>
-            <div id="signalement_front_dejectionsNombrePiecesConcernees" class="fr-radio-group">
-                <input type="radio" id="signalement_front_dejectionsNombrePiecesConcernees_0" name="signalement_front[dejectionsNombrePiecesConcernees]" required="required" value="1">
-                <label for="signalement_front_dejectionsNombrePiecesConcernees_0" class="required">1 pièce</label>
-                <input type="radio" id="signalement_front_dejectionsNombrePiecesConcernees_1" name="signalement_front[dejectionsNombrePiecesConcernees]" required="required" value="2">
-                <label for="signalement_front_dejectionsNombrePiecesConcernees_1" class="required">2 pièces ou +</label>
+    <div id="form-group-dejectionsNombrePiecesConcernees">
+        <fieldset class="fr-fieldset" id="signalement_front_dejectionsNombrePiecesConcernees" aria-labelledby="signalement_front_dejectionsNombrePiecesConcernees_legend">
+            <legend class="fr-fieldset__legend--regular fr-fieldset__legend" id="signalement_front_dejectionsNombrePiecesConcernees_legend">
+                <label class="fr-label">
+                    Dans combien de pièces ?
+                </label>
+            </legend>
+            <div class="fr-fieldset__element">
+                <div class="fr-radio-group">
+                    <input type="radio" id="signalement_front_dejectionsNombrePiecesConcernees_0" name="signalement_front[dejectionsNombrePiecesConcernees]" required="required" value="1">
+                    <label for="signalement_front_dejectionsNombrePiecesConcernees_0" class="required">1 pièce</label>
+                </div>
+            </div>
+            <div class="fr-fieldset__element">
+                <div class="fr-radio-group">
+                    <input type="radio" id="signalement_front_dejectionsNombrePiecesConcernees_1" name="signalement_front[dejectionsNombrePiecesConcernees]" required="required" value="2">
+                    <label for="signalement_front_dejectionsNombrePiecesConcernees_1" class="required">2 pièces ou +</label>
+                </div>
             </div>
             <p class="fr-error-text fr-hidden">
                 Veuillez renseigner le nombre de pièces concernées.
             </p>
-        </div>
+        </fieldset>
     </div>
 
-    <div id="form-group-dejectionsFaciliteDetections" class="fr-form-group">
-        <div class="fr-select-group">
-            <label class="fr-label required">Je trouve les déjections...</label>
-            <div id="signalement_front_dejectionsFaciliteDetections" class="fr-radio-group">
-                <input type="radio" id="signalement_front_dejectionsFaciliteDetections_0" name="signalement_front[dejectionsFaciliteDetections]" required="required" value="FACILE">
-                <label for="signalement_front_dejectionsFaciliteDetections_0" class="required">Facilement</label>
-                <input type="radio" id="signalement_front_dejectionsFaciliteDetections_1" name="signalement_front[dejectionsFaciliteDetections]" required="required" value="RECHERCHE">
-                <label for="signalement_front_dejectionsFaciliteDetections_1" class="required">En cherchant bien</label>
+    <div id="form-group-dejectionsFaciliteDetections">
+        <fieldset class="fr-fieldset" id="signalement_front_dejectionsFaciliteDetections" aria-labelledby="signalement_front_dejectionsFaciliteDetections_legend">
+            <legend class="fr-fieldset__legend--regular fr-fieldset__legend" id="signalement_front_dejectionsFaciliteDetections_legend">
+                <label class="fr-label">
+                    Je trouve les déjections...
+                </label>
+            </legend>
+            <div class="fr-fieldset__element">
+                <div class="fr-radio-group">
+                    <input type="radio" id="signalement_front_dejectionsFaciliteDetections_0" name="signalement_front[dejectionsFaciliteDetections]" required="required" value="FACILE">
+                    <label for="signalement_front_dejectionsFaciliteDetections_0" class="required">Facilement</label>
+                </div>
+            </div>
+            <div class="fr-fieldset__element">
+                <div class="fr-radio-group">
+                    <input type="radio" id="signalement_front_dejectionsFaciliteDetections_1" name="signalement_front[dejectionsFaciliteDetections]" required="required" value="RECHERCHE">
+                    <label for="signalement_front_dejectionsFaciliteDetections_1" class="required">En cherchant bien</label>
+                </div>
             </div>
             <p class="fr-error-text fr-hidden">
                 Veuillez renseigner comment vous trouvez les déjections.
             </p>
-        </div>
+        </fieldset>
     </div>
 
     <div id="form-group-dejectionsLieuxObservations" class="fr-form-group">
-        <div class="fr-select-group">
-            <label class="fr-label required">Je les vois sur...</label>
-            <em>Plusieurs réponses possibles</em>
-            <div id="signalement_front_dejectionsLieuxObservations" class="fr-checkbox-group">
-                <input type="checkbox" id="signalement_front_dejectionsLieuxObservations_0" name="signalement_front[dejectionsLieuxObservations][]" value="LIT">
-                <label for="signalement_front_dejectionsLieuxObservations_0">Le lit</label>
-                <input type="checkbox" id="signalement_front_dejectionsLieuxObservations_1" name="signalement_front[dejectionsLieuxObservations][]" value="CANAPE">
-                <label for="signalement_front_dejectionsLieuxObservations_1">Le canapé</label>
-                <input type="checkbox" id="signalement_front_dejectionsLieuxObservations_2" name="signalement_front[dejectionsLieuxObservations][]" value="MEUBLES">
-                <label for="signalement_front_dejectionsLieuxObservations_2">Des meubles</label>
-                <input type="checkbox" id="signalement_front_dejectionsLieuxObservations_3" name="signalement_front[dejectionsLieuxObservations][]" value="MURS">
-                <label for="signalement_front_dejectionsLieuxObservations_3">Les murs</label>
+        <fieldset class="fr-fieldset" id="signalement_front_dejectionsLieuxObservations_checkboxes" aria-labelledby="signalement_front_dejectionsLieuxObservations_legend">
+            <legend class="fr-fieldset__legend" id="signalement_front_dejectionsLieuxObservations_legend">
+                Je les vois sur...
+                <br>
+                <em class="fr-fieldset__legend--regular">Plusieurs réponses possibles</em>
+            </legend>
+            <div id="signalement_front_dejectionsLieuxObservations">
+                <div class="fr-fieldset__element">
+                    <div class="fr-checkbox-group">
+                        <input name="signalement_front[dejectionsLieuxObservations][]" id="signalement_front_dejectionsLieuxObservations_0" type="checkbox" value="LIT">
+                        <label for="signalement_front_dejectionsLieuxObservations_0">
+                            Le lit
+                        </label>
+                    </div>
+                </div>
+                <div class="fr-fieldset__element">
+                    <div class="fr-checkbox-group">
+                        <input name="signalement_front[dejectionsLieuxObservations][]" id="signalement_front_dejectionsLieuxObservations_1" type="checkbox" value="CANAPE">
+                        <label for="signalement_front_dejectionsLieuxObservations_1">
+                            Le canapé
+                        </label>
+                    </div>
+                </div>
+                <div class="fr-fieldset__element">
+                    <div class="fr-checkbox-group">
+                        <input name="signalement_front[dejectionsLieuxObservations][]" id="signalement_front_dejectionsLieuxObservations_2" type="checkbox" value="MEUBLES">
+                        <label for="signalement_front_dejectionsLieuxObservations_2">
+                            Des meubles
+                        </label>
+                    </div>
+                </div>
+                <div class="fr-fieldset__element">
+                    <div class="fr-checkbox-group">
+                        <input name="signalement_front[dejectionsLieuxObservations][]" id="signalement_front_dejectionsLieuxObservations_3" type="checkbox" value="MURS">
+                        <label for="signalement_front_dejectionsLieuxObservations_3">
+                            Les murs
+                        </label>
+                    </div>
+                </div>
             </div>
-            <p class="fr-error-text fr-hidden">
+            <p class="fr-error-text fr-messages-group fr-hidden">
                 Veuillez renseigner les endroits où vous les voyez.
             </p>
-        </div>
+        </fieldset>
     </div>
 
     {% include 'front_signalement/_partial_signalement_navigation_container.html.twig' with {'next': 'Suivant', 'previous': 'Précédent' } %}

--- a/templates/front_signalement/_partial_step_traces_punaises_piqures.html.twig
+++ b/templates/front_signalement/_partial_step_traces_punaises_piqures.html.twig
@@ -60,22 +60,23 @@
                 <a href="#" class="info" data-fr-opened="false" aria-controls="fr-modal-piqures">Plus d'informations</a>
             </label>
             <div class="fr-mt-3v">
-                {{ form_widget(form.piquresExistantes) }}
-                <p class="fr-error-text fr-hidden">
-                    Veuillez renseigner si vous avez des piqûres de punaises de lit.
-                </p>
+                {% include 'common/components/form/list-radio-buttons.html.twig' with {
+                    'name': 'piquresExistantes',
+                    'displayLabel': false,
+                    'formObject': form.piquresExistantes,
+                    'errorLabel': 'Veuillez renseigner si vous avez des piqûres de punaises de lit.'
+                } %}
             </div>
         </div>
     </div>
 
     <div id="form-group-piquresConfirmees" class="fr-form-group">
-        <div class="fr-select-group">
-            {{ form_label(form.piquresConfirmees) }}
-            {{ form_widget(form.piquresConfirmees) }}
-            <p class="fr-error-text fr-hidden">
-                Veuillez renseigner si quelqu'un a confirmé que vous avez des piqûres de punaises de lit.
-            </p>
-        </div>
+        {% include 'common/components/form/list-radio-buttons.html.twig' with {
+            'name': 'piquresConfirmees',
+            'displayLabel': true,
+            'formObject': form.piquresConfirmees,
+            'errorLabel': 'Veuillez renseigner si quelqu\'un a confirmé que vous avez des piqûres de punaises de lit.'
+        } %}
     </div>
 
     <div id="form-group-photos" class="fr-form-group">


### PR DESCRIPTION
## Ticket

#580    

## Description
Avec la mise à jour du DSFR, les boutons radio et cases à cocher n'avaient pas une bonne marge verticale.
De plus, quand on cliquait sur un bouton radio lui-même (pas son label), le dernier était toujours sélectionné.

## Tests
- [ ] Faire un signalement, en oubliant de cocher, vérifier qu'on est bloqué, vérifier le résumé à la fin, vérifier le signalement créé
