### PR TITLE
[Accessibilité - Audit] [Formulaire signalement - 11.7] Légende mal reliée à des radio

### DIFF
--- a/src/Form/SignalementFrontType.php
+++ b/src/Form/SignalementFrontType.php
@@ -239,7 +239,8 @@ class SignalementFrontType extends AbstractType
                 'label_attr' => [
                     'class' => 'fr-label',
                 ],
-                'label' => 'J\'ai des piqures de punaises de lit',
+                'label' => 'J\'ai des <span class="underline">piqûres</span> de punaises de lit<br><a href="#" class="info" data-fr-opened="false" aria-controls="fr-modal-piqures">Plus d\'informations</a>',
+                'label_html' => true,
                 'row_attr' => [
                     'class' => 'fr-select-group',
                 ],

--- a/templates/front_signalement/_partial_step_traces_punaises_piqures.html.twig
+++ b/templates/front_signalement/_partial_step_traces_punaises_piqures.html.twig
@@ -54,15 +54,10 @@
 
     <div class="fr-form-group">
         <div class="fr-select-group">
-            <label class="fr-label required">
-                J'ai des <span class="underline">piqûres</span> de punaises de lit
-                <br>
-                <a href="#" class="info" data-fr-opened="false" aria-controls="fr-modal-piqures">Plus d'informations</a>
-            </label>
             <div class="fr-mt-3v">
                 {% include 'common/components/form/list-radio-buttons.html.twig' with {
                     'name': 'piquresExistantes',
-                    'displayLabel': false,
+                    'displayLabel': true,
                     'formObject': form.piquresExistantes,
                     'errorLabel': 'Veuillez renseigner si vous avez des piqûres de punaises de lit.'
                 } %}


### PR DESCRIPTION
## Ticket

#620

## Description
Tous les label des radio buttons sont géré par le `components/form/list-radio-buttons.html.twig`

## Tests
- [ ] Vérifier qu'aucun label de groupe de radio bouton est affiché hors du composant
