### PR TITLE
[Accessibilité - Informations] Corrections sur les descriptions d'image et les contrastes

### DIFF
--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -499,25 +499,24 @@ span.image-caption {
                     font-weight: bold;
                     vertical-align: middle;
                     border-radius: 15px;
-                    background-color: #00A95F;
+                    color: var(--grey-1000-50);
+                    background-color: var(--success-425-625);
 
                     &.number-1 {
-                        background-color: #E4794A;
+                        background-color: var(--orange-terre-battue-main-645);
+                        color: var(--grey-200-850);
                     }
 
                     &.number-2 {
-                        background-color: #B34000;
-                        color: #FFF;
+                        background-color: var(--warning-425-625);
                     }
 
                     &.number-3 {
-                        background-color: #CE0500;
-                        color: #FFF;
+                        background-color: var(--error-425-625);
                     }
 
                     &.number-4 {
-                        background-color: #161616;
-                        color: #FFF;
+                        background-color: var(--grey-50-1000);
                     }
                 }
             }

--- a/templates/front/information.html.twig
+++ b/templates/front/information.html.twig
@@ -269,7 +269,7 @@
                                             <figure class="fr-content-media" role="group" aria-label="Où se cachent les punaises de lit ?">
                                                 <div class="fr-content-media__img">
                                                     <img src="{{ asset('build/images/flyer-ou-se-cachent-elles.jpg') }}"
-                                                        alt="Où se cachent les punaises de lit ? Dans la chambre, dans les matelas et sommiers. Derrière les cadres, les raccords de papier peint, sous les meubles, dans les plinthes, sous les prises électriques. Dans les fissures et les fentes du parquet. Dans les canapés. Sous les tapis."
+                                                        alt="Punaises de lit : où se cachent-elles ?"
                                                         >
                                                 </div>
                                                 <figcaption class="fr-content-media__caption align-left">
@@ -541,7 +541,7 @@
                     <figure class="fr-content-media" role="group" aria-label="Comment éviter les punaises de lit ?">
                         <div class="fr-content-media__img">
                             <img src="{{ asset('build/images/flyer-comment-les-eviter.jpg') }}" width="500" height="954"
-                                alt="Comment éviter les punaises de lit ? En voyage, ne posez pas votre bagage sur le lit, encore moins sous le lit. Contrôlez vos effets personnels à votre retour. Evitez d'encombrer les espaces. Attention aux achats d'occasion, lavez-les à 60°C. Nettoyez les meubles récupérés."
+                                alt="Punaises de lit : comment les éviter ?"
                                 >
                         </div>
                         <figcaption class="fr-content-media__caption">Crédit : Citizen</figcaption>

--- a/templates/front/information.html.twig
+++ b/templates/front/information.html.twig
@@ -41,7 +41,11 @@
                         <div class="fr-content-media__img">
                             <img src="{{ asset('build/images/punaises-de-lit-gros-plan.jpg') }}" alt="Gros plan d'une punaise de lit">
                         </div>
-                        <figcaption class="fr-content-media__caption">Gros plan d'une punaise de lit - Crédit photo : INELP</figcaption>
+                        <figcaption class="fr-content-media__caption">
+                            Insecte de couleur rougeâtre-brun, elle a un corps aplati qui semble légèrement rayé, de forme ovale. Sa tête est 4 fois plus petite que son corps. Elle a six pattes et deux antennes.
+                            <br>
+                            Crédit photo : INELP
+                        </figcaption>
                     </figure>
                 </div>
                 <div class="fr-col-12 fr-col-lg-9">
@@ -109,7 +113,11 @@
                                     <div class="fr-content-media__img">
                                         <img src="{{ asset('build/images/dejections-punaise-sommier.jpg') }}" alt="Déjections et œufs de punaises de lit sur un sommier">
                                     </div>
-                                    <figcaption class="fr-content-media__caption">Déjections et œufs de punaises de lit sur un sommier</figcaption>
+                                    <figcaption class="fr-content-media__caption">
+                                        Gros plan sur un sommier de lit, couvert de déjections et œufs de punaises de lit de couleur noire et blanche.
+                                        <br>
+                                        Crédit photo : INELP
+                                    </figcaption>
                                 </figure>
                             </div>
                             <div class="fr-col-4 align-center">
@@ -117,7 +125,11 @@
                                     <div class="fr-content-media__img">
                                         <img src="{{ asset('build/images/traces-punaise-de-lit-couture-matelas.jpg') }}" alt="Traces de punaises de lit dans la couture d'un matelas">
                                     </div>
