### PR TITLE
 [Accessibilité - Audit] [Tableau de bord - 10.3] Page compréhensible sans css

### DIFF
--- a/templates/dashboard/index.html.twig
+++ b/templates/dashboard/index.html.twig
@@ -15,6 +15,14 @@
             <div class="fr-col fr-col-md-4">
                 <div class="fr-card fr-enlarge-link">
                     <div class="fr-card__body">
+                        <div class="fr-card__content">
+                            <h2 class="fr-card__title">
+                                <a href="{{ path('app_signalement_list') }}">Signalements à traiter</a>
+                            </h2>
+                            <p class="fr-card__desc">Consultez et traitez les signalements déposés par les particuliers !</p>
+                        </div>
+                    </div>
+                    <div class="fr-card__header fr-px-2w ">
                         <ul class="fr-badges-group">
                             <li>
                                 <p class="fr-badge fr-badge--no-icon fr-badge--warning">{{count_nouveaux}} nouveau(x)</p>
@@ -23,12 +31,6 @@
                                 <p class="fr-badge fr-badge--no-icon fr-badge--success">{{count_en_cours}} en cours</p>
                             </li>
                         </ul>
-                        <div class="fr-card__content">
-                            <h2 class="fr-card__title">
-                                <a href="{{ path('app_signalement_list') }}">Signalements à traiter</a>
-                            </h2>
-                            <p class="fr-card__desc">Consultez et traitez les signalements déposés par les particuliers !</p>
-                        </div>
                     </div>
                 </div>
             </div>
@@ -37,17 +39,19 @@
                 <div class="fr-col fr-col-md-4">
                     <div class="fr-card fr-enlarge-link">
                         <div class="fr-card__body">
-                        <ul class="fr-badges-group">
-                            <li>
-                                <p class="fr-badge fr-badge--no-icon fr-badge--info">{{count_hors_perimetre}} signalement(s)</p>
-                            </li>
-                        </ul>
                             <div class="fr-card__content">
                                 <h2 class="fr-card__title">
                                     <a href="{{ path('app_horsperimetre_list') }}">Hors périmètre</a>
                                 </h2>
                                 <p class="fr-card__desc">Consultez les signalements déposés sur les territoires non déployés.</p>
                             </div>
+                        </div>
+                        <div class="fr-card__header fr-px-2w ">
+                            <ul class="fr-badges-group">
+                                <li>
+                                    <p class="fr-badge fr-badge--no-icon fr-badge--info">{{count_hors_perimetre}} signalement(s)</p>
+                                </li>
+                            </ul>
                         </div>
                     </div>
                 </div>
@@ -57,17 +61,19 @@
                 <div class="fr-col fr-col-md-4">
                     <div class="fr-card fr-enlarge-link">
                         <div class="fr-card__body">
-                        <ul class="fr-badges-group">
-                            <li>
-                                <p class="fr-badge fr-badge--no-icon fr-badge--info">{{count_erp_transports}} signalement(s)</p>
-                            </li>
-                        </ul>
                             <div class="fr-card__content">
                                 <h2 class="fr-card__title">
                                     <a href="{{ path('app_erptransports_list') }}">ERP & Transports</a>
                                 </h2>
                                 <p class="fr-card__desc">Consultez les signalements sur les lieux publics et transports en commun.</p>
                             </div>
+                        </div>
+                        <div class="fr-card__header fr-px-2w ">
+                            <ul class="fr-badges-group">
+                                <li>
+                                    <p class="fr-badge fr-badge--no-icon fr-badge--info">{{count_erp_transports}} signalement(s)</p>
+                                </li>
+                            </ul>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Ticket

#629    

## Description
Utilisation correcte des cartes dsfr pour le tableau de bord : https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/carte/

## Changements apportés
* Déplacement des badges dans une div `<div class="fr-card__header">`

## Pré-requis

## Tests
- [ ] Afficher le tableau de bord, avec et sans styles css. Vérifier avec les styles que les badges s'affichent proprement en haut de la carte, et sans les styles qu'on a les infos sous le titre et la description de la carte
