### PR TITLE
[Accessibilité - BO] Amélioration des liens

### DIFF
--- a/assets/controllers/list_employes.js
+++ b/assets/controllers/list_employes.js
@@ -25,10 +25,21 @@ function startListeEmployesApp() {
       zeroRecords: "Aucun employé trouvé",
       paginate: {
         first: "|&lt;",
-        previous: "&lt;",
-        next: "&gt;",
+        previous: "&lt; Page précédente",
+        next: "Page suivante &gt;",
         last: "&gt;|"
       }
+    },
+    initComplete: function(settings, json) {
+      $('#datatable_paginate').attr('role', 'navigation');
+      $('#datatable_paginate').attr('aria-label', 'Pagination');
+      $('#datatable_previous').attr('title', 'Page précédente');
+      $('#datatable_next').attr('title', 'Page suivante');
+      $('.paginate_button').each(function(index, element) {
+        if ($(element).text().indexOf('Page') == -1) {
+          $(element).attr('title', 'Page ' + index)
+        }
+      })
     }
   });
 

--- a/assets/controllers/list_employes.js
+++ b/assets/controllers/list_employes.js
@@ -35,10 +35,14 @@ function startListeEmployesApp() {
       $('#datatable_paginate').attr('aria-label', 'Pagination');
       $('#datatable_previous').attr('title', 'Page précédente');
       $('#datatable_next').attr('title', 'Page suivante');
-      $('.paginate_button').each(function(index, element) {
+      $('a.paginate_button').each(function(index, element) {
+        $(element).attr('href', '#')
         if ($(element).text().indexOf('Page') == -1) {
           $(element).attr('title', 'Page ' + index)
         }
+      })
+      $("a.paginate_button").on("click", function(e){
+        e.preventDefault();
       })
     }
   });

--- a/assets/controllers/list_employes.js
+++ b/assets/controllers/list_employes.js
@@ -30,7 +30,7 @@ function startListeEmployesApp() {
         last: "&gt;|"
       }
     },
-    initComplete: function(settings, json) {
+    drawCallback: function(settings, json) {
       $('#datatable_paginate').attr('role', 'navigation');
       $('#datatable_paginate').attr('aria-label', 'Pagination');
       $('#datatable_previous').attr('title', 'Page précédente');

--- a/assets/controllers/list_entreprises.js
+++ b/assets/controllers/list_entreprises.js
@@ -36,10 +36,14 @@ function startListeEntreprisesApp() {
       $('#datatable_paginate').attr('aria-label', 'Pagination');
       $('#datatable_previous').attr('title', 'Page précédente');
       $('#datatable_next').attr('title', 'Page suivante');
-      $('.paginate_button').each(function(index, element) {
+      $('a.paginate_button').each(function(index, element) {
+        $(element).attr('href', '#')
         if ($(element).text().indexOf('Page') == -1) {
           $(element).attr('title', 'Page ' + index)
         }
+      })
+      $("a.paginate_button").on("click", function(e){
+        e.preventDefault();
       })
     }
   });

--- a/assets/controllers/list_entreprises.js
+++ b/assets/controllers/list_entreprises.js
@@ -31,7 +31,7 @@ function startListeEntreprisesApp() {
         last: "&gt;|"
       }
     },
-    initComplete: function(settings, json) {
+    drawCallback: function(settings, json) {
       $('#datatable_paginate').attr('role', 'navigation');
       $('#datatable_paginate').attr('aria-label', 'Pagination');
       $('#datatable_previous').attr('title', 'Page précédente');

--- a/assets/controllers/list_entreprises.js
+++ b/assets/controllers/list_entreprises.js
@@ -26,10 +26,21 @@ function startListeEntreprisesApp() {
       zeroRecords: "Aucune entreprise trouvée",
       paginate: {
         first: "|&lt;",
-        previous: "&lt;",
-        next: "&gt;",
+        previous: "&lt; Page précédente",
+        next: "Page suivante &gt;",
         last: "&gt;|"
       }
+    },
+    initComplete: function(settings, json) {
+      $('#datatable_paginate').attr('role', 'navigation');
+      $('#datatable_paginate').attr('aria-label', 'Pagination');
+      $('#datatable_previous').attr('title', 'Page précédente');
+      $('#datatable_next').attr('title', 'Page suivante');
+      $('.paginate_button').each(function(index, element) {
+        if ($(element).text().indexOf('Page') == -1) {
+          $(element).attr('title', 'Page ' + index)
+        }
+      })
     }
   });
 

--- a/assets/controllers/list_signalement.js
+++ b/assets/controllers/list_signalement.js
@@ -27,10 +27,21 @@ function startListeSignalementsApp() {
       zeroRecords: "Aucun signalement trouvé",
       paginate: {
         first: "|&lt;",
-        previous: "&lt;",
-        next: "&gt;",
+        previous: "&lt; Page précédente",
+        next: "Page suivante &gt;",
         last: "&gt;|"
       }
+    },
+    initComplete: function(settings, json) {
+      $('#datatable-ajax_paginate').attr('role', 'navigation');
+      $('#datatable-ajax_paginate').attr('aria-label', 'Pagination');
+      $('#datatable-ajax_previous').attr('title', 'Page précédente');
+      $('#datatable-ajax_next').attr('title', 'Page suivante');
+      $('.paginate_button').each(function(index, element) {
+        if ($(element).text().indexOf('Page') == -1) {
+          $(element).attr('title', 'Page ' + index)
+        }
+      })
     }
   }
   let idTable = 'table#datatable'