-                                    <figcaption class="fr-content-media__caption">Traces de punaises de lit dans la couture d'un matelas</figcaption>
+                                    <figcaption class="fr-content-media__caption">
+                                        Doigt qui entrouvre la couture d'un matelas, pleine de tâches noires, qui sont des traces de punaises de lit.
+                                        <br>
+                                        Crédit photo : INELP
+                                    </figcaption>
                                 </figure>
                             </div>
                             <div class="fr-col-4 align-center">
@@ -125,12 +137,13 @@
                                     <div class="fr-content-media__img">
                                         <img src="{{ asset('build/images/punaises-infestation-massive-oeufs-mues.jpg') }}" alt="Infestation massive avec punaises de lit à différents stades de croissance, œufs et mues">
                                     </div>
-                                    <figcaption class="fr-content-media__caption">Infestation massive avec punaises de lit à différents stades de croissance, œufs et mues</figcaption>
+                                    <figcaption class="fr-content-media__caption">
+                                        Différents stades de croissance, œufs et mues de punaises de lit. 8 insectes de couleur rougeâtre-brun sont regroupées. Des oeufs de couleur blanchâtre sont disséminés tout autour.
+                                        <br>
+                                        Crédit photo : INELP
+                                    </figcaption>
                                 </figure>
                             </div>
-                        </div>
-                        <div class="align-center fr-my-3w">
-                            <span class="image-caption">Crédit photo : INELP</span>
                         </div>
 
                         <hr>
@@ -156,7 +169,11 @@
                                     <div class="fr-content-media__img">
                                         <img src="{{ asset('build/images/piqures-punaises-de-lit-bras.jpg') }}" alt="Piqures de punaises en ligne sur un bras">
                                     </div>
-                                    <figcaption class="fr-content-media__caption">Piqures de punaises en ligne sur un bras</figcaption>
+                                    <figcaption class="fr-content-media__caption">
+                                        Avant-bras humain couverts de 6 traces de piqures alignées. 
+                                        <br>
+                                        Crédit photo : INELP
+                                    </figcaption>
                                 </figure>
                             </div>
                             <div class="fr-col-6 align-center">
@@ -164,12 +181,13 @@
                                     <div class="fr-content-media__img">
                                         <img src="{{ asset('build/images/piqures-punaises-de-lit-cou.jpg') }}" alt="Piqures de punaises groupées dans le cou">
                                     </div>
-                                    <figcaption class="fr-content-media__caption">Piqures de punaises groupées dans le cou</figcaption>
+                                    <figcaption class="fr-content-media__caption">
+                                        Cou humain couvert de 7 traces de piqures.
+                                        <br>
+                                        Crédit photo : INELP
+                                    </figcaption>
                                 </figure>
                             </div>
-                        </div>
-                        <div class="align-center fr-my-3w">
-                            <span class="image-caption">Crédit photo : INELP</span>
                         </div>
 
                         <hr>

--- a/templates/front/information.html.twig
+++ b/templates/front/information.html.twig
@@ -56,7 +56,7 @@
                     </p>
                     <div class="fr-alert fr-alert--warning fr-alert--sm">
                         <p>
-                            Le développement des punaises de lit est rapide !
+                            Attention : Le développement des punaises de lit est rapide !
                             Il est donc important d'intervenir au plus vite pour éviter que l'infestation se propage.
                         </p>
                     </div>
@@ -83,7 +83,7 @@
                     il ne faut pas hésiter non plus malgré le coût, autrement le traitement sera inefficace.
                 </p>
                 <p class="fr-alert fr-alert--info fr-alert--sm">
-                    Si vous êtes allocataire la CAF peut dans certains cas vous aider.
+                    Information : Si vous êtes allocataire, la CAF peut dans certains cas vous aider.
                 </p>
             </div>
         </div>

--- a/templates/front/information.html.twig
+++ b/templates/front/information.html.twig
@@ -114,7 +114,7 @@
                                         <img src="{{ asset('build/images/dejections-punaise-sommier.jpg') }}" alt="Déjections et œufs de punaises de lit sur un sommier">
                                     </div>
                                     <figcaption class="fr-content-media__caption">
-                                        Gros plan sur un sommier de lit, couvert de déjections et œufs de punaises de lit de couleur noire et blanche.
+                                        Gros plan sur un sommier de lit, couvert de déjections noires et d'œufs de punaises de lit de couleur blanche.
                                         <br>
                                         Crédit photo : INELP
                                     </figcaption>
