### PR TITLE
[Accessibilité] Amélioration des liens sur les pages Accueil, Information et Contact

### DIFF
--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -64,6 +64,9 @@ span.statut-infestation {
 .align-justify {
     text-align: justify;
 }
+.align-left {
+    text-align: left;
+}
 .align-right {
     text-align: right;
 }

--- a/templates/common/footer.html.twig
+++ b/templates/common/footer.html.twig
@@ -6,7 +6,7 @@
                     République
                     <br>Française
                 </p>
-                <a class="fr-footer__brand-link" href="{{ path('home') }}" title="Accueil - Stop punaises - Ministère de la transition écologique et de la cohésion des territoires">
+                <a class="fr-footer__brand-link" href="{{ path('home') }}" title="Accueil - Stop punaises - République Française">
                     <p class="fr-header__service-title">
                         <img src="{{ asset('build/images/logo-stop-punaises.svg') }}" alt="Stop punaises" width="90">
                     </p>

--- a/templates/common/header-back.html.twig
+++ b/templates/common/header-back.html.twig
@@ -11,7 +11,7 @@
                             </p>
                         </div>
                         <div class="fr-header__operator">
-                            <a href="{{ path('home') }}" title="Accueil - Stop punaises - Ministère de la transition écologique et de la cohésion des territoires">
+                            <a href="{{ path('home') }}" title="Accueil - Stop punaises - République Française">
                                 <p class="fr-header__service-title">
                                     <img src="{{ asset('build/images/logo-stop-punaises.svg') }}" alt="Stop punaises" width="90">
                                 </p>

--- a/templates/common/header.html.twig
+++ b/templates/common/header.html.twig
@@ -11,7 +11,7 @@
                             </p>
                         </div>
                         <div class="fr-header__operator">
-                            <a href="{{ path('home') }}" title="Accueil - Stop punaises - Ministère de la transition écologique et de la cohésion des territoires">
+                            <a href="{{ path('home') }}" title="Accueil - Stop punaises - République Française">
                                 <p class="fr-header__service-title">
                                     <img src="{{ asset('build/images/logo-stop-punaises.svg') }}" alt="Stop punaises" width="90">
                                 </p>

--- a/templates/front/contact.html.twig
+++ b/templates/front/contact.html.twig
@@ -26,9 +26,9 @@
                     Pour toute question appelez le&nbsp;:
                 </p>
                 <p>
-                    <a href="tel:+33806706806" title="Appeler le service Info logement indigne"><span class="fr-icon-phone-fill">0806 706 806</span></a>
+                    <a href="tel:+33806706806" title="Appeler le 0806 706 806 (prix d’un appel local)"><span class="fr-icon-phone-fill">0806 706 806</span></a>
                     <br>
-                    <span class="local-phone-price">Prix d'un appel local</span>
+                    <span class="local-phone-price" aria-hidden="true">Prix d'un appel local</span>
                 </p>
             </div>
 

--- a/templates/front/index.html.twig
+++ b/templates/front/index.html.twig
@@ -35,7 +35,7 @@
                         Dans tous les cas, il faut agir vite pour éviter leur prolifération dans le foyer.
                     </p>
                     <p class="button-container">
-                        <a class="fr-link" href="{{ path('app_front_information') }}">En savoir plus</a>
+                        <a class="fr-link" href="{{ path('app_front_information') }}">Tout savoir sur les punaises de lit</a>
                     </p>
                 </div>
                 <div class="fr-col-12 fr-col-lg-6 video-container fr-mt-3w">
@@ -69,9 +69,8 @@
                         Les punaises de lit peuvent infester n'importe qui et il est parfois compliqué de savoir d'où elles viennent.
                     </p>
                     <p>
-                        D'après <a href="https://www.anses.fr/fr/system/files/BIOCIDES2021SA0147Ra.pdf" target="_blank" rel="noopener">le rapport de l'Anses (6,3 Mo)</a> 
-                        (l’Agence nationale de sécurité sanitaire de l’alimentation, de l’environnement et du travail) publié en juillet 2023, 
-                        11 % des ménages français auraient été infestés par les punaises de lit entre 2017 et 2022.
+                        D'après <a href="https://www.anses.fr/fr/system/files/BIOCIDES2021SA0147Ra.pdf" target="_blank" rel="noopener">le rapport de l'Anses, l’Agence nationale de sécurité sanitaire de l’alimentation, de l’environnement et du travail (PDF – 6,3 Mo)</a> 
+                        publié en juillet 2023, 11 % des ménages français auraient été infestés par les punaises de lit entre 2017 et 2022.
                         <br>
                         L'Anses ajoute « qu'un faible niveau de revenu ne serait pas lié à un risque supérieur d’infestation par des punaises de lit ».
                     </p>

--- a/templates/front/information.html.twig
+++ b/templates/front/information.html.twig
@@ -247,16 +247,57 @@
                 <div class="fr-col-12 fr-col-lg-4">
                     <figure class="fr-content-media" role="group" aria-label="Où se cachent les punaises de lit ?">
                         <div class="fr-content-media__img">
-                            <a href="{{ asset('build/images/flyer-ou-se-cachent-elles.jpg') }}" target="_blank" rel="noopener" title="Voir l'image : Où se cachent les punaises de lit ?">
-                                <img src="{{ asset('build/images/flyer-ou-se-cachent-elles-resize.jpg') }}"  width="500" height="954"
-                                    alt="Où se cachent les punaises de lit ? Dans la chambre, dans les matelas et sommiers. Derrière les cadres, les raccords de papier peint, sous les meubles, dans les plinthes, sous les prises électriques. Dans les fissures et les fentes du parquet. Dans les canapés. Sous les tapis."
-                                    >
-                            </a>
+                            <img src="{{ asset('build/images/flyer-ou-se-cachent-elles-resize.jpg') }}" width="500" height="954"
+                                alt="Où se cachent les punaises de lit ? Dans la chambre, dans les matelas et sommiers. Derrière les cadres, les raccords de papier peint, sous les meubles, dans les plinthes, sous les prises électriques. Dans les fissures et les fentes du parquet. Dans les canapés. Sous les tapis."
+                                >
                         </div>
                         <figcaption class="fr-content-media__caption">Crédit : Citizen</figcaption>
-                        <br>
-                        <span class="click-to-expand">Cliquez sur l'image pour l'agrandir</span>
+                        <button class="fr-btn"  data-fr-opened="false" aria-controls="fr-modal-flyer-cache">
+                            Agrandir l'image
+                        </button>
                     </figure>
+                    <dialog aria-labelledby="fr-modal-title-modal-flyer-cache" role="dialog" id="fr-modal-flyer-cache" class="fr-modal">
+                        <div class="fr-container fr-container--fluid fr-container-md">
+                            <div class="fr-grid-row fr-grid-row--center">
+                                <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
+                                    <div class="fr-modal__body">
+                                        <div class="fr-modal__header">
+                                            <button class="fr-btn--close fr-btn" title="Fermer la fenêtre modale" aria-controls="fr-modal-flyer-cache">Fermer</button>
+                                        </div>
+                                        <div class="fr-modal__content">
+                                            <h1 id="fr-modal-title-modal-flyer-cache" class="fr-modal__title">Punaises de lit : où se cachent-elles ?</h1>
+                                            <figure class="fr-content-media" role="group" aria-label="Où se cachent les punaises de lit ?">
+                                                <div class="fr-content-media__img">
+                                                    <img src="{{ asset('build/images/flyer-ou-se-cachent-elles.jpg') }}"
+                                                        alt="Où se cachent les punaises de lit ? Dans la chambre, dans les matelas et sommiers. Derrière les cadres, les raccords de papier peint, sous les meubles, dans les plinthes, sous les prises électriques. Dans les fissures et les fentes du parquet. Dans les canapés. Sous les tapis."
+                                                        >
+                                                </div>
+                                                <figcaption class="fr-content-media__caption align-left">
+                                                    Punaises de lit : où se cachent-elles ?
+                                                    <br>
+                                                    Les punaises de lit sont visibles à l'oeil nu et sont généralement brunes.
+                                                    <br>
+                                                    L'adulte a les dimensions d'un pépin de pomme. L'oeuf, de couleur blanche, mesure environ 1mm. Elles ne sautent pas et ne volent pas.
+                                                    <br>
+                                                    La chambre, leur espace préféré.
+                                                    <br>
+                                                    On les trouve en grande majorité :
+                                                    <br>
+                                                    <ul>
+                                                        <li>dans les matelas et sommiers qu'il ne faut pas hésiter à retourner pour une inspection complète</li>
+                                                        <li>derrière les cadres, les raccords de papier peint, sous les meubles, dans les plinthes, sous les prises électriques...</li>
+                                                        <li>dans les fissures et les fentes du parquet</li>
+                                                        <li>dans les canapés</li>
+                                                        <li>sous les tapis</li>
+                                                    </ul>
+                                                </figcaption>
+                                            </figure>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </dialog>
                 </div>
             </div>
         </div>
@@ -499,16 +540,53 @@
                 <div class="fr-col-12 fr-col-lg-4">
                     <figure class="fr-content-media" role="group" aria-label="Comment éviter les punaises de lit ?">
                         <div class="fr-content-media__img">
-                            <a href="{{ asset('build/images/flyer-comment-les-eviter.jpg') }}" target="_blank" rel="noopener" title="Voir l'image : Comment éviter les punaises de lit ?">
-                                <img src="{{ asset('build/images/flyer-comment-les-eviter.jpg') }}" width="500" height="954"
-                                    alt="Comment éviter les punaises de lit ? En voyage, ne posez pas votre bagage sur le lit, encore moins sous le lit. Contrôlez vos effets personnels à votre retour. Evitez d'encombrer les espaces. Attention aux achats d'occasion, lavez-les à 60°C. Nettoyez les meubles récupérés."
-                                    >
-                            </a>
+                            <img src="{{ asset('build/images/flyer-comment-les-eviter.jpg') }}" width="500" height="954"
+                                alt="Comment éviter les punaises de lit ? En voyage, ne posez pas votre bagage sur le lit, encore moins sous le lit. Contrôlez vos effets personnels à votre retour. Evitez d'encombrer les espaces. Attention aux achats d'occasion, lavez-les à 60°C. Nettoyez les meubles récupérés."
+                                >
                         </div>
                         <figcaption class="fr-content-media__caption">Crédit : Citizen</figcaption>
-                        <br>
-                        <span class="click-to-expand">Cliquez sur l'image pour l'agrandir</span>
+                        <button class="fr-btn"  data-fr-opened="false" aria-controls="fr-modal-flyer-eviter">
+                            Agrandir l'image
+                        </button>
                     </figure>
+                    <dialog aria-labelledby="fr-modal-title-modal-flyer-eviter" role="dialog" id="fr-modal-flyer-eviter" class="fr-modal">
+                        <div class="fr-container fr-container--fluid fr-container-md">
+                            <div class="fr-grid-row fr-grid-row--center">
+                                <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
+                                    <div class="fr-modal__body">
+                                        <div class="fr-modal__header">
+                                            <button class="fr-btn--close fr-btn" title="Fermer la fenêtre modale" aria-controls="fr-modal-flyer-eviter">Fermer</button>
+                                        </div>
+                                        <div class="fr-modal__content">
+                                            <h1 id="fr-modal-title-modal-flyer-eviter" class="fr-modal__title">Punaises de lit : comment les éviter ?</h1>
+                                            <figure class="fr-content-media" role="group" aria-label="Comment éviter les punaises de lit ?">
+                                                <div class="fr-content-media__img">
+                                                    <img src="{{ asset('build/images/flyer-comment-les-eviter.jpg') }}"
+                                                        alt="Comment éviter les punaises de lit ? En voyage, ne posez pas votre bagage sur le lit, encore moins sous le lit. Contrôlez vos effets personnels à votre retour. Evitez d'encombrer les espaces. Attention aux achats d'occasion, lavez-les à 60°C. Nettoyez les meubles récupérés."
+                                                        >
+                                                </div>
+                                                <figcaption class="fr-content-media__caption align-left">
+                                                    Punaises de lit : comment les éviter ?
+                                                    <br>
+                                                    Des gestes de prévention simples permettent de limiter leur venue ou installation.
+                                                    <br>
+                                                    En voyageant, soyez vigilants :
+                                                    <br>
+                                                    <ul>
+                                                        <li>Ne posez pas votre bagage sur le lit et encore moins sous le lit</li>
+                                                        <li>Contrôlez vos effets personnels à votre retour</li>
+                                                        <li>Evitez d'encombrer les espaces</li>
+                                                        <li>Attention aux achats d'occasion. Lavez bien les vêtements à 60°C.</li>
+                                                        <li>Nettoyez les meubles récupérés</li>
+                                                    </ul>
+                                                </figcaption>
+                                            </figure>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </dialog>
                 </div>
             </div>
         </div>
@@ -524,9 +602,9 @@
             Pour toute question appelez le&nbsp;:
         </p>
         <p>
-            <a href="tel:+33806706806" title="Appeler le service Info logement indigne"><span class="fr-icon-phone-fill">0806 706 806</span></a>
+            <a href="tel:+33806706806" title="Appeler le 0806 706 806 (prix d’un appel local)"><span class="fr-icon-phone-fill">0806 706 806</span></a>
             <br>
-            <span class="local-phone-price">Prix d'un appel local</span>
+            <span class="local-phone-price" aria-hidden="true">Prix d'un appel local</span>
         </p>
     </section>
 


### PR DESCRIPTION
## Ticket

#586
#591
#599

## Description
Amélioration des liens sur les pages Accueil, Information et Contact

## Tests
- [ ] Header/Footer : Attribut title sur les logos fait apparaitre "République Française" plutôt que le ministère
- [ ] Accueil : Lien "en savoir plus" est renommé "Tout savoir sur les punaises de lit"
- [ ] Accueil : Lien ok pour le rapport de l'Anses
- [ ] Contact : Lien pour appeler l'ADIL est ok
- [ ] Informations : Lien pour appeler l'ADIL est ok
- [ ] Informations : Les grosses images à droite s'affichent correctement sur la page, dans la modale et en responsive, avec la bonne transcription
