### PR TITLE
[Accessibilité] Amélioration liens d'echappement sur toutes les pages, et responsive sur Mentions légales

### DIFF
--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -600,6 +600,11 @@ span.image-caption {
             display: none;
         }
     }
+
+    .word-wrap {
+        word-wrap: break-word;
+        hyphens: auto;
+    }
 }
 @media (min-width: 768px) {
     .information-comment-reconnaitre-infestation, .information-comment-eviter {

--- a/templates/base-back.html.twig
+++ b/templates/base-back.html.twig
@@ -48,9 +48,9 @@
             {% endfor %}
         {% endfor %}
         
-        <div id="contenu">
+        <main role="main" id="contenu" tabindex="-1">
         {% block body %}{% endblock %}
-        </div>
+        </main>
         
         {% block javascripts %}
             {% if 'app_cartographie' in app.request.get('_route') %}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -30,9 +30,9 @@
         {% include "common/skiplink.html.twig" %}
         {% include "common/header.html.twig" %}
 
-        <div id="contenu">
+        <main role="main" id="contenu" tabindex="-1">
         {% block body %}{% endblock %}
-        </div>
+        </main>
 
         {% include "common/footer.html.twig" %}
     </body>

--- a/templates/common/footer.html.twig
+++ b/templates/common/footer.html.twig
@@ -1,4 +1,4 @@
-<footer class="fr-footer" role="contentinfo" id="footer">
+<footer class="fr-footer" role="contentinfo" id="footer" tabindex="-1">
     <div class="fr-container">
         <div class="fr-footer__body">
             <div class="fr-footer__brand fr-enlarge-link">

--- a/templates/front/mentions-legales.html.twig
+++ b/templates/front/mentions-legales.html.twig
@@ -266,50 +266,54 @@
 
         <h3>6.5 – Durée de conservation des traitements de données</h3>
 
-        <table>
-            <thead>
-                <tr>
-                    <td style="text-align: center; font-weight: bold;">Données</td>
-                    <td style="text-align: center; font-weight: bold;">Durées de conversation</td>
-                </tr>
-            </thead>
-            <tbody>
-                <tr>
-                    <td>
-                        Données relatives au signalement du problème d’infestation de punaises de lit
-                    </td>
-                    <td>
-                        5 ans à compter de la fin de la prise en charge du problème par l’entreprise/le partenaire.
-                        <br>
-                        Stop-Punaises utilise ces données pour détecter des signalements sur une même adresse ou une même zone.
-                    </td>
-                </tr>
-                <tr>
-                    <td>
-                        Données de création de compte et relatives au suivi du problème d’habitat
-                    </td>
-                    <td>
-                        2 ans à compter de la suppression du compte 
-                    </td>
-                </tr>
-                <tr>
-                    <td>
-                        Données de connexion 
-                    </td>
-                    <td>
-                        1 an
-                    </td>
-                </tr>
-                <tr>
-                    <td>
-                        Cookies
-                    </td>
-                    <td>
-                        13 mois ou jusqu’au retrait du consentement de la personne concernée 
-                    </td>
-                </tr>
-            </tbody>
-        </table>
+
+        <div class="fr-table">
+            <table>
+                <caption>Durée de conservation</caption>
+                <thead>
+                    <tr>
+                        <th scope="col">Données</th>
+                        <th scope="col">Durées de conversation</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>
+                            Données relatives au signalement du problème d’infestation de punaises de lit
+                        </td>
+                        <td>
+                            5 ans à compter de la fin de la prise en charge du problème par l’entreprise/le partenaire.
+                            <br>
+                            Stop-Punaises utilise ces données pour détecter des signalements sur une même adresse ou une même zone.
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            Données de création de compte et relatives au suivi du problème d’habitat
+                        </td>
+                        <td>
+                            2 ans à compter de la suppression du compte 
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            Données de connexion 
+                        </td>
+                        <td>
+                            1 an
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            Cookies
+                        </td>
+                        <td>
+                            13 mois ou jusqu’au retrait du consentement de la personne concernée 
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
 
         <h3>6.6 – Sécurité et confidentialité</h3>
 
@@ -338,7 +342,7 @@
             Vous pouvez exercer ces droits en écrivant 
             <strong>par mail</strong> à dpd.daj.sg@developpement-durable.gouv.fr 
 
-        <p>
+        <p class="word-wrap">
             En raison de l’obligation de sécurité et de confidentialité dans le traitement des données 
             à caractère personnel qui incombe au responsable de traitement, votre demande ne sera traitée 
             que si vous rapportez la preuve de votre identité. Pour vous aider dans votre démarche, 
@@ -376,13 +380,16 @@
             de garanties adéquates et du respect de conditions strictes de confidentialité, d’usage 
             et de protection des données. 
         </p>
+
+        <div class="fr-table">
             <table>
+                <caption>Liste des sous-traitants</caption>
                 <thead>
                     <tr>
-                        <td style="text-align: center; font-weight: bold;">Partenaire</td>
-                        <td style="text-align: center; font-weight: bold;">Traitement réalisé</td>
-                        <td style="text-align: center; font-weight: bold;">Pays destinataire</td>
-                        <td style="text-align: center; font-weight: bold;">Garanties</td>
+                        <th scope="col">Partenaire</th>
+                        <th scope="col">Traitement réalisé</th>
+                        <th scope="col">Pays destinataire</th>
+                        <th scope="col">Garanties</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -398,6 +405,7 @@
                     </tr>
                 </tbody>
             </table>
+        </div>
 
         <h3 id="cookies">6.10 – Cookies</h3>
 


### PR DESCRIPTION
## Ticket

#588 
#594

## Description
Prise de focus sur les liens d'échappement
- Ajout d'une balise `<main>` avec un attribut `tagindex`
- Ajout d'un `tagindex` sur le `<footer>`

Prise en compte du tableau de la page Mentions légales : éviter qu'il ne déclenche un scroll horizontal pour l'ensemble de la page.

Toujours sur la page Mentions Légales : L'auditeur signale que le lien `exercer-son-droit-dacces` dépasse de l'écran en responsive et préconise des règles css. Je n'ai pas réussi à reproduire, mais j'ai tout de même appliqué la règle css sur son paragraphe.

## Tests
- [ ] Vérifier les liens d'échappement
- [ ] Vérifier la page mentions légales en responsive