@@ -126,7 +126,7 @@
                                         <img src="{{ asset('build/images/traces-punaise-de-lit-couture-matelas.jpg') }}" alt="Traces de punaises de lit dans la couture d'un matelas">
                                     </div>
                                     <figcaption class="fr-content-media__caption">
-                                        Doigt qui entrouvre la couture d'un matelas, pleine de tâches noires, qui sont des traces de punaises de lit.
+                                        Doigt qui entrouvre la couture d'un matelas, pleine de tâches noires, qui sont des traces de déjections de punaises de lit.
                                         <br>
                                         Crédit photo : INELP
                                     </figcaption>
@@ -170,7 +170,7 @@
                                         <img src="{{ asset('build/images/piqures-punaises-de-lit-bras.jpg') }}" alt="Piqures de punaises en ligne sur un bras">
                                     </div>
                                     <figcaption class="fr-content-media__caption">
-                                        Avant-bras humain couverts de 6 traces de piqures alignées. 
+                                        Avant-bras humain couvert de 6 traces de piqûres alignées. 
                                         <br>
                                         Crédit photo : INELP
                                     </figcaption>
@@ -182,7 +182,7 @@
                                         <img src="{{ asset('build/images/piqures-punaises-de-lit-cou.jpg') }}" alt="Piqures de punaises groupées dans le cou">
                                     </div>
                                     <figcaption class="fr-content-media__caption">
-                                        Cou humain couvert de 7 traces de piqures.
+                                        Cou humain couvert de 7 traces de piqûres.
                                         <br>
                                         Crédit photo : INELP
                                     </figcaption>

--- a/templates/sitemap/index.html.twig
+++ b/templates/sitemap/index.html.twig
@@ -54,23 +54,23 @@
                                 {% endif %}
                             </ul>
                         </li>
-                        <li><span class="fr-icon-account-line" title="Page réservée aux utilisateurs connectés"
-                                  aria-hidden="true"></span>
-                            <a href="{{ path('app_signalement_list') }}">Signalements usager à traiter</a>
+                        <li>
+                            <span class="fr-icon-account-line" title="Page réservée aux utilisateurs connectés" aria-hidden="true"></span>
+                            <a href="{{ path('app_signalement_list') }}">Signalements usager à traiter (connexion nécessaire)</a>
                         </li>
-                        <li><span class="fr-icon-account-line" title="Page réservée aux utilisateurs connectés"
-                                  aria-hidden="true"></span>
-                            <a href="{{ path('app_horsperimetre_list') }}">Signalements hors périmètre</a>
+                        <li>
+                            <span class="fr-icon-account-line" title="Page réservée aux utilisateurs connectés" aria-hidden="true"></span>
+                            <a href="{{ path('app_horsperimetre_list') }}">Signalements hors périmètre (connexion nécessaire)</a>
                         </li>
                         {% if feature_three_forms %}
-                        <li><span class="fr-icon-account-line" title="Page réservée aux utilisateurs connectés"
-                                      aria-hidden="true"></span>
-                                <a href="{{ path('app_erptransports_list') }}">Signalements ERP et transports</a>
-                            </li>
+                        <li>
+                            <span class="fr-icon-account-line" title="Page réservée aux utilisateurs connectés" aria-hidden="true"></span>
+                            <a href="{{ path('app_erptransports_list') }}">Signalements ERP et transports (connexion nécessaire)</a>
+                        </li>
                         {% endif %}
-                        <li><span class="fr-icon-account-line" title="Page réservée aux utilisateurs connectés"
-                                  aria-hidden="true"></span>
-                            <a href="{{ path('app_historique_list') }}">Données historiques</a>
+                        <li>
+                            <span class="fr-icon-account-line" title="Page réservée aux utilisateurs connectés" aria-hidden="true"></span>
+                            <a href="{{ path('app_historique_list') }}">Données historiques (connexion nécessaire)</a>
                         </li>
                     </ul>
                 </section>
@@ -87,44 +87,41 @@
                             <a href="{{ path('request_password') }}">Réinitialiser mon mot de passe</a>
                         </li>
                         <li>
-                                <span class="fr-icon-account-line" title="Page réservée aux utilisateurs connectés"
-                                      aria-hidden="true"></span>
-                            <a href="{{ path('app_entreprise_list') }}">Créer un compte entreprise</a>
+                            <span class="fr-icon-account-line" title="Page réservée aux utilisateurs connectés" aria-hidden="true"></span>
+                            <a href="{{ path('app_entreprise_list') }}">Créer un compte entreprise (connexion nécessaire)</a>
                         </li>
                         <li>
