### PR TITLE
[Accessibilité - Audit] [Formulaire signalement - 9.1] Utilisation des titres

### DIFF
--- a/templates/front_signalement/_partial_step_autotraitement_info.html.twig
+++ b/templates/front_signalement/_partial_step_autotraitement_info.html.twig
@@ -2,7 +2,7 @@
 
 {% block content %}
     <div>
-        <h2>Auto-traitement</h2>
+        <h1 class="fr-h2">Auto-traitement</h1>
 
         <p>
             Vous avez opté pour l'auto-traitement.

--- a/templates/front_signalement/_partial_step_autotraitement_sent.html.twig
+++ b/templates/front_signalement/_partial_step_autotraitement_sent.html.twig
@@ -2,7 +2,7 @@
 
 {% block content %}
     <div>
-        <h2>Instructions envoyées</h2>
+        <h1 class="fr-h2">Instructions envoyées</h1>
 
         <p>
             Vous recevrez vos instructions par email d'ici quelques minutes.

--- a/templates/front_signalement/_partial_step_info_intro.html.twig
+++ b/templates/front_signalement/_partial_step_info_intro.html.twig
@@ -2,7 +2,7 @@
 
 {% block content %}
     <div>
-        <h2>Avant de commencer</h2>
+        <h1 class="fr-h2">Avant de commencer</h1>
 
         <p>
             Stop Punaises vous accompagne pour choisir la meilleure solution pour

--- a/templates/front_signalement/_partial_step_info_locataire.html.twig
+++ b/templates/front_signalement/_partial_step_info_locataire.html.twig
@@ -2,10 +2,10 @@
 
 {% block content %}
     <div class="fr-stepper">
-        <h2 class="fr-stepper__title">
+        <h1 class="fr-stepper__title fr-h2">
             Informations du logement
             <span class="fr-stepper__state">Étape 1 sur 8</span>
-        </h2>
+        </h1>
         <div class="fr-stepper__steps" data-fr-current-step="1" data-fr-steps="8"></div>
         <p class="fr-stepper__details">
             <span class="fr-text--bold">Étape suivante :</span> Durée de l'infestation

--- a/templates/front_signalement/_partial_step_info_logement.html.twig
+++ b/templates/front_signalement/_partial_step_info_logement.html.twig
@@ -2,10 +2,10 @@
 
 {% block content %}
     <div class="fr-stepper">
-        <h2 class="fr-stepper__title">
+        <h1 class="fr-stepper__title fr-h2">
             Informations du logement
             <span class="fr-stepper__state">Étape 1 sur 8</span>
-        </h2>
+        </h1>
         <div class="fr-stepper__steps" data-fr-current-step="1" data-fr-steps="8"></div>
         <p class="fr-stepper__details">
             <span class="fr-text--bold">Étape suivante :</span> Durée de l'infestation

--- a/templates/front_signalement/_partial_step_info_problemes.html.twig
+++ b/templates/front_signalement/_partial_step_info_problemes.html.twig
@@ -2,10 +2,10 @@
 
 {% block content %}
     <div class="fr-stepper">
-        <h2 class="fr-stepper__title">
+        <h1 class="fr-stepper__title fr-h2">
             Durée de l'infestation
             <span class="fr-stepper__state">Étape 2 sur 8</span>
-        </h2>
+        </h1>
         <div class="fr-stepper__steps" data-fr-current-step="2" data-fr-steps="8"></div>
         <p class="fr-stepper__details">
             <span class="fr-text--bold">Étape suivante :</span> Les traces de punaises

--- a/templates/front_signalement/_partial_step_info_usager.html.twig
+++ b/templates/front_signalement/_partial_step_info_usager.html.twig
@@ -3,10 +3,10 @@
 {% block content %}
     <div class="if-territory-open">
         <div class="fr-stepper">
-            <h2 class="fr-stepper__title">
+            <h1 class="fr-stepper__title fr-h2">
                 Vos coordonnées
                 <span class="fr-stepper__state">Étape 7 sur 8</span>
-            </h2>
+            </h1>
             <div class="fr-stepper__steps" data-fr-current-step="7" data-fr-steps="8"></div>
             <p class="fr-stepper__details">
                 <span class="fr-text--bold">Étape suivante :</span> Votre recommandation
@@ -14,7 +14,7 @@
         </div>
         
         <div>
-            <h2>C'est presque fini&nbsp;!</h2>
+            <h2 class="fr-h3">C'est presque fini&nbsp;!</h2>
 
             <p>
                 Renseignez vos coordonnées pour afficher votre recommandation personnalisée.
