### PR TITLE
[Accessibilité - Formulaire signalement] Amélioration responsive sur l'étape de résumé

### DIFF
--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -71,6 +71,10 @@ span.statut-infestation {
     text-align: right;
 }
 
+.word-wrap {
+    word-wrap: break-word;
+}
+
 .add-button-container {
     float: right;
 }
@@ -611,11 +615,6 @@ span.image-caption {
         .no-accordions-group {
             display: none;
         }
-    }
-
-    .word-wrap {
-        word-wrap: break-word;
-        hyphens: auto;
     }
 }
 @media (min-width: 768px) {

--- a/templates/front_signalement/_partial_step_resume.html.twig
+++ b/templates/front_signalement/_partial_step_resume.html.twig
@@ -9,7 +9,7 @@
         <div class="fr-stepper__steps" data-fr-current-step="8" data-fr-steps="8"></div>
     </div>
 
-    <div class="fr-mb-4w">
+    <div class="fr-mb-4w word-wrap">
         <h2 class="fr-h4">Récapitulatif</h2>
         <div class="fr-grid-row">
             <div class="fr-col-8">


### PR DESCRIPTION
## Ticket

#619   

## Description
Sur l'étape de résumé, avec un nom/prénom/email long, le texte sortait de la zone et provoquait l'apparition d'un scroll horizontal en format mobile.
Ajout d'une règle css pour que ça revienne à la ligne automatiquement sur cette zone, si nécessaire.

## Tests
- [ ] Faire un signalement, mettre des infos longues, et vérifier l'affichage