-                                <span class="fr-icon-account-line" title="Page réservée aux utilisateurs connectés"
-                                      aria-hidden="true"></span>
-                            <a href="{{ path('app_dashboard_home') }}">Tableau de bord utilisateur</a>
+                            <span class="fr-icon-account-line" title="Page réservée aux utilisateurs connectés" aria-hidden="true"></span>
+                            <a href="{{ path('app_dashboard_home') }}">Tableau de bord utilisateur (connexion nécessaire)</a>
                         </li>
                         <li>
-                                <span class="fr-icon-account-line" title="Page réservée aux utilisateurs connectés"
-                                      aria-hidden="true"></span>
-                            <a href="{{ path('app_logout') }}">Déconnexion du compte</a>
+                            <span class="fr-icon-account-line" title="Page réservée aux utilisateurs connectés" aria-hidden="true"></span>
+                            <a href="{{ path('app_logout') }}">Déconnexion du compte (connexion nécessaire)</a>
                         </li>
                     </ul>
                 </section>
                 <section class="fr-py-6v">
                     <h2>Entreprise</h2>
                     <ul>
-                        <li><span class="fr-icon-account-line" title="Page réservée aux utilisateurs connectés"
-                                  aria-hidden="true"></span>
-                            <a href="{{ path('app_entreprise_list') }}">Les entreprises partenaires</a>
+                        <li>
+                            <span class="fr-icon-account-line" title="Page réservée aux utilisateurs connectés" aria-hidden="true"></span>
+                            <a href="{{ path('app_entreprise_list') }}">Les entreprises partenaires (connexion nécessaire)</a>
                         </li>
-                        <li><span class="fr-icon-account-line" title="Page réservée aux utilisateurs connectés"
-                                  aria-hidden="true"></span>
-                            <a href="{{ path('app_entreprise_list') }}">Gérer l'entreprise</a>
+                        <li>
+                            <span class="fr-icon-account-line" title="Page réservée aux utilisateurs connectés" aria-hidden="true"></span>
+                            <a href="{{ path('app_entreprise_list') }}">Gérer l'entreprise (connexion nécessaire)</a>
                         </li>
-                        <li><span class="fr-icon-account-line" title="Page réservée aux utilisateurs connectés"
-                                  aria-hidden="true"></span>
-                            <a href="{{ path('app_entreprise_list') }}">Editer l'entreprise</a>
+                        <li>
+                            <span class="fr-icon-account-line" title="Page réservée aux utilisateurs connectés" aria-hidden="true"></span>
+                            <a href="{{ path('app_entreprise_list') }}">Editer l'entreprise (connexion nécessaire)</a>
                         </li>
-                        <li><span class="fr-icon-account-line" title="Page réservée aux utilisateurs connectés"
-                                  aria-hidden="true"></span>
-                            <a href="{{ path('app_entreprise_list') }}">Ajouter un employé</a>
+                        <li>
+                            <span class="fr-icon-account-line" title="Page réservée aux utilisateurs connectés" aria-hidden="true"></span>
+                            <a href="{{ path('app_entreprise_list') }}">Ajouter un employé (connexion nécessaire)</a>
                         </li>
-                        <li><span class="fr-icon-account-line" title="Page réservée aux utilisateurs connectés"
-                                  aria-hidden="true"></span>
-                            <a href="{{ path('app_entreprise_list') }}">Modifier les infos employé</a>
+                        <li>
+                            <span class="fr-icon-account-line" title="Page réservée aux utilisateurs connectés" aria-hidden="true"></span>
+                            <a href="{{ path('app_entreprise_list') }}">Modifier les infos employé (connexion nécessaire)</a>
                         </li>
                     </ul>
                 </section>


### PR DESCRIPTION
## Ticket

#595
#596
#597
#598
#601
#610

## Description
Corrections sur les descriptions d'image et contrastes sur la page Informations et Plan du site

Attention : une partie des modifications consiste à la rédaction de description précise sur certaines images. Je suis largement ouvert aux retours, j'ai fait comme j'ai pu !

## Tests sur la page Plan du site
- [ ] Une précision textuelle apparait pour dire qu'il faut être connecté sur les pages où il y a un picto bonhomme

## Tests sur la page Informations
- [ ] Les nombres qui représentent les niveaux d'infestation sont assez contrastés (j'ai repris le design du BO, je ne sais pas pourquoi ce n'était pas le même)
- [ ] Les messages d'alerte sont précédés de Attention et Information
- [ ] Les alternatives des deux infographies sont simplifiées
- [ ] Les crédits des images sont placés sous chaque image
- [ ] Les images de la page ont des informations plus détaillées qu'avant
