### PR TITLE
[Suivi usager] Couleurs, structuration modale et lien téléchargement

### DIFF
--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -232,7 +232,6 @@ span.statut-infestation {
     .even-item-date {
         font-size: 0.9rem;
         font-style: italic;
-        color: var(--grey-625-425);
     }
 
     h4 {

--- a/src/EventSubscriber/SignalementAddedSubscriber.php
+++ b/src/EventSubscriber/SignalementAddedSubscriber.php
@@ -48,7 +48,6 @@ class SignalementAddedSubscriber implements EventSubscriberInterface
                 recipient: $signalement->getEmailOccupant(),
                 userId: null,
                 pdfUrl: $signalementAddedEvent->getPdfUrl(),
-                pdfSize: $signalementAddedEvent->getPdfSize(),
             );
             $this->eventRepository->updateCreatedAt($event, $signalementAddedEvent->getCreatedAt());
 
@@ -57,7 +56,6 @@ class SignalementAddedSubscriber implements EventSubscriberInterface
                 recipient: null,
                 userId: Event::USER_ALL,
                 pdfUrl: null,
-                pdfSize: null,
             );
             $this->eventRepository->updateCreatedAt($event, $signalementAddedEvent->getCreatedAt());
         }

--- a/src/Manager/EventManager.php
+++ b/src/Manager/EventManager.php
@@ -7,7 +7,6 @@ use App\Entity\MessageThread;
 use App\Entity\Signalement;
 use App\Factory\EventFactory;
 use App\Repository\EventRepository;
-use App\Utils\FileHelper;
 use Doctrine\Persistence\ManagerRegistry;
 
 class EventManager extends AbstractManager
@@ -68,9 +67,7 @@ class EventManager extends AbstractManager
         ?string $recipient,
         ?int $userId,
         ?string $pdfUrl,
