### PR TITLE
[Accessibilité - W3C] Suppression de doublons de balises main

### DIFF
--- a/templates/bundles/TwigBundle/Exception/error.html.twig
+++ b/templates/bundles/TwigBundle/Exception/error.html.twig
@@ -1,7 +1,7 @@
 {% extends 'base.html.twig' %}
 
 {% block body %}
-    <main class="fr-container--fluid">
+    <div class="fr-container--fluid">
         <section class="index-header fr-container fr-mt-3w fr-mt-md-12w">
             <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--center fr-px-1w">
                 <div class="fr-col-10 fr-col-md-5 fr-col-lg-6">
@@ -19,6 +19,6 @@
                 </div>
             </div>
         </section>
-    </main>
+    </div>
 
 {% endblock %}

--- a/templates/bundles/TwigBundle/Exception/error403.html.twig
+++ b/templates/bundles/TwigBundle/Exception/error403.html.twig
@@ -1,7 +1,7 @@
 {% extends 'base.html.twig' %}
 
 {% block body %}
-    <main class="fr-container--fluid">
+    <div class="fr-container--fluid">
         <section class="index-header fr-container fr-mt-3w fr-mt-md-12w">
             <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--center fr-px-1w">
                 <div class="fr-col-10 fr-col-md-5 fr-col-lg-6">
@@ -18,5 +18,5 @@
                 </div>
             </div>
         </section>
-    </main>
+    </div>
 {% endblock %}

--- a/templates/bundles/TwigBundle/Exception/error404.html.twig
+++ b/templates/bundles/TwigBundle/Exception/error404.html.twig
@@ -1,7 +1,7 @@
 {% extends 'base.html.twig' %}
 
 {% block body %}
-    <main class="fr-container--fluid">
+    <div class="fr-container--fluid">
         <section class="index-header fr-container fr-mt-3w fr-mt-md-12w">
             <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--center fr-px-1w">
                 <div class="fr-col-10 fr-col-md-5 fr-col-lg-6">
@@ -18,5 +18,5 @@
                 </div>
             </div>
         </section>
-    </main>
+    </div>
 {% endblock %}

--- a/templates/front/contact.html.twig
+++ b/templates/front/contact.html.twig
@@ -3,7 +3,7 @@
 {% block title %}Contact{% endblock %}
 
 {% block body %}
-    <main id="contact-container" class="fr-container--fluid">
+    <div id="contact-container" class="fr-container--fluid fr-py-5w fr-py-md-10w">
     
         {% for label, messages in app.flashes %}
             {% for message in messages %}
@@ -13,7 +13,7 @@
             {% endfor %}
         {% endfor %}
 
-        <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--center fr-py-5w fr-py-md-10w">
+        <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--center">
             <h1 class="fr-col-11 fr-col-md-8">Contact</h1>
 
             <div class="information-contact fr-col-11 fr-col-md-8">
@@ -93,5 +93,5 @@
                 </button>
             </div>
         </div>
-    </main>
+    </div>
 {% endblock %}

--- a/templates/front/politique-de-confidentialite.html.twig
+++ b/templates/front/politique-de-confidentialite.html.twig
@@ -2,7 +2,7 @@
 {% block title %}Politique de confidentialité{% endblock %}
 
 {% block body %}
-    <main class="fr-container fr-py-5w fr-py-md-10w">
+    <div class="fr-container fr-py-5w fr-py-md-10w">
         <section class="cgu fr-grid-row fr-grid-row--center">
             <div class="fr-col-12 fr-col-lg-8">
                 <h1>Politique de confidentialité Stop-Punaises</h1>
@@ -235,5 +235,5 @@
                 </ul>
             </div>
         </section>
-    </main>
+    </div>
 {% endblock %}

--- a/templates/security/login.html.twig
+++ b/templates/security/login.html.twig
@@ -3,7 +3,7 @@
 {% block title %}Connexion à l'espace pro{% endblock %}
 
 {% block body %}
-<main class="fr-container fr-py-5w">
+<div class="fr-container fr-py-5w">
     <div class="fr-grid-row fr-grid-row--center">
         <div class="fr-col-10 fr-col-md-8 fr-col-lg-6">
             <h1>Connexion à Stop Punaises</h1>
@@ -65,5 +65,5 @@
             {% include "security/_partial_link_account_activation.html.twig" %}
         </div>
     </div>
-</main>
+</div>
 {% endblock %}

--- a/templates/security/reset_password.html.twig
+++ b/templates/security/reset_password.html.twig
@@ -7,7 +7,7 @@
 {% endblock %}
 
 {% block body %}
-<main class="fr-container fr-py-5w">
+<div class="fr-container fr-py-5w">
     <div class="fr-grid-row fr-grid-row--center">
         <div class="fr-col-10 fr-col-md-8 fr-col-lg-6">
             <h1>
@@ -65,5 +65,5 @@
             {% include "security/_partial_link_account_login.html.twig" %}
         </div>
     </div>
-</main>
+</div>
 {% endblock %}

--- a/templates/security/reset_password_link_sent.html.twig
+++ b/templates/security/reset_password_link_sent.html.twig
@@ -3,7 +3,7 @@
 {% block title %}Demande de réinitialisation envoyée{% endblock %}
 
 {% block body %}
-<main class="fr-container fr-py-5w">
+<div class="fr-container fr-py-5w">
     <div class="fr-grid-row fr-grid-row--center">
         <div class="fr-col-10 fr-col-md-8 fr-col-lg-6">
             <h1>Réinitialiser mon mot de passe</h1>
@@ -24,5 +24,5 @@
             </div>
         </div>
     </div>
-</main>
+</div>
 {% endblock %}

--- a/templates/security/reset_password_new.html.twig
+++ b/templates/security/reset_password_new.html.twig
@@ -3,7 +3,7 @@
 {% block title %}Activer mon compte{% endblock %}
 
 {% block body %}
-<main class="fr-container fr-py-5w">
+<div class="fr-container fr-py-5w">
     <div class="fr-grid-row fr-grid-row--center">
         <div class="fr-col-10 fr-col-md-8 fr-col-lg-6">
             <h1>Création de votre mot de passe</h1>
@@ -49,5 +49,5 @@
             </form>
         </div>
     </div>
-</main>
+</div>
 {% endblock %}

--- a/templates/sitemap/index.html.twig
+++ b/templates/sitemap/index.html.twig
@@ -3,7 +3,7 @@
 {% block title %}Plan du site{% endblock %}
 
 {% block body %}
-    <main class="fr-container fr-py-16v plan-du-site-header">
+    <div class="fr-container fr-py-16v plan-du-site-header">
         <div class="fr-grid-row">
             <div class="fr-col-12 fr-col-md-8">
                 <h1>Plan du site</h1>
@@ -130,5 +130,5 @@
                 </section>
             </div>
         </div>
-    </main>
+    </div>
 {% endblock %}


### PR DESCRIPTION
## Ticket

#640    

## Description
Suite aux retours de l'auditeur, des balises `div` ont été changées en balise `main` dans les fichier `base` et `base_back`.
Quand j'ai fait ça, j'ai pas pensé qu'il y en avait déjà sur certaines pages.
C'était le cas sur 
- les pages d'erreur
- la page contact
- politique de confidentialité
- login
- mot de passe oublié
- plan du site

## Tests
- [ ] Vérifier les pages concernées pour voir si il n'y a pas de problème d'affichage.