@@ -25,7 +25,7 @@
     </div>
 
     <div class="if-territory-not-open">
-        <h2>Stop punaises</h2>
+        <h1 class="fr-h2">Stop punaises</h1>
 
         <p>
             Renseignez vos coordonnées pour accéder à la liste des entreprises labellisées de votre département
@@ -41,7 +41,7 @@
     </div>
 
     <div class="if-logement-social">
-        <h2>Stop punaises</h2>
+        <h1 class="fr-h2">Stop punaises</h1>
 
         <p>
             En tant que locataire du parc social, votre bailleur doit avoir un service 

--- a/templates/front_signalement/_partial_step_insectes_larves_intro.html.twig
+++ b/templates/front_signalement/_partial_step_insectes_larves_intro.html.twig
@@ -2,10 +2,10 @@
 
 {% block content %}
     <div class="fr-stepper">
-        <h2 class="fr-stepper__title">
+        <h1 class="fr-stepper__title fr-h2">
             Les insectes et larves
             <span class="fr-stepper__state">Étape 5 sur 8</span>
-        </h2>
+        </h1>
         <div class="fr-stepper__steps" data-fr-current-step="5" data-fr-steps="8"></div>
         <p class="fr-stepper__details">
             <span class="fr-text--bold">Étape suivante :</span> Les punaises
@@ -13,7 +13,7 @@
     </div>
 
     <div>
-        <h2>Les insectes et larves</h2>
+        <h2 class="fr-h3">Les insectes et larves</h2>
 
         <p>
             Dans cette partie, nous nous intéressons aux insectes&nbsp;:

--- a/templates/front_signalement/_partial_step_insectes_larves_oeufs.html.twig
+++ b/templates/front_signalement/_partial_step_insectes_larves_oeufs.html.twig
@@ -2,10 +2,10 @@
 
 {% block content %}
     <div class="fr-stepper">
-        <h2 class="fr-stepper__title">
+        <h1 class="fr-stepper__title fr-h2">
             Les insectes et larves
             <span class="fr-stepper__state">Étape 5 sur 8</span>
-        </h2>
+        </h1>
         <div class="fr-stepper__steps" data-fr-current-step="5" data-fr-steps="8"></div>
         <p class="fr-stepper__details">
             <span class="fr-text--bold">Étape suivante :</span> Les punaises

--- a/templates/front_signalement/_partial_step_insectes_punaises.html.twig
+++ b/templates/front_signalement/_partial_step_insectes_punaises.html.twig
@@ -2,10 +2,10 @@
 
 {% block content %}
     <div class="fr-stepper">
-        <h2 class="fr-stepper__title">
+        <h1 class="fr-stepper__title fr-h2">
             Les punaises
             <span class="fr-stepper__state">Étape 6 sur 8</span>
-        </h2>
+        </h1>
         <div class="fr-stepper__steps" data-fr-current-step="6" data-fr-steps="8"></div>
         <p class="fr-stepper__details">
             <span class="fr-text--bold">Étape suivante :</span> Vos coordonnées

--- a/templates/front_signalement/_partial_step_professionnel_info.html.twig
+++ b/templates/front_signalement/_partial_step_professionnel_info.html.twig
@@ -2,7 +2,7 @@
 
 {% block content %}
     <div>
-        <h2>Prise en charge professionnelle</h2>
+        <h1 class="fr-h2">Prise en charge professionnelle</h1>
 
         <p>
             Vous avez choisi la prise en charge professionnelle.

--- a/templates/front_signalement/_partial_step_professionnel_sent.html.twig
+++ b/templates/front_signalement/_partial_step_professionnel_sent.html.twig
@@ -2,7 +2,7 @@
 
 {% block content %}
     <div>
-        <h2>Demande envoyée</h2>
+        <h1 class="fr-h2">Demande envoyée</h1>
 
         <p>
             Vous recevrez une confirmation par email d'ici quelques minutes.

--- a/templates/front_signalement/_partial_step_recommandation.html.twig
+++ b/templates/front_signalement/_partial_step_recommandation.html.twig
@@ -2,15 +2,15 @@
 
 {% block content %}
     <div class="fr-stepper">
-        <h2 class="fr-stepper__title">
+        <h1 class="fr-stepper__title fr-h2">
             Votre recommandation
             <span class="fr-stepper__state">Étape 8 sur 8</span>
-        </h2>
+        </h1>
         <div class="fr-stepper__steps" data-fr-current-step="8" data-fr-steps="8"></div>
     </div>
     
     <div>
