### PR TITLE
[Accessibilité - BO - Fiche signalement] Modification du champ d'upload

### DIFF
--- a/templates/signalement_view/tab-intervention.html.twig
+++ b/templates/signalement_view/tab-intervention.html.twig
@@ -62,7 +62,7 @@
                 <label class="fr-label" for="file-upload">Ajouter des photos
                     <span class="fr-hint-text">Taille maximale : 5 Mo. Formats supportés : jpg, png. Plusieurs fichiers possibles.</span>
                 </label>
-                <input class="fr-upload" type="file" id="file-upload" name="file-upload[]" multiple>
+                <input class="fr-upload" type="file" id="file-upload" name="file-upload[]" multiple accept=".jpg, .jpeg, .png">
             </div>
         </form>
         <div class="fr-grid-row fr-grid fr-grid-row--gutters fr-signalement-photos">

--- a/templates/signalement_view/tab-intervention.html.twig
+++ b/templates/signalement_view/tab-intervention.html.twig
@@ -59,7 +59,9 @@
         <h3>Photos de la situation</h3>
         <form action="{{ path('app_add_photos', {'uuid': signalement.uuid }) }}" method="POST" enctype="multipart/form-data" class="fr-my-3w file-auto-submit">
             <div class="fr-upload-group">
-                <label class="fr-label" for="file-upload">Ajouter des fichiers</label>
+                <label class="fr-label" for="file-upload">Ajouter des photos
+                    <span class="fr-hint-text">Taille maximale : 5 Mo. Formats supportés : jpg, png. Plusieurs fichiers possibles.</span>
+                </label>
                 <input class="fr-upload" type="file" id="file-upload" name="file-upload[]" multiple>
             </div>
         </form>


### PR DESCRIPTION
## Ticket

#673    

## Description
Modification du champ d'upload dans la fiche signalement (label, conseil, type de fichiers)

## Tests
- [ ] Aller sur un signalement historique, dans le premier onglet, vérifier l'affichage
