### PR TITLE
[Accessibilité - Audit] [Formulaire signalement - 11.13] Faciliter remplissage automatique

### DIFF
--- a/src/Form/EmployeType.php
+++ b/src/Form/EmployeType.php
@@ -19,6 +19,8 @@ class EmployeType extends AbstractType
                 'attr' => [
                     'class' => 'fr-input',
                     'maxlength' => '50',
+                    'placeholder' => 'Petit',
+                    'autocomplete' => 'family-name',
                 ],
                 'label_attr' => [
                     'class' => 'fr-label',
@@ -30,6 +32,8 @@ class EmployeType extends AbstractType
                 'attr' => [
                     'class' => 'fr-input',
                     'maxlength' => '50',
+                    'placeholder' => 'Claude',
+                    'autocomplete' => 'given-name',
                 ],
                 'label_attr' => [
                     'class' => 'fr-label',
@@ -53,6 +57,8 @@ class EmployeType extends AbstractType
                     'class' => 'fr-input',
                     'pattern' => '^(?:0|\(?\+33\)?\s?|0033\s?)[1-9](?:[\.\-\s]?\d\d){4}$',
                     'maxlength' => '20',
+                    'placeholder' => '0706050403',
+                    'autocomplete' => 'tel-national',
                 ],
                 'label_attr' => [
                     'class' => 'fr-label',
@@ -64,6 +70,8 @@ class EmployeType extends AbstractType
                 'attr' => [
                     'class' => 'fr-input',
                     'maxlength' => '100',
+                    'placeholder' => 'claude.petit@courriel.fr',
+                    'autocomplete' => 'email',
                 ],
                 'label_attr' => [
                     'class' => 'fr-label',

--- a/src/Form/EntrepriseType.php
+++ b/src/Form/EntrepriseType.php
@@ -76,7 +76,7 @@ class EntrepriseType extends AbstractType
                 'attr' => [
                     'class' => 'fr-input',
                     'maxlength' => '100',
-                    'placeholder' => 'claude.petit@courriel.fr',
+                    'placeholder' => 'contact@sarl-stop-punaises.fr',
                     'autocomplete' => 'email',
                 ],
                 'label_attr' => [

--- a/src/Form/EntrepriseType.php
+++ b/src/Form/EntrepriseType.php
@@ -25,6 +25,8 @@ class EntrepriseType extends AbstractType
                 'attr' => [
                     'class' => 'fr-input',
                     'maxlength' => '255',
+                    'placeholder' => 'SARL Stop Punaises',
+                    'autocomplete' => 'organization',
                 ],
                 'label_attr' => [
                     'class' => 'fr-label',
@@ -36,6 +38,8 @@ class EntrepriseType extends AbstractType
                 'attr' => [
                     'class' => 'fr-input',
                     'maxlength' => '50',
+                    'placeholder' => '12345678901234',
+                    'autocomplete' => 'off',
                 ],
                 'label_attr' => [
                     'class' => 'fr-label',
@@ -48,6 +52,8 @@ class EntrepriseType extends AbstractType
                     'class' => 'fr-input',
                     'pattern' => '^(?:0|\(?\+33\)?\s?|0033\s?)[1-9](?:[\.\-\s]?\d\d){4}$',
                     'maxlength' => '20',
+                    'placeholder' => '0605040302',
+                    'autocomplete' => 'tel-national',
                 ],
                 'label_attr' => [
                     'class' => 'fr-label',
@@ -70,6 +76,8 @@ class EntrepriseType extends AbstractType
                 'attr' => [
                     'class' => 'fr-input',
                     'maxlength' => '100',
+                    'placeholder' => 'claude.petit@courriel.fr',
+                    'autocomplete' => 'email',
                 ],
                 'label_attr' => [
                     'class' => 'fr-label',

--- a/src/Form/SignalementFrontType.php
+++ b/src/Form/SignalementFrontType.php
@@ -131,7 +131,7 @@ class SignalementFrontType extends AbstractType
                     'class' => 'fr-input',
                     'maxlength' => '100',
                     'placeholder' => 'Nom du bailleur',
-                    'autocomplete' => 'nom',
+                    'autocomplete' => 'organization',
                 ],
                 'label_attr' => [
                     'class' => 'fr-label',

--- a/src/Form/SignalementFrontType.php
+++ b/src/Form/SignalementFrontType.php
@@ -56,6 +56,7 @@ class SignalementFrontType extends AbstractType
             ->add('adresse', TextType::class, [
                 'attr' => [
                     'class' => 'fr-input',
+                    'autocomplete' => 'address-line1',
                 ],
                 'label_attr' => [
                     'class' => 'fr-label',
@@ -69,6 +70,7 @@ class SignalementFrontType extends AbstractType
                     'pattern' => '[0-9]{5}',
                     'maxlength' => '5',
                     'minlength' => '5',
+                    'autocomplete' => 'postal-code',
                 ],
                 'label_attr' => [
                     'class' => 'fr-label',
@@ -90,6 +92,7 @@ class SignalementFrontType extends AbstractType
                 'attr' => [
                     'class' => 'fr-input',
                     'maxlength' => '100',
+                    'autocomplete' => 'address-level2',
                 ],
                 'label_attr' => [
                     'class' => 'fr-label',
@@ -128,6 +131,7 @@ class SignalementFrontType extends AbstractType
                     'class' => 'fr-input',
                     'maxlength' => '100',
                     'placeholder' => 'Nom du bailleur',
+                    'autocomplete' => 'nom',
                 ],
                 'label_attr' => [
                     'class' => 'fr-label',
@@ -271,6 +275,7 @@ class SignalementFrontType extends AbstractType
                 'attr' => [
                     'class' => 'fr-input',
                     'maxlength' => '100',
+                    'autocomplete' => 'family-name',
                 ],
                 'label_attr' => [
                     'class' => 'fr-label',
@@ -282,6 +287,7 @@ class SignalementFrontType extends AbstractType
                 'attr' => [
                     'class' => 'fr-input',
                     'maxlength' => '100',
+                    'autocomplete' => 'given-name',
                 ],
                 'label_attr' => [
                     'class' => 'fr-label',
@@ -293,6 +299,7 @@ class SignalementFrontType extends AbstractType
                 'attr' => [
                     'class' => 'fr-input',
                     'maxlength' => '15',
+                    'autocomplete' => 'tel-national',
                 ],
                 'label_attr' => [
                     'class' => 'fr-label',
@@ -304,6 +311,7 @@ class SignalementFrontType extends AbstractType
                 'attr' => [
                     'class' => 'fr-input',
                     'maxlength' => '100',
+                    'autocomplete' => 'email',
                 ],
                 'label_attr' => [
                     'class' => 'fr-label',

--- a/src/Form/SignalementHistoryType.php
+++ b/src/Form/SignalementHistoryType.php
@@ -38,6 +38,7 @@ class SignalementHistoryType extends AbstractType
             ->add('adresse', TextType::class, [
                 'attr' => [
                     'class' => 'fr-input',
+                    'autocomplete' => 'address-line1',
                 ],
                 'label_attr' => [
                     'class' => 'fr-label',
@@ -51,6 +52,7 @@ class SignalementHistoryType extends AbstractType
                     'pattern' => '[0-9]{5}',
                     'maxlength' => '5',
                     'minlength' => '5',
+                    'autocomplete' => 'postal-code',
                 ],
                 'label_attr' => [
                     'class' => 'fr-label',
@@ -140,6 +142,7 @@ class SignalementHistoryType extends AbstractType
                 'attr' => [
                     'class' => 'fr-input',
                     'maxlength' => '100',
+                    'autocomplete' => 'family-name',
                 ],
                 'label_attr' => [
                     'class' => 'fr-label',
@@ -151,6 +154,7 @@ class SignalementHistoryType extends AbstractType
                 'attr' => [
                     'class' => 'fr-input',
                     'maxlength' => '100',
+                    'autocomplete' => 'given-name',
                 ],
                 'label_attr' => [
                     'class' => 'fr-label',
@@ -162,6 +166,7 @@ class SignalementHistoryType extends AbstractType
                 'attr' => [
                     'class' => 'fr-input',
                     'maxlength' => '15',
+                    'autocomplete' => 'tel-national',
                 ],
                 'label_attr' => [
                     'class' => 'fr-label',
@@ -173,6 +178,7 @@ class SignalementHistoryType extends AbstractType
                 'attr' => [
                     'class' => 'fr-input',
                     'maxlength' => '100',
+                    'autocomplete' => 'email',
                 ],
                 'label_attr' => [
                     'class' => 'fr-label',
@@ -254,7 +260,7 @@ class SignalementHistoryType extends AbstractType
                 'placeholder' => 'Type de traitement',
                 'required' => false,
             ])
-            ->add('nomBiocide', TelType::class, [
+            ->add('nomBiocide', TextType::class, [
                 'attr' => [
                     'class' => 'fr-input',
                     'maxlength' => '100',

--- a/templates/front_signalement/_partial_step_home.html.twig
+++ b/templates/front_signalement/_partial_step_home.html.twig
@@ -9,7 +9,15 @@
 
             <div class="fr-input-group">
                 <label class="fr-label" for="code-postal">Code postal</label>
-                <input class="fr-input" id="code-postal" name="code-postal" placeholder="Exemple : 69002" required type="text" maxlength=5 minlength=5>
+                <input class="fr-input"
+                       id="code-postal"
+                       name="code-postal"
+                       placeholder="Exemple : 69002"
+                       required
+                       type="text"
+                       maxlength=5
+                       minlength=5
+                       autocomplete="postal-code">
                 <p class="fr-error-text fr-hidden">
                     Veuillez renseigner votre code postal.
                 </p>

--- a/templates/front_signalement/_partial_step_info_logement.html.twig
+++ b/templates/front_signalement/_partial_step_info_logement.html.twig
@@ -35,7 +35,7 @@
             <label for="rechercheAdresse" class="fr-label required">Mon adresse est...</label>
             <span class="fr-hint-text help-text">Saisissez le début de votre adresse puis sélectionnez-la dans la liste.</span>
             <div class="fr-input-wrap fr-icon-map-pin-2-line">
-                <input id="rechercheAdresse" type="text" class="fr-input">
+                <input id="rechercheAdresse" type="text" class="fr-input" autocomplete="street">
                 <p class="fr-error-text fr-hidden">
                     Veuillez renseigner l'adresse de votre logement.
                 </p>

--- a/templates/security/reset_password_new.html.twig
+++ b/templates/security/reset_password_new.html.twig
@@ -31,12 +31,12 @@
 
                 <div class="fr-input-group">
                     <label class="fr-label" for="login-password">Mot de passe</label>
-                    <input class="fr-input" type="password" id="login-password" name="password" required minlength="8">
+                    <input class="fr-input" type="password" id="login-password" name="password" required minlength="8" autocomplete="new-password">
                 </div>
 
                 <div class="fr-input-group">
                     <label class="fr-label" for="login-password-repeat">Confirmation du mot de passe</label>
-                    <input class="fr-input" type="password" id="login-password-repeat" name="password-repeat" required minlength="8">
+                    <input class="fr-input" type="password" id="login-password-repeat" name="password-repeat" required minlength="8" autocomplete="new-password">
                 </div>
 
                 <input type="hidden" name="_csrf_token" value="{{ csrf_token('create_password_'~id) }}">

--- a/templates/signalement_create/tab-1.html.twig
+++ b/templates/signalement_create/tab-1.html.twig
@@ -11,7 +11,7 @@
                     Si vous ne trouvez pas l'adresse, saisissez-la manuellement
                 </span>
                 <div class="fr-input-wrap fr-icon-map-pin-2-line">
-                    <input id="rechercheAdresse" type="text" class="fr-input">
+                    <input id="rechercheAdresse" type="text" class="fr-input" autocomplete="street">
                     <div id="rechercheAdresseListe" class="fr-mt-1v fr-py-1w">
                         <select size="5">
                         </select>


### PR DESCRIPTION
## Ticket

#623    

## Description
Description de la modification apportée

## Changements apportés
* Ajout attribut autocomplete contextualisé sur les champs de formulaire

## Pré-requis
https://developer.mozilla.org/fr/docs/Web/HTML/Attributes/autocomplete

## Tests
- [ ] Formulaire de dépôt de signalement
- [ ] Formulaire de création de signalement BO
- [ ] Formulaire création entreprise
- [ ] Formulaire création employé
- [ ] Formuaire Login
- [ ] Formualires Request and Reset password
