### PR TITLE
[Accessibilité - Logo header] Ajout d'un focus lors de la navigation au clavier

### DIFF
--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -113,6 +113,12 @@ span.statut-infestation {
 }
 
 .fr-header {
+    .fr-header__operator {
+        a {
+            outline-width: 1px;
+            outline-offset: 3px;
+        }
+    }
     .fr-header__menu-links {
         &::after {
             display: none;


### PR DESCRIPTION
## Ticket

#584    

## Description
Bug dans le DSFR : lors de la navigation clavier, il n'y a pas de focus sur le logo Punaises.
J'ai rajouté une règle css pour le gérer.

## Pré-requis
`npm run watch`

## Tests
- [ ] Tester la navigation au clavier et vérifier l'affichage du focus