-        <h2>Votre recommandation</h2>
+        <h2 class="fr-h3">Votre recommandation</h2>
 
         <p>
             D'après les informations fournies, nous estimons le niveau d'infestation de votre logement à&nbsp;:

--- a/templates/front_signalement/_partial_step_resume.html.twig
+++ b/templates/front_signalement/_partial_step_resume.html.twig
@@ -2,10 +2,10 @@
 
 {% block content %}
     <div class="fr-stepper">
-        <h2 class="fr-stepper__title">
+        <h1 class="fr-stepper__title fr-h2">
             Votre recommandation
             <span class="fr-stepper__state">Étape 8 sur 8</span>
-        </h2>
+        </h1>
         <div class="fr-stepper__steps" data-fr-current-step="8" data-fr-steps="8"></div>
     </div>
 

--- a/templates/front_signalement/_partial_step_traces_punaises_dejections.html.twig
+++ b/templates/front_signalement/_partial_step_traces_punaises_dejections.html.twig
@@ -2,10 +2,10 @@
 
 {% block content %}
     <div class="fr-stepper">
-        <h2 class="fr-stepper__title">
+        <h1 class="fr-stepper__title fr-h2">
             Les déjections
             <span class="fr-stepper__state">Étape 4 sur 8</span>
-        </h2>
+        </h1>
         <div class="fr-stepper__steps" data-fr-current-step="4" data-fr-steps="8"></div>
         <p class="fr-stepper__details">
             <span class="fr-text--bold">Étape suivante :</span> Les insectes et larves

--- a/templates/front_signalement/_partial_step_traces_punaises_intro.html.twig
+++ b/templates/front_signalement/_partial_step_traces_punaises_intro.html.twig
@@ -2,10 +2,10 @@
 
 {% block content %}
     <div class="fr-stepper">
-        <h2 class="fr-stepper__title">
+        <h1 class="fr-stepper__title fr-h2">
             Les traces de punaises
             <span class="fr-stepper__state">Étape 3 sur 8</span>
-        </h2>
+        </h1>
         <div class="fr-stepper__steps" data-fr-current-step="3" data-fr-steps="8"></div>
         <p class="fr-stepper__details">
             <span class="fr-text--bold">Étape suivante :</span> Les déjections
@@ -13,7 +13,7 @@
     </div>
 
     <div>
-        <h2>Les traces de punaises</h2>
+        <h2 class="fr-h3">Les traces de punaises</h2>
 
         <p>
             Nous allons prendre un moment pour nous intéresser aux traces laissées

--- a/templates/front_signalement/_partial_step_traces_punaises_piqures.html.twig
+++ b/templates/front_signalement/_partial_step_traces_punaises_piqures.html.twig
@@ -2,10 +2,10 @@
 
 {% block content %}
     <div class="fr-stepper">
-        <h2 class="fr-stepper__title">
+        <h1 class="fr-stepper__title fr-h2">
             Les traces de punaises
             <span class="fr-stepper__state">Étape 3 sur 8</span>
-        </h2>
+        </h1>
         <div class="fr-stepper__steps" data-fr-current-step="3" data-fr-steps="8"></div>
         <p class="fr-stepper__details">
             <span class="fr-text--bold">Étape suivante :</span> Les déjections

--- a/templates/signalement_create/index.html.twig
+++ b/templates/signalement_create/index.html.twig
@@ -18,11 +18,11 @@
         {{ form_row(form._token) }}
 
         <div class="fr-stepper">
-            <h2 class="fr-stepper__title">
+            <h1 class="fr-stepper__title fr-h2">
                 <span class="fr-stepper__state">Étape <span>1</span> sur 2</span>
                 <span data-step="1">Logement</span>
                 <span class="fr-stepper__hidden" data-step="2">Intervention</span>
-            </h2>
+            </h1>
             <div class="fr-stepper__steps" data-fr-current-step="1" data-fr-steps="2"></div>
         </div>
 


### PR DESCRIPTION
## Ticket

#617 
![image](https://github.com/MTES-MCT/stop-punaises/assets/5757116/7395b26c-92dd-45d3-a628-1646d5b8a399)

## Description
Remplacer à chaque étape du formulaire, page intermédiaire et de confirmation le titre h2 par à h1

## Changements apportés
* Remplacement de balise mais conservation du style via les classes DSFR appropriées

## Pré-requis

## Tests
- [ ] Déposer un signalement via l'inspecteur en vérifiant que le titre du formulaire est une bien une balise h1 
     - Etape du formulaire
     - Page intermédiaire
     - Page de confirmation Pro
     - Page de confirmation Auto traitement
     - Page de confirmation locataire 
