### PR TITLE
[Accessibilité - Menu] Modification de l'affichage de la page en cours

### DIFF
--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -124,9 +124,7 @@ span.statut-infestation {
                 margin-bottom: 6px;
 
                 &.active {
-                    a {
-                        color: var(--red-marianne-main-472);
-                    }
+                    border-left: 2px solid var(--text-action-high-blue-france);
                 }
     
                 a.fr-btn {
@@ -137,6 +135,17 @@ span.statut-infestation {
                     &.fr-icon-lock-line {
                         min-height: 1rem !important;
                     }
+                }
+            }
+        }
+    }
+}
+.fr-header {
+    .fr-header__tools-links {
+        ul.fr-btns-group {
+            li {
+                a[aria-current=page] {
+                    border-bottom: 1px solid var(--text-action-high-blue-france);
                 }
             }
         }

--- a/templates/common/header-back.html.twig
+++ b/templates/common/header-back.html.twig
@@ -28,19 +28,25 @@
                     <div class="fr-header__tools-links">
                         <ul class="fr-btns-group">
                             <li {% if app.request.get('_route') == 'app_dashboard_home' %} class="active"{% endif %}>
-                                <a class="fr-btn" href="{{ path('app_dashboard_home') }}">
+                                <a class="fr-btn" href="{{ path('app_dashboard_home') }}"
+                                    {% if app.request.get('_route') == 'app_dashboard_home' %}aria-current="page"{% endif %}
+                                    >
                                     Tableau de bord
                                 </a>
                             </li>
                             {% if is_granted('ROLE_ADMIN') %}
                             <li {% if app.request.get('_route') == 'app_cartographie' %} class="active"{% endif %}>
-                                <a class="fr-btn" href="{{ path('app_cartographie') }}">
+                                <a class="fr-btn" href="{{ path('app_cartographie') }}"
+                                    {% if app.request.get('_route') == 'app_cartographie' %}aria-current="page"{% endif %}
+                                    >
                                     Cartographie
                                 </a>
                             </li>
                             {% elseif is_granted('ROLE_ENTREPRISE') %}
                             <li>
-                                <a class="fr-btn" href="{{ path('app_entreprise_view',{uuid:app.user.entreprise.uuid}) }}">
+                                <a class="fr-btn" href="{{ path('app_entreprise_view',{uuid:app.user.entreprise.uuid}) }}"
+                                    {% if app.request.get('_route') == 'app_entreprise_view' %}aria-current="page"{% endif %}
+                                    >
                                     Mon entreprise
                                 </a>
                             </li>

--- a/templates/common/header.html.twig
+++ b/templates/common/header.html.twig
@@ -27,18 +27,24 @@
                 <div class="fr-header__tools">
                     <div class="fr-header__tools-links">
                         <ul class="fr-btns-group">
-                            <li {% if app.request.get('_route') == 'home' %} class="active"{% endif %}>
-                                <a class="fr-btn" href="{{ path('home') }}">
+                            <li {% if app.request.get('_route') == 'home' %}class="active"{% endif %}>
+                                <a class="fr-btn" href="{{ path('home') }}"
+                                    {% if app.request.get('_route') == 'home' %}aria-current="page"{% endif %}
+                                    >
                                     Accueil
                                 </a>
                             </li>
-                            <li {% if app.request.get('_route') == 'app_front_information' %} class="active"{% endif %}>
-                                <a class="fr-btn" href="{{ path('app_front_information') }}">
+                            <li {% if app.request.get('_route') == 'app_front_information' %}class="active"{% endif %}>
+                                <a class="fr-btn" href="{{ path('app_front_information') }}"
+                                    {% if app.request.get('_route') == 'app_front_information' %}aria-current="page"{% endif %}
+                                    >
                                     Informations
                                 </a>
                             </li>
-                            <li {% if app.request.get('_route') == 'app_front_contact' %} class="active"{% endif %}>
-                                <a class="fr-btn" href="{{ path('app_front_contact') }}">
+                            <li {% if app.request.get('_route') == 'app_front_contact' %}class="active"{% endif %}>
+                                <a class="fr-btn" href="{{ path('app_front_contact') }}"
+                                    {% if app.request.get('_route') == 'app_front_contact' %}aria-current="page"{% endif %}
+                                    >
                                     Contact
                                 </a>
                             </li>
@@ -47,19 +53,14 @@
                                 {% if app.user %}
                                     <a class="fr-btn fr-icon-user-line" href="{{ path('app_dashboard_home') }}">Tableau de bord</a>
                                 {% else %}
-                                    <a class="fr-btn fr-icon-lock-line" href="{{ path('app_login') }}">
+                                    <a class="fr-btn fr-icon-lock-line" href="{{ path('app_login') }}"
+                                        {% if app.request.get('_route') == 'app_login' %}aria-current="page"{% endif %}
+                                        >
                                         Espace pro
                                     </a>
                                 {% endif %}
                             </li>
                         </ul>
-                    </div>
-                    <div class="fr-header__search fr-modal" id="modal-575">
-                        <div class="fr-container fr-container-lg--fluid">
-                            <button class="fr-btn--close fr-btn" aria-controls="modal-575" title="Fermer">
-                                Fermer
-                            </button>
-                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Ticket

#583   

## Description
Actuellement :
- sur desktop, la page en cours n'est pas mise en avant
- sur mobile, la page en cours est colorée en rouge

L'auditeur propose d'utiliser le composant de [Navigation principale](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/navigation-principale/).
Mais nous utilisons le composant [Entête](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/en-tete) qui me semble plus approprié. Je reviendrai vers lui à ce sujet.

J'ai donc apporté une micro-modification css pour
- souligner la page en cours sur desktop
- mettre une bordure à gauche sur mobile

## Tests
- [ ] Tester différentes pages sur desktop et mobile et vérifier l'affichage de la page en cours
