### PR TITLE
[Accessibilité - Audit] [BO Ajout signalement - 12.8] Ordre de tabulation incohérent

### DIFF
--- a/templates/signalement_create/tab-2.html.twig
+++ b/templates/signalement_create/tab-2.html.twig
@@ -158,6 +158,6 @@
 </div>
 
 <nav class="stepper-previous fr-mt-3w">
-    <a href="#">&lt; Précédent</a>
     <button class="fr-btn fr-btn--icon-left fr-icon-checkbox-circle-line" disabled>Valider</button>
+    <a href="#">&lt; Précédent</a>
 </nav>


### PR DESCRIPTION
## Ticket

#660

## Description
Dépôt signalement BO: Modification de l'ordre dans le HTML du bouton Valider et précédent pour la cohérence de la navigation par tabulations

## Pré-requis

## Tests
- [ ] Vérifier que la tabulation amène en premier sur le bouton "Valider" 
