### PR TITLE
[Accessibilité - Audit] [Liste signalements - 5.4] Titre associé au tableau

### DIFF
--- a/templates/entreprise_list/index.html.twig
+++ b/templates/entreprise_list/index.html.twig
@@ -19,10 +19,10 @@
         </div>
 
         <div class="fr-mt-3w">
-            <h2><span id="count-entreprise">{{ count_entreprises }}</span> entreprises trouvées</h2>
+            <h2 id="liste-entreprises-title"><span id="count-entreprise">{{ count_entreprises }}</span> entreprises trouvées</h2>
 
             {% if entreprises is not empty %}
-                <table id="datatable" class="nowrap">
+                <table id="datatable" class="nowrap" aria-labelledby="liste-entreprises-title">
                     <thead>
                         <tr>
                             <th>ID</th>

--- a/templates/entreprise_list/index.html.twig
+++ b/templates/entreprise_list/index.html.twig
@@ -19,7 +19,7 @@
         </div>
 
         <div class="fr-mt-3w">
-            <h2 id="liste-entreprises-title"><span id="count-entreprise">{{ count_entreprises }}</span> entreprises trouvées</h2>
+            <h2 id="liste-entreprises-title" role="status"><span id="count-entreprise">{{ count_entreprises }}</span> entreprises trouvées</h2>
 
             {% if entreprises is not empty %}
                 <table id="datatable" class="nowrap" aria-labelledby="liste-entreprises-title">

--- a/templates/entreprise_view/index.html.twig
+++ b/templates/entreprise_view/index.html.twig
@@ -47,7 +47,7 @@
         <div class="fr-container">
             <div class="fr-grid-row">
                 <div class="fr-col-12 fr-col-lg-9">
-                    <h2><span class="fr-icon-team-line" aria-hidden="true"></span>Employés</h2>
+                    <h2 id="liste-employes-title"><span class="fr-icon-team-line" aria-hidden="true"></span>Employés</h2>
                 </div>
                 <div class="fr-col-12 fr-col-lg-3">
                     <div class="add-button-container">
@@ -57,7 +57,7 @@
             </div>
 
             {% if entreprise.employes is not empty %}
-                <table id="datatable" class="nowrap">
+                <table id="datatable" class="nowrap" aria-labelledby="liste-employes-title">
                     <thead>
                         <tr>
                             <th>ID</th>

--- a/templates/signalement_list/erp-transports.html.twig
+++ b/templates/signalement_list/erp-transports.html.twig
@@ -34,7 +34,7 @@
     </div>
 
     <div class="fr-container fr-mt-3w">
-        <h2 id="liste-signalements-title"><span id="count-signalement">{{ count_signalement }}</span> signalements trouvés</h2>
+        <h2 id="liste-signalements-title" role="status"><span id="count-signalement">{{ count_signalement }}</span> signalements trouvés</h2>
 
         {% if signalements is not empty %}
             <table id="datatable" class="liste-signalements-erp-transports nowrap" aria-labelledby="liste-signalements-title">

--- a/templates/signalement_list/erp-transports.html.twig
+++ b/templates/signalement_list/erp-transports.html.twig
@@ -34,10 +34,10 @@
     </div>
 
     <div class="fr-container fr-mt-3w">
-        <h2><span id="count-signalement">{{ count_signalement }}</span> signalements trouvés</h2>
+        <h2 id="liste-signalements-title"><span id="count-signalement">{{ count_signalement }}</span> signalements trouvés</h2>
 
         {% if signalements is not empty %}
-            <table id="datatable" class="liste-signalements-erp-transports nowrap">
+            <table id="datatable" class="liste-signalements-erp-transports nowrap" aria-labelledby="liste-signalements-title">
                 <thead>
                     <tr>
                         <th>ID</th>

--- a/templates/signalement_list/historique.html.twig
+++ b/templates/signalement_list/historique.html.twig
@@ -54,10 +54,10 @@
     </div>
 
     <div class="fr-container fr-mt-3w">
-        <h2><span id="count-signalement">{{ count_signalement }}</span> signalements trouvés</h2>
+        <h2 id="liste-signalements-title"><span id="count-signalement">{{ count_signalement }}</span> signalements trouvés</h2>
 
         {% if signalements is not empty %}
