### PR TITLE
[Accessibilité - Liens externes] Ajout de titres pour indiquer l'ouverture dans une nouvelle fenêtre

### DIFF
--- a/templates/common/footer.html.twig
+++ b/templates/common/footer.html.twig
@@ -15,16 +15,16 @@
             <div class="fr-footer__content">
                 <ul class="fr-footer__content-list">
                     <li class="fr-footer__content-item">
-                        <a class="fr-footer__content-link" target="_blank" rel="noopener" href="https://legifrance.gouv.fr">legifrance.gouv.fr</a>
+                        <a class="fr-footer__content-link" target="_blank" rel="noopener" href="https://legifrance.gouv.fr" title="legifrance.gouv.fr - nouvelle fenêtre">legifrance.gouv.fr</a>
                     </li>
                     <li class="fr-footer__content-item">
-                        <a class="fr-footer__content-link" target="_blank" rel="noopener" href="https://gouvernement.fr">gouvernement.fr</a>
+                        <a class="fr-footer__content-link" target="_blank" rel="noopener" href="https://gouvernement.fr" title="gouvernement.fr - nouvelle fenêtre">gouvernement.fr</a>
                     </li>
                     <li class="fr-footer__content-item">
-                        <a class="fr-footer__content-link" target="_blank" rel="noopener" href="https://service-public.fr">service-public.fr</a>
+                        <a class="fr-footer__content-link" target="_blank" rel="noopener" href="https://service-public.fr" title="service-public.fr - nouvelle fenêtre">service-public.fr</a>
                     </li>
                     <li class="fr-footer__content-item">
-                        <a class="fr-footer__content-link" target="_blank" rel="noopener" href="https://data.gouv.fr">data.gouv.fr</a>
+                        <a class="fr-footer__content-link" target="_blank" rel="noopener" href="https://data.gouv.fr" title="data.gouv.fr - nouvelle fenêtre">data.gouv.fr</a>
                     </li>
                 </ul>
             </div>
@@ -51,15 +51,17 @@
                 </li>
                 <li class="fr-footer__bottom-item">
                     <a class="fr-footer__bottom-link" target="_blank" rel="noreferrer noopener"
-                        href="https://github.com/MTES-MCT/stop-punaises">Code source
+                        href="https://github.com/MTES-MCT/stop-punaises" title="github.com - nouvelle fenêtre">Code source
                     </a>
                 </li>
             </ul>
             <div class="fr-footer__bottom-copy">
                 <p>
-                    Sauf mention contraire, tous les contenus de ce site sont sous <a href="https://github.com/etalab/licence-ouverte/blob/master/LO.md" target="_blank" rel="noopener">licence etalab-2.0</a>
+                    Sauf mention contraire, tous les contenus de ce site sont sous 
+                    <a href="https://github.com/etalab/licence-ouverte/blob/master/LO.md" target="_blank" rel="noopener" title="github.com - nouvelle fenêtre">licence etalab-2.0</a>
                     <br>
-                    Les éléments graphiques sont mis à disposition par la direction de la communication du <a href="https://www.ecologie.gouv.fr/" target="_blank" rel="noopener">Ministère de la Transition Ecologique</a>.
+                    Les éléments graphiques sont mis à disposition par la direction de la communication du 
+                    <a href="https://www.ecologie.gouv.fr/" target="_blank" rel="noopener" title="ecologie.gouv.fr - nouvelle fenêtre">Ministère de la Transition Ecologique</a>.
                 </p>
             </div>
         </div>


### PR DESCRIPTION
## Ticket

#582   

## Description
Ajout d'information sur les liens externes pour que les aides techniques puissent signaler le changement de contexte

**Liste des liens concernés**
- legifrance.gouv.fr
- gouvernement.fr
- service-public.fr
- data.gouv.fr
- Code source
- licence etalab-2.0
- Ministère de la Transition Ecologique

## Tests
- [ ] Vérifier l'attribut "title" au survol des liens externes