--- a/assets/controllers/list_signalement.js
+++ b/assets/controllers/list_signalement.js
@@ -37,10 +37,14 @@ function startListeSignalementsApp() {
       $('#datatable-ajax_paginate').attr('aria-label', 'Pagination');
       $('#datatable-ajax_previous').attr('title', 'Page précédente');
       $('#datatable-ajax_next').attr('title', 'Page suivante');
-      $('.paginate_button').each(function(index, element) {
+      $('a.paginate_button').each(function(index, element) {
+        $(element).attr('href', '#')
         if ($(element).text().indexOf('Page') == -1) {
           $(element).attr('title', 'Page ' + index)
         }
+      })
+      $("a.paginate_button").on("click", function(e){
+        e.preventDefault();
       })
 
       // refresh count when ajax call is done

--- a/assets/controllers/list_signalement.js
+++ b/assets/controllers/list_signalement.js
@@ -32,7 +32,7 @@ function startListeSignalementsApp() {
         last: "&gt;|"
       }
     },
-    initComplete: function(settings, json) {
+    drawCallback: function( oSettings ) {
       $('#datatable-ajax_paginate').attr('role', 'navigation');
       $('#datatable-ajax_paginate').attr('aria-label', 'Pagination');
       $('#datatable-ajax_previous').attr('title', 'Page précédente');
@@ -42,6 +42,11 @@ function startListeSignalementsApp() {
           $(element).attr('title', 'Page ' + index)
         }
       })
+
+      // refresh count when ajax call is done
+      if (oSettings.json !== undefined) {
+        $("span#count-signalement").text(oSettings.json.recordsFiltered);
+      }
     }
   }
   let idTable = 'table#datatable'

--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -119,11 +119,6 @@ span.statut-infestation {
         border: 0px;
         background: var(--blue-france-850-200);
     }
-    .dataTables_paginate .paginate_button:hover {
-        color: #161616 !important;
-        background-color: #E5E5E5;
-
-    }
 }
 
 .fr-header {


### PR DESCRIPTION
## Ticket

#632
#670   

## Description
Amélioration des liens dans le BO
- les liens de pagination de listes
- les liens dans la fiche de suivi d'un signalement

L'auditeur conseillait d'utiliser la pagination du DSFR, mais la structure est très différente de celle de Datatable.
J'ai donc opté plutôt pour l'édition en js des title et roles des balises pour faire correspondre.

## Tests
- [ ] Dans les listes de signalements : Vérifier les liens de pagination
- [ ] Dans les listes des entreprises : Vérifier les liens de pagination
- [ ] Dans une listes d'employés  : Vérifier les liens de pagination
- [ ] Dans une fiche signalement : vérifier lien pour ouvrir la carte et pour voir les photos