-            <table id="datatable" class="liste-signalements-historique nowrap">
+            <table id="datatable" class="liste-signalements-historique nowrap" aria-labelledby="liste-signalements-title">
                 <thead>
                     <tr>
                         <th>ID</th>

--- a/templates/signalement_list/historique.html.twig
+++ b/templates/signalement_list/historique.html.twig
@@ -54,7 +54,7 @@
     </div>
 
     <div class="fr-container fr-mt-3w">
-        <h2 id="liste-signalements-title"><span id="count-signalement">{{ count_signalement }}</span> signalements trouvés</h2>
+        <h2 id="liste-signalements-title" role="status"><span id="count-signalement">{{ count_signalement }}</span> signalements trouvés</h2>
 
         {% if signalements is not empty %}
             <table id="datatable" class="liste-signalements-historique nowrap" aria-labelledby="liste-signalements-title">

--- a/templates/signalement_list/hors-perimetre.html.twig
+++ b/templates/signalement_list/hors-perimetre.html.twig
@@ -30,7 +30,7 @@
     </div>
 
     <div class="fr-container fr-mt-3w">
-        <h2 id="liste-signalements-title"><span id="count-signalement">{{ count_signalement }}</span> signalements trouvés</h2>
+        <h2 id="liste-signalements-title" role="status"><span id="count-signalement">{{ count_signalement }}</span> signalements trouvés</h2>
 
         {% if signalements is not empty %}
             <table id="datatable" class="liste-signalements-hors-perimetres nowrap" aria-labelledby="liste-signalements-title">

--- a/templates/signalement_list/hors-perimetre.html.twig
+++ b/templates/signalement_list/hors-perimetre.html.twig
@@ -30,10 +30,10 @@
     </div>
 
     <div class="fr-container fr-mt-3w">
-        <h2><span id="count-signalement">{{ count_signalement }}</span> signalements trouvés</h2>
+        <h2 id="liste-signalements-title"><span id="count-signalement">{{ count_signalement }}</span> signalements trouvés</h2>
 
         {% if signalements is not empty %}
-            <table id="datatable" class="liste-signalements-hors-perimetres nowrap">
+            <table id="datatable" class="liste-signalements-hors-perimetres nowrap" aria-labelledby="liste-signalements-title">
                 <thead>
                     <tr>
                         <th>ID</th>

--- a/templates/signalement_list/signalements.html.twig
+++ b/templates/signalement_list/signalements.html.twig
@@ -86,9 +86,9 @@
     </div>
 
     <div class="fr-container fr-mt-3w">
-        <h2><span id="count-signalement">{{ count_signalement }}</span> signalements trouvés</h2>
+        <h2 id="liste-signalements-title"><span id="count-signalement">{{ count_signalement }}</span> signalements trouvés</h2>
 
-        <table id="datatable-ajax" class="liste-signalements-usagers nowrap">
+        <table id="datatable-ajax" class="liste-signalements-usagers nowrap" aria-labelledby="liste-signalements-title">
             <thead>
                 <tr>
                     <th>Statut</th>

--- a/templates/signalement_list/signalements.html.twig
+++ b/templates/signalement_list/signalements.html.twig
@@ -86,7 +86,7 @@
     </div>
 
     <div class="fr-container fr-mt-3w">
-        <h2 id="liste-signalements-title"><span id="count-signalement">{{ count_signalement }}</span> signalements trouvés</h2>
+        <h2 id="liste-signalements-title" role="status"><span id="count-signalement">{{ count_signalement }}</span> signalements trouvés</h2>
 
         <table id="datatable-ajax" class="liste-signalements-usagers nowrap" aria-labelledby="liste-signalements-title">
             <thead>


### PR DESCRIPTION
## Ticket

#631 #633

## Description
Ajout de titres sur les tableaux n'ayant pas via l'attribut` aria-labelledby`
Ajout de l'attribut `role="status"` sur les titre de tableau de type "x éléments trouvés"

## Tests
- [ ] Tous les tableaux doivent être relié a un titre
- [ ] Tous les titre de type "x éléments trouvés" doivent avoir l'attribut `role="status"`
