### PR TITLE
[Accessibilité - Audit] [Pages du BO - 10.11] Affichage sans scroll en responsive

### DIFF
--- a/templates/base-back.html.twig
+++ b/templates/base-back.html.twig
@@ -2,6 +2,7 @@
 <html lang="fr">
     <head>
         <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>{% block title %}{% endblock %} - Stop punaises</title>
 
         <link rel="stylesheet" href="{{ asset('build/dsfr/dsfr.min.css') }}">

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -2,7 +2,7 @@
 <html lang="fr">
     <head>
         <meta charset="UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>{% block title %}{% endblock %} - Stop Punaises</title>
         
         <link rel="stylesheet" href="{{ asset('build/dsfr/dsfr.min.css') }}">


### PR DESCRIPTION
## Ticket

#630    

## Description
Ajout d'une meta dans le BO pour adapter l'affichage à la largeur de l'écran en responsive

## Changements apportés
* ajout de la meta

## Pré-requis

## Tests
- [ ] Afficher le BO en mobile pour vérifier que le contenu s'adapte à la largeur de l'écran (et vérifier en desktop aussi)
