### PR TITLE
[Accessibilité] Remplacement des doubles balises br, amélioration structure titres page Contact

### DIFF
--- a/assets/controllers/form_signalement_erp_transport.js
+++ b/assets/controllers/form_signalement_erp_transport.js
@@ -91,7 +91,7 @@ function handleFileUpload() {
                 let imgSrc = URL.createObjectURL(event.target.files[i]);
                 let strAppend = '<div class="fr-col-6 fr-col-md-3" style="text-align: center;">';
                 strAppend += '<img src="' + imgSrc + '" width="100" height="100">';
-                strAppend += '<br><br><button type="button" data-filename="' + filename  +'" class="fr-link fr-icon-close-circle-line fr-link--icon-left link--error file-uploaded"> Supprimer </button>';
+                strAppend += '<br><button type="button" data-filename="' + filename  +'" class="fr-link fr-icon-close-circle-line fr-link--icon-left link--error file-uploaded"> Supprimer </button>';
                 strAppend += '</div>';
                 $('.fr-front-signalement-photos').append(strAppend);
                 filesUploaded.push(event.target.files[i]);

--- a/templates/front/contact.html.twig
+++ b/templates/front/contact.html.twig
@@ -17,6 +17,8 @@
             <h1 class="fr-col-11 fr-col-md-8">Contact</h1>
 
             <div class="information-contact fr-col-11 fr-col-md-8">
+                <h2 class="fr-h6">Service Info logement indigne</h2>
+
                 <p class="all-questions">
                     Le réseau des ADIL vous informe gratuitement sur toutes les problématiques logement et habitat.
                 </p>

--- a/templates/front/contact.html.twig
+++ b/templates/front/contact.html.twig
@@ -17,13 +17,13 @@
             <h1 class="fr-col-11 fr-col-md-8">Contact</h1>
 
             <div class="information-contact fr-col-11 fr-col-md-8">
+                <p class="all-questions">
+                    Le réseau des ADIL vous informe gratuitement sur toutes les problématiques logement et habitat.
+                </p>
+                <p class="all-questions">
+                    Pour toute question appelez le&nbsp;:
+                </p>
                 <p>
-                    <span class="all-questions">
-                        Le réseau des ADIL vous informe gratuitement sur toutes les problématiques logement et habitat.
-                        <br><br>
-                        Pour toute question appelez le&nbsp;:
-                    </span>
-                    <br>
                     <a href="tel:+33806706806" title="Appeler le service Info logement indigne"><span class="fr-icon-phone-fill">0806 706 806</span></a>
                     <br>
                     <span class="local-phone-price">Prix d'un appel local</span>
@@ -39,7 +39,8 @@
                 le formulaire de contact ne permet pas de déposer un signalement.
                 Si vous souhaitez signaler un problème de logement, remplissez
                 <a href="{{ path('app_front_signalement_type_list') }}">le formulaire de signalement</a>.
-                <br><br>
+            </p>
+            <p class="fr-col-11 fr-col-md-8">
                 Tous les champs sont obligatoires.
             </p>
 

--- a/templates/front/index.html.twig
+++ b/templates/front/index.html.twig
@@ -219,9 +219,11 @@
                 <div class="fr-col-12 fr-col-md-8">
                     <p>
                         En mars 2021, le gouvernement a lancé un plan national de lutte contre les infestations de punaises de lit.
-                        <br><br>
+                    </p>
+                    <p>
                         Stop-punaises.beta.gouv.fr est une plateforme numérique de l’Etat en cours de déploiement national.
-                        <br><br>
+                    </p>
+                    <p>
                         Elle est propulsée par le programme beta.gouv, sous la gouvernance du Ministère de la Transition Écologique et de la Cohésion des Territoires.
                     </p>
                 </div>

--- a/templates/front/information.html.twig
+++ b/templates/front/information.html.twig
@@ -517,13 +517,13 @@
 
     <section class="information-contact fr-mt-3w fr-mt-md-5w fr-py-3w">
         <h2>Vous n'avez pas trouvé la réponse à votre question ?</h2>
+        <p class="all-questions">
+            Le réseau des ADIL vous informe gratuitement sur toutes les problématiques logement et habitat.
+        </p>
+        <p class="all-questions">
+            Pour toute question appelez le&nbsp;:
+        </p>
         <p>
-            <span class="all-questions">
-                Le réseau des ADIL vous informe gratuitement sur toutes les problématiques logement et habitat.
-                <br><br>
-                Pour toute question appelez le&nbsp;:
-            </span>
-            <br>
             <a href="tel:+33806706806" title="Appeler le service Info logement indigne"><span class="fr-icon-phone-fill">0806 706 806</span></a>
             <br>
             <span class="local-phone-price">Prix d'un appel local</span>

--- a/templates/front/politique-de-confidentialite.html.twig
+++ b/templates/front/politique-de-confidentialite.html.twig
@@ -114,10 +114,11 @@
                 </ul>
                 <p>Pour les exercer, contactez-nous :
                     Email : <a href="mailto:dpd.daj.sg@developpement-durable.gouv.fr">dpd.daj.sg@developpement-durable.gouv.fr</a>
-                    <br><br>
                 </p>
-                <address>
-                    Ou par voie postale :<br><br>
+                <p>
+                    Ou par voie postale :
+                </p>
+                <address class="fr-pb-5v">
                     Ministère de la Transition écologique et solidaire<br>
                     Direction Générale de l’Aménagement, du Logement et de la Nature<br>
                     Direction de l’habitat, de l’urbanisme et des paysages<br>

--- a/templates/security/reset_password_link_sent.html.twig
+++ b/templates/security/reset_password_link_sent.html.twig
@@ -13,7 +13,8 @@
                 <p>
                     Vous allez recevoir un email d'ici quelques minutes.
                     Cliquez sur le lien dans l'email pour réinitialiser votre mot de passe.
-                    <br><br>
+                </p>
+                <p>
                     <em>
                         Ce courriel à été envoyé à l'adresse&nbsp;:
                         <br>


### PR DESCRIPTION
## Ticket

#587
#590 

## Description
L'auditeur accessibilité 
- déconseille d'utiliser des doubles balises de sauts de ligne pour l'affichage, mais plutôt diviser en plusieurs paragraphes quand nécessaire.
- conseille d'utiliser un titre de deuxième niveau sur la première zone de la page Contact

## Tests
- [ ] Vérifier l'affichage sur la page d'accueil, d'informations, de contact, de politique de confidentialité, de renouvellement de mot de passe
- [ ] Vérifier l'affichage du deuxième titre sur la page contact