-        ?int $pdfSize,
     ): Event {
-        $pdfSizeFormatted = $pdfSize ? ' ('.FileHelper::fileSizeFormatter($pdfSize, 2).')' : '';
         $event = $this->eventFactory->createInstance(
             domain: Event::DOMAIN_PROTOCOLE,
             title: 'Protocole envoyé',
@@ -78,7 +75,7 @@ class EventManager extends AbstractManager
             userId: $userId,
             recipient: $recipient,
             actionLink: $pdfUrl ? $pdfUrl : null,
-            actionLabel: $pdfUrl ? 'Télécharger le protocole'.$pdfSizeFormatted : null,
+            actionLabel: $pdfUrl ? 'Télécharger le protocole' : null,
             entityName: Signalement::class,
             entityUuid: $signalement->getUuid()
         );

--- a/templates/common/components/signalement-detail-evenements.html.twig
+++ b/templates/common/components/signalement-detail-evenements.html.twig
@@ -29,7 +29,7 @@
                 {% if event.domain is same as(constant('App\\Entity\\Event::DOMAIN_PROTOCOLE') ) %}
                     <div class="event-item-action fr-mt-3v">
                         <a class="fr-link fr-link--download" download href="{{ event.actionLink }}">
-                            {{ event.actionLabel }}<span class="fr-link__detail">PDF</span>
+                            {{ event.actionLabel }}<span class="fr-link__detail">PDF - {{size_pdf|format_bytes}}</span>
                         </a>
                     </div>
                 {% else  %}

--- a/templates/common/components/signalement-detail-evenements.html.twig
+++ b/templates/common/components/signalement-detail-evenements.html.twig
@@ -4,7 +4,7 @@
 
 {% for event in events %}
     <div class="event-item fr-mb-3w fr-pb-3w">
-        <div class="even-item-date">{{ event.date.format('d/m/Y') }}</div>
+        <div class="even-item-date fr-text--light">{{ event.date.format('d/m/Y') }}</div>
         {% if event.label is defined and event.label is not null %}
             <div><p class="fr-badge fr-badge--warning fr-badge--no-icon">{{ event.label }}</p></div>
         {% endif %}
@@ -26,9 +26,17 @@
                     <a href="#" class="{{ event.actionLink }}">{{ event.actionLabel }}</a>
                 </div>
             {% else  %}
-                <div class="event-item-action fr-mt-3v">
-                    <a href="{{ event.actionLink }}" {% if event.domain is not defined %} target="_blank" {% endif %}>{{ event.actionLabel }}</a>
-                </div>
+                {% if event.domain is same as(constant('App\\Entity\\Event::DOMAIN_PROTOCOLE') ) %}
+                    <div class="event-item-action fr-mt-3v">
+                        <a class="fr-link fr-link--download" download href="{{ event.actionLink }}">
+                            {{ event.actionLabel }}<span class="fr-link__detail">PDF</span>
+                        </a>
+                    </div>
+                {% else  %}
+                    <div class="event-item-action fr-mt-3v">
+                        <a href="{{ event.actionLink }}" {% if event.domain is not defined %} target="_blank" {% endif %}>{{ event.actionLabel }}</a>
+                    </div>
+                {% endif %}
             {% endif %}
         {% endif %}
     </div>

--- a/templates/front_suivi_usager/index.html.twig
+++ b/templates/front_suivi_usager/index.html.twig
@@ -55,7 +55,9 @@
             {% if not signalement.resolvedAt and not signalement.closedAt %}
             <div class="fr-grid-row fr-grid-row--gutters align-center">
                 <div class="fr-col fr-col-12 fr-col-lg-6 fr-mb-3v">
-                    <a class="fr-btn fr-btn--icon-left fr-icon-download-line" href="{{ link_pdf }}" target="_blank">Télécharger le protocole ({{size_pdf|format_bytes}})</a>
+                    <a class="fr-link fr-link--download" download href="{{ link_pdf }}">
+                        Télécharger le protocole <span class="fr-link__detail">PDF – {{size_pdf|format_bytes}}</span>
+                    </a>
                 </div>
 
                 <div class="fr-col fr-col-12 fr-col-lg-6 fr-mb-3v">

--- a/templates/front_suivi_usager/modal-close-signalement.html.twig
+++ b/templates/front_suivi_usager/modal-close-signalement.html.twig
@@ -10,11 +10,12 @@
                         <h1 id="fr-modal-title-modal-close-signalement" class="fr-modal__title">Arrêter la procédure</h1>
                         <p>
                             En arrêtant la procédure :<br>
-                            - Votre signalement sera clôturé<br>
-                            - Les estimations acceptées ou en attente seront refusées<br>
-                            - Vous ne pourrez plus répondre aux entreprises<br>
-                            - Les entreprises ne pourront plus vous contacter<br>
-                            <br>
+                            <ul>
+                                <li>Votre signalement sera clôturé</li>
+                                <li>Les estimations acceptées ou en attente seront refusées</li>
+                                <li>Vous ne pourrez plus répondre aux entreprises</li>
+                                <li>Les entreprises ne pourront plus vous contacter</li>
+                            </ul>
                             Voulez-vous vraiment arrêter la procédure ?
                         </p>
                         <div>
@@ -24,7 +25,7 @@
                             </form>
                         </div>
                         <p class="align-center fr-mt-3v">
-                            <a aria-controls="fr-modal-close-signalement" href="#">&lt; Retour</a>
+                            <button class="fr-btn  fr-btn--tertiary fr-btn--icon-left  fr-icon-arrow-go-back-line" aria-controls="fr-modal-close-signalement" href="#">Retour</button>
                         </p>
                     </div>
                 </div>

--- a/templates/front_suivi_usager/modal-empty-estimations.html.twig
+++ b/templates/front_suivi_usager/modal-empty-estimations.html.twig
@@ -38,7 +38,7 @@
                             </form>
                         </div>
                         <p class="align-center fr-mt-3v">
-                            <a aria-controls="fr-modal-toujours-punaises" href="#">&lt; Retour</a>
+                            <button class="fr-btn  fr-btn--tertiary fr-btn--icon-left  fr-icon-arrow-go-back-line" aria-controls="fr-modal-empty-estimations" href="#">Retour</button>
                         </p>
                     </div>
                 </div>

--- a/templates/front_suivi_usager/modal-probleme-resolu-pro.html.twig
+++ b/templates/front_suivi_usager/modal-probleme-resolu-pro.html.twig
@@ -23,7 +23,7 @@
                             <button class="fr-btn fr-btn--sm fr-btn--icon-left fr-icon-close-line color-close" data-fr-opened="false" aria-controls="fr-modal-toujours-punaises-pro">J'ai toujours des punaises</button>
                         </div>
                         <p class="align-center fr-mt-3v">
-                            <a aria-controls="fr-modal-probleme-resolu-pro" href="#">&lt; Retour</a>
+                            <button class="fr-btn  fr-btn--tertiary fr-btn--icon-left  fr-icon-arrow-go-back-line" aria-controls="fr-modal-probleme-resolu-pro" href="#">Retour</button>
                         </p>
                     </div>
                 </div>

--- a/templates/front_suivi_usager/modal-probleme-resolu.html.twig
+++ b/templates/front_suivi_usager/modal-probleme-resolu.html.twig
@@ -23,7 +23,7 @@
                             <button class="fr-btn fr-btn--sm fr-btn--icon-left fr-icon-close-line color-close" data-fr-opened="false" aria-controls="fr-modal-toujours-punaises">J'ai toujours des punaises</button>
                         </div>
                         <p class="align-center fr-mt-3v">
-                            <a aria-controls="fr-modal-probleme-resolu" href="#">&lt; Retour</a>
+                            <button class="fr-btn  fr-btn--tertiary fr-btn--icon-left  fr-icon-arrow-go-back-line" aria-controls="fr-modal-probleme-resolu" href="#">Retour</button>
                         </p>
                     </div>
                 </div>

--- a/templates/front_suivi_usager/modal-toujours-punaises-pro.html.twig
+++ b/templates/front_suivi_usager/modal-toujours-punaises-pro.html.twig
@@ -20,7 +20,7 @@
                             </form>
                         </div>
                         <p class="align-center fr-mt-3v">
-                            <a aria-controls="fr-modal-toujours-punaises-pro" href="#">&lt; Retour</a>
+                            <button class="fr-btn  fr-btn--tertiary fr-btn--icon-left  fr-icon-arrow-go-back-line" aria-controls="fr-modal-toujours-punaises-pro" href="#">Retour</button>
                         </p>
                     </div>
                 </div>

--- a/templates/front_suivi_usager/modal-toujours-punaises.html.twig
+++ b/templates/front_suivi_usager/modal-toujours-punaises.html.twig
@@ -32,7 +32,7 @@
                             </form>
                         </div>
                         <p class="align-center fr-mt-3v">
-                            <a aria-controls="fr-modal-toujours-punaises" href="#">&lt; Retour</a>
+                            <button class="fr-btn  fr-btn--tertiary fr-btn--icon-left  fr-icon-arrow-go-back-line" aria-controls="fr-modal-toujours-punaises" href="#">Retour</button>
                         </p>
                     </div>
                 </div>


### PR DESCRIPTION
## Ticket

#644   
#648
#651
#645

## Description
Modifications sur la page de suivi usager

## Changements apportés
* Modification sur la couleur de date des évenemtns
* Dans la modale de confirmation d'arrêt de procédure utilisation d'une liste structurée `<ul>`
* Dans différentes modales  (dont arrêt de la procédure) transformation du lien "< Retour" etn bouton Retour
* Transformation du lien Télécharger le protocole, dans la page de suivi et dans la liste d'événement (si autotraitement) pour utiliser le DSFR https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/telechargement-de-fichier

## Pré-requis

## Tests
- [ ] Vérifier les différents points ci-dessus dans la page de suivi usager, en traitement pro et en autotraitement
