### PR TITLE
[Accessibilité - Niveau infestation] Modification de la couleur faible pour un meilleur contraste

### DIFF
--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -17,7 +17,7 @@ span.niveau-infestation {
         background-color: var(--success-425-625);
     }
     &.niveau-1 {
-        background-color: var(--orange-terre-battue-main-645);
+        background-color: var(--yellow-tournesol-925-125);
         color: var(--grey-200-850);
     }
     &.niveau-2 {
@@ -498,7 +498,7 @@ span.image-caption {
                     background-color: var(--success-425-625);
 
                     &.number-1 {
-                        background-color: var(--orange-terre-battue-main-645);
+                        background-color: var(--yellow-tournesol-925-125);
                         color: var(--grey-200-850);
                     }
 


### PR DESCRIPTION
## Ticket

#669    

## Description
Modification de la couleur de niveau d'infestation faible pour améliorer le contraste

## Tests
- [ ] Vérifier couleur d'affichage sur page d'informations
- [ ] Vérifier couleur d'affichage dans la liste des signalements BO et sur la fiche signalement
