### PR TITLE
Hiérarchie des titres

### DIFF
--- a/templates/common/components/signalement-detail-evenements.html.twig
+++ b/templates/common/components/signalement-detail-evenements.html.twig
@@ -1,5 +1,5 @@
 <div class="fr-mt-5w">
-    <h3>Détails des événements</h3>
+    <h2>Détails des événements</h2>
 </div>
 
 {% for event in events %}

--- a/templates/front_suivi_usager/index.html.twig
+++ b/templates/front_suivi_usager/index.html.twig
@@ -37,8 +37,8 @@
 
     <div class="fr-grid-row fr-grid-row--gutters">
         <div class="fr-col fr-col-12 fr-col-lg-6">
-            <h1 class="fr-h2">Bonjour {{ signalement.prenomOccupant }},</h1>
-            <h2 class="fr-h3">Votre signalement #{{ signalement.reference }}</h2>
+            <h1 class="fr-h2">Suivi de votre signalement #{{ signalement.reference }}</h1>
+            <h2 class="fr-h3">A propos de votre signalement</h2>
 
             {% include "common/components/progression-signalement.html.twig" %}
 

--- a/templates/signalement_create/index.html.twig
+++ b/templates/signalement_create/index.html.twig
@@ -6,7 +6,7 @@
 <div class="creer-signalement">
     <div class="fr-p-5w">
         <div class="fr-container">
-            <h1>Détails de l'intervention</h1>
+            <h1>Création manuelle d’un signalement et d’une intervention</h1>
             <p>
                 Renseignez les détails du signalement et de votre intervention en complétant le formulaire ci-dessous.
                 Une fois toutes les étapes passées, vous pourrez le valider.
@@ -18,12 +18,15 @@
         {{ form_row(form._token) }}
 
         <div class="fr-stepper">
-            <h1 class="fr-stepper__title fr-h2">
+            <h2 class="fr-stepper__title fr-h2">
                 <span class="fr-stepper__state">Étape <span>1</span> sur 2</span>
-                <span data-step="1">Logement</span>
+                <span data-step="1">Le logement et son occupant</span>
                 <span class="fr-stepper__hidden" data-step="2">Intervention</span>
-            </h1>
+            </h2>
             <div class="fr-stepper__steps" data-fr-current-step="1" data-fr-steps="2"></div>
+            <p class="fr-stepper__details">
+                <span class="fr-text--bold">Étape suivante :</span> Intervention
+            </p>
         </div>
 
         <div id="form-creer-signalement-step-1">

--- a/templates/signalement_create/tab-1.html.twig
+++ b/templates/signalement_create/tab-1.html.twig
@@ -1,4 +1,4 @@
-<h2>Adresse et infos du logement</h2>
+<h3>Adresse et infos du logement</h3>
 
 <div class="fr-grid-row fr-grid-row--gutters">
     <div class="fr-col-12 fr-col-md-6">

--- a/templates/signalement_create/tab-2.html.twig
+++ b/templates/signalement_create/tab-2.html.twig
@@ -1,11 +1,10 @@
-<h2>Intervention</h2>
-
-<p>Sélectionnez le type d'intervention puis remplissez les champs proposés.</p>
-
 <div class="fr-grid-row fr-grid-row--gutters">
     <div class="fr-col-12 fr-col-md-6">
         <div class="fr-form-group">
             <div class="fr-select-group">
+            <label class="fr-label" for="select-hint">Type d'intervention
+                <span class="fr-hint-text">Sélectionnez le type d'intervention puis remplissez les champs proposés.</span>
+            </label>
                 {{ form_widget(form.typeIntervention) }}
                 <p class="fr-error-text fr-hidden">
                     Veuillez renseigner le type d'intervention

--- a/tests/Functional/Controller/Front/SuiviUsagerViewControllerTest.php
+++ b/tests/Functional/Controller/Front/SuiviUsagerViewControllerTest.php
@@ -31,8 +31,13 @@ class SuiviUsagerViewControllerTest extends WebTestCase
         $client->loginUser($user);
         $client->request('GET', $route);
         $this->assertResponseIsSuccessful($signalement->getId());
-        $this->assertSelectorTextContains('.suivi-usager h2',
-            'Votre signalement #'.$signalement->getReference()
+        $this->assertSelectorTextContains(
+            '.suivi-usager h1',
+            'Suivi de votre signalement #'.$signalement->getReference()
+        );
+        $this->assertSelectorTextContains(
+            '.suivi-usager h2',
+            'A propos de votre signalement'
         );
     }
 


### PR DESCRIPTION
## Ticket

#655 
#647    

## Description
Mise à jour de la hiérarchie des titres sur le suivi usager, la fiche signalement dans le BO, et l'ajout de signalement dans le BO

## Changements apportés
* Mise à jour des twigs

## Pré-requis

## Tests
- [ ] Vérifier que la hiérarchie des titres est visuellement cohérente, mais aussi en terme de headings (avec a11y-outline par exemple)
