### PR TITLE
[Accessibilité - Contact] Meilleure gestion des erreurs

### DIFF
--- a/src/Form/ContactType.php
+++ b/src/Form/ContactType.php
@@ -23,6 +23,7 @@ class ContactType extends AbstractType
                 'attr' => [
                     'class' => 'fr-input',
                     'placeholder' => 'Claude Petit',
+                    'autocomplete' => 'name',
                 ],
                 'label' => 'Votre nom',
                 'constraints' => [
@@ -36,6 +37,7 @@ class ContactType extends AbstractType
                 'attr' => [
                     'class' => 'fr-input',
                     'placeholder' => 'claude.petit@courriel.fr',
+                    'autocomplete' => 'email',
                 ],
                 'label' => 'Votre adresse courriel',
                 'constraints' => [

--- a/src/Form/ContactType.php
+++ b/src/Form/ContactType.php
@@ -18,7 +18,7 @@ class ContactType extends AbstractType
         $builder
             ->add('nom', TextType::class, [
                 'row_attr' => [
-                    'class' => 'fr-input-group fr-col-12 fr-col-md-6',
+                    'class' => 'fr-input-group fr-col-12',
                 ],
                 'attr' => [
                     'class' => 'fr-input',
@@ -32,14 +32,15 @@ class ContactType extends AbstractType
             ])
             ->add('email', EmailType::class, [
                 'row_attr' => [
-                    'class' => 'fr-input-group fr-col-12 fr-col-md-6',
+                    'class' => 'fr-input-group fr-col-12',
                 ],
                 'attr' => [
                     'class' => 'fr-input',
                     'placeholder' => 'claude.petit@courriel.fr',
                     'autocomplete' => 'email',
                 ],
-                'label' => 'Votre adresse courriel',
+                'label' => 'Votre adresse courriel <span class="fr-hint-text">Format attendu : nom@domaine.fr</span>',
+                'label_html' => true,
                 'constraints' => [
                     new Assert\NotBlank(message: 'Merci de renseigner votre email.'),
                     new Assert\Email(mode: Email::VALIDATION_MODE_STRICT, message: 'Votre adresse e-mail doit être au bon format.'),
@@ -54,7 +55,8 @@ class ContactType extends AbstractType
                     'rows' => 10,
                     'minlength' => 10,
                 ],
-                'label' => 'Votre message',
+                'label' => 'Votre message <span class="fr-hint-text">Format attendu : doit comporter au moins 10 caractères.</span>',
+                'label_html' => true,
                 'constraints' => [
                     new Assert\NotBlank(message: 'Merci de renseigner votre message.'),
                     new Assert\Length(min: 10, minMessage: 'Votre message doit comporter au moins 10 caractères.'),

--- a/templates/front/contact.html.twig
+++ b/templates/front/contact.html.twig
@@ -49,9 +49,41 @@
             <div class="fr-col-11 fr-col-md-8 fr-py-5w">
                 {{ form_start(form) }}
                 <div class="fr-grid-row fr-grid-row--gutters">
-                    {{ form_row(form.nom) }}
-                    {{ form_row(form.email) }}
-                    {{ form_row(form.message) }}
+                    <div class="fr-col-12">
+                        {{ form_label(form.nom) }}
+                        {{ form_widget(form.nom) }}
+                        {% if form.nom.vars.errors|length > 0 %}
+                            {% for error in form.nom.vars.errors %}
+                                <p id="text-input-error-desc-error" class="fr-error-text">
+                                    {{ error.message }}
+                                </p>
+                            {% endfor %}
+                        {% endif %}
+                    </div>
+
+                    <div class="fr-col-12">
+                        {{ form_label(form.email) }}
+                        {{ form_widget(form.email) }}
+                        {% if form.email.vars.errors|length > 0 %}
+                            {% for error in form.email.vars.errors %}
+                                <p id="text-input-error-desc-error" class="fr-error-text">
+                                    {{ error.message }}
+                                </p>
+                            {% endfor %}
+                        {% endif %}
+                    </div>
+
+                    <div class="fr-col-12">
+                        {{ form_label(form.message) }}
+                        {{ form_widget(form.message) }}
+                        {% if form.message.vars.errors|length > 0 %}
+                            {% for error in form.message.vars.errors %}
+                                <p id="text-input-error-desc-error" class="fr-error-text">
+                                    {{ error.message }}
+                                </p>
+                            {% endfor %}
+                        {% endif %}
+                    </div>
                 </div>
                 {{ form_end(form) }}
             </div>


### PR DESCRIPTION
## Ticket

#589 
#592 
#593   

## Description
Amélioration de la gestion des erreurs du formulaire de contact

## Changements apportés
* Modification de l'affichage des champs pour pouvoir utiliser les messages d'erreur DSFR
* Ajout du format attendu sous les champs
* Ajout de l'attribut autocomplete sur les champs nom et email pour que ce soit automatiquement proposé

## Tests
- [ ] Tester l'affichage de la page et du formulaire
- [ ] Faire des erreurs pour vérifier l'affichage
