### PR TITLE
[Accessibilité - Plusieurs pages] Utilisation sans feuille de style

### DIFF
--- a/assets/controllers/list_employes.js
+++ b/assets/controllers/list_employes.js
@@ -31,4 +31,9 @@ function startListeEmployesApp() {
       }
     }
   });
+
+  $('#select-sort-table-by').on('change', function() {
+    listTable.order([Number($('#select-sort-table-by').val()), 'asc'])
+      .draw();
+  })
 }

--- a/assets/controllers/list_entreprises.js
+++ b/assets/controllers/list_entreprises.js
@@ -41,6 +41,11 @@ function startListeEntreprisesApp() {
     $("span#count-entreprise").text(generateTableTitleFromDatatable('entreprise'));
     document.title = generatePageTitleFromDatatable('Les entreprises partenaires', 'entreprise');
   })
+  
+  $('#select-sort-table-by').on('change', function() {
+    listTable.order([Number($('#select-sort-table-by').val()), 'asc'])
+      .draw();
+  })
 }
 
 function refreshTableWithSearch() {

--- a/assets/controllers/list_signalement.js
+++ b/assets/controllers/list_signalement.js
@@ -46,6 +46,11 @@ function startListeSignalementsApp() {
   }
   listTable = $(idTable).DataTable(options);
   initComponentsEvents();
+
+  $('#select-sort-table-by').on('change', function() {
+    listTable.order([Number($('#select-sort-table-by').val()), 'asc'])
+      .draw();
+  })
 }
 
 function initComponentsEvents() {

--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -88,6 +88,8 @@ span.statut-infestation {
         width: 100%;
         .button-view {
             .fr-btn.fr-icon-arrow-right-fill, .fr-btn.fr-icon-pencil-line {
+                font-size: 0px;
+                line-height: 0px;
                 display: inline-block;
                 border-radius: 20px;
                 min-height: 1.5rem;
@@ -95,6 +97,11 @@ span.statut-infestation {
                 &::before {
                     margin-right: 0px;
                 }
+            }
+
+            a {
+                font-size: 0px;
+                line-height: 0px;
             }
         }
     }

--- a/src/Service/Signalement/SignalementOccupantDataTableHandler.php
+++ b/src/Service/Signalement/SignalementOccupantDataTableHandler.php
@@ -194,6 +194,6 @@ class SignalementOccupantDataTableHandler
                 <a class="fr-btn fr-icon-arrow-right-fill"
                 href="'.$link.'"
                 title="Voir le signalement '.$row['reference'].'"
-                ></a></span>';
+                >Voir le signalement '.$row['reference'].'</a></span>';
     }
 }

--- a/templates/common/components/signalement-detail.html.twig
+++ b/templates/common/components/signalement-detail.html.twig
@@ -83,11 +83,11 @@
                     <div class="fr-col-6 fr-col-md-3">
                         <div style="background: url('{{ photo.url }}?_csrf_token={{ csrf_token('signalement_ext_file_view') }}')no-repeat center center/cover">
                             <a class="fr-btn fr-icon-eye-line"
-                               href="{{ photo.url }}?_csrf_token={{ csrf_token('signalement_ext_file_view') }}"
-                               title="{{ 'Photo ' ~ (index + 1) ~ ' envoyée par l\'usager' }}"
-                               aria-label="{{ 'Photo ' ~ (index + 1) ~ 'envoyée par l\'usager' }}"
-                               target="_blank"
-                               rel="noopener"></a>
+                                href="{{ photo.url }}?_csrf_token={{ csrf_token('signalement_ext_file_view') }}"
+                                title="Voir la photo {{ index + 1 }} {{ photo.file }} - nouvelle fenêtre"
+                                aria-label="Voir la photo {{ index + 1 }} {{ photo.file }} - nouvelle fenêtre"
+                                target="_blank"
+                                rel="noopener">Voir la photo {{ index + 1 }} {{ photo.file }}</a>
                         </div>
                     </div>
                 {% endfor %}

--- a/templates/entreprise_list/index.html.twig
+++ b/templates/entreprise_list/index.html.twig
@@ -19,7 +19,25 @@
         </div>
 
         <div class="fr-mt-3w">
-            <h2 id="liste-entreprises-title" role="status"><span id="count-entreprise">0 entreprise trouvée</h2>
+            <h2 id="liste-entreprises-title" role="status"><span id="count-entreprise">0</span> entreprises trouvées</h2>
+
+            <div class="fr-grid-row fr-grid-row--right fr-mb-5v">
+                <div class="fr-select-group fr-col-12 fr-col-lg-3">
+                    <label class="fr-label" for="select-sort-table-by">
+                        Trier la liste par
+                    </label>
+                    <select class="fr-select" id="select-sort-table-by" name="select">
+                        <option value="" selected disabled hidden>Sélectionner une option</option>
+                        <option value="0">ID</option>
+                        <option value="1">Nom</option>
+                        <option value="2">SIRET</option>
+                        <option value="3">Label</option>
+                        <option value="4">Employés</option>
+                        <option value="5">Territoire</option>
+                    </select>
+                </div>
+            </div>
+
             {% if entreprises is not empty %}
                 <table id="datatable" class="nowrap" aria-labelledby="liste-entreprises-title">
                     <thead>

--- a/templates/entreprise_list/index.html.twig
+++ b/templates/entreprise_list/index.html.twig
@@ -46,7 +46,11 @@
                                         {{ territoire.zip }}{{ not loop.last ? ',' }}
                                     {% endfor %}
                                 </td>
-                                <td class="button-view"><a href="{{ path('app_entreprise_view',{uuid:entreprise.uuid}) }}" class="fr-btn fr-icon-arrow-right-fill" title="Voir l'entreprise {{ entreprise.nom }}"></a></td>
+                                <td class="button-view">
+                                    <a href="{{ path('app_entreprise_view',{uuid:entreprise.uuid}) }}" class="fr-btn fr-icon-arrow-right-fill" title="Voir l'entreprise {{ entreprise.nom }}">
+                                        Voir l'entreprise {{ entreprise.nom }}
+                                    </a>
+                                </td>
                             </tr>
                         {% endfor %}
                     </tbody>

--- a/templates/entreprise_view/index.html.twig
+++ b/templates/entreprise_view/index.html.twig
@@ -56,6 +56,22 @@
                 </div>
             </div>
 
+            <div class="fr-grid-row fr-grid-row--right fr-mb-5v">
+                <div class="fr-select-group fr-col-12 fr-col-lg-3">
+                    <label class="fr-label" for="select-sort-table-by">
+                        Trier la liste par
+                    </label>
+                    <select class="fr-select" id="select-sort-table-by" name="select">
+                        <option value="" selected disabled hidden>Sélectionner une option</option>
+                        <option value="0">ID</option>
+                        <option value="1">Nom</option>
+                        <option value="2">Certification Biocide</option>
+                        <option value="3">Email</option>
+                        <option value="4">Téléphone</option>
+                    </select>
+                </div>
+            </div>
+
             {% if entreprise.employes is not empty %}
                 <table id="datatable" class="nowrap" aria-labelledby="liste-employes-title">
                     <thead>

--- a/templates/entreprise_view/index.html.twig
+++ b/templates/entreprise_view/index.html.twig
@@ -77,7 +77,9 @@
                                 <td>{{ employe.email }}</td>
                                 <td>{{ employe.telephone|format_phone }}</td>
                                 <td class="button-view">
-                                    <button class="fr-btn fr-icon-pencil-line" data-fr-opened="false" aria-controls="fr-modal-edit-employe-{{employe.uuid}}"></button>
+                                    <button class="fr-btn fr-icon-pencil-line" data-fr-opened="false" aria-controls="fr-modal-edit-employe-{{employe.uuid}}" title="Editer l'employé {{ employe }}">
+                                        Editer l'employé {{ employe }}
+                                    </button>
                                 </td>
                             </tr>
                         {% endfor %}

--- a/templates/front/accessibilite.html.twig
+++ b/templates/front/accessibilite.html.twig
@@ -61,8 +61,11 @@
         <p>Vous pouvez&nbsp;:</p>
 
         <ul>
-            <li>Écrire un message au <a href="https://formulaire.defenseurdesdroits.fr/" target="_blank" rel="noopener">Défenseur des droits</a></li>
-            <li>Contacter <a href="https://www.defenseurdesdroits.fr/saisir/delegues" target="_blank" rel="noopener">le délégué du Défenseur des droits dans votre région</a></li>
+            <li>Écrire un message au <a href="https://formulaire.defenseurdesdroits.fr/" target="_blank" rel="noopener"
+                title="Défenseur des droits - nouvelle fenêtre">Défenseur des droits</a></li>
+            <li>Contacter <a href="https://www.defenseurdesdroits.fr/saisir/delegues" target="_blank" rel="noopener"
+                title="Délégué régional du Défenseur des droits - nouvelle fenêtre"
+                >le délégué du Défenseur des droits dans votre région</a></li>
             <li>
                 Envoyer un courrier par la poste (gratuit, ne pas mettre de timbre)&nbsp;:<br>
                 Défenseur des droits<br>
@@ -75,7 +78,9 @@
         
         <p>
             Cette déclaration d’accessibilité a été créé le <span>14 novembre 2023</span> grâce au 
-            <a href="https://betagouv.github.io/a11y-generateur-declaration/#create" target="_blank" rel="noopener">Générateur de Déclaration d’Accessibilité de BetaGouv</a>.
+            <a href="https://betagouv.github.io/a11y-generateur-declaration/#create" target="_blank" rel="noopener"
+                title="Générateur de Déclaration d’Accessibilité de BetaGouv - nouvelle fenêtre"
+                >Générateur de Déclaration d’Accessibilité de BetaGouv</a>.
         </p>
     </section>
 

--- a/templates/front/entreprises-labelisees.html.twig
+++ b/templates/front/entreprises-labelisees.html.twig
@@ -49,7 +49,7 @@
                                     {% if entreprise_publique.url %}
                                         <a target="_blank" rel="noopener"
                                             href="{{ entreprise_publique.url }}"
-                                            title="Accéder au site web de l'entreprise {{ entreprise_publique.nom }}">
+                                            title="Accéder au site web de l'entreprise {{ entreprise_publique.nom }} - nouvelle fenêtre">
                                     {% endif %}
                                         {{ entreprise_publique.nom }}
                                     {% if entreprise_publique.url %}
@@ -74,7 +74,7 @@
                                     <li>
                                         <a class="fr-link fr-icon-arrow-right-line fr-link--icon-right" target="_blank" rel="noopener"
                                             href="{{ entreprise_publique.url }}"
-                                            title="Accéder au site web de l'entreprise {{ entreprise_publique.nom }}"
+                                            title="Accéder au site web de l'entreprise {{ entreprise_publique.nom }} - nouvelle fenêtre"
                                             >
                                             Accéder au site web
                                         </a>

--- a/templates/front/index.html.twig
+++ b/templates/front/index.html.twig
@@ -73,7 +73,7 @@
                         Les punaises de lit peuvent infester n'importe qui et il est parfois compliqué de savoir d'où elles viennent.
                     </p>
                     <p>
-                        D'après <a href="https://www.anses.fr/fr/system/files/BIOCIDES2021SA0147Ra.pdf" target="_blank" rel="noopener">le rapport de l'Anses, l’Agence nationale de sécurité sanitaire de l’alimentation, de l’environnement et du travail (PDF – 6,3 Mo)</a> 
+                        D'après <a href="https://www.anses.fr/fr/system/files/BIOCIDES2021SA0147Ra.pdf" target="_blank" rel="noopener" title="Voir le rapport de l'Anses - nouvelle fenêtre">le rapport de l'Anses, l’Agence nationale de sécurité sanitaire de l’alimentation, de l’environnement et du travail (PDF – 6,3 Mo)</a> 
                         publié en juillet 2023, 11 % des ménages français auraient été infestés par les punaises de lit entre 2017 et 2022.
                         <br>
                         L'Anses ajoute « qu'un faible niveau de revenu ne serait pas lié à un risque supérieur d’infestation par des punaises de lit ».
@@ -166,7 +166,7 @@
                     <p>
                         Le bailleur (propriétaire) du logement paye l'intervention.
                         <br>
-                        Comme le dispose <a href="https://www.legifrance.gouv.fr/loda/id/LEGIARTI000037670751/2018-11-25/" target="_blank" rel="noopener">la loi n°2018-1021 du 23 novembre 2018</a> :
+                        Comme le dispose <a href="https://www.legifrance.gouv.fr/loda/id/LEGIARTI000037670751/2018-11-25/" target="_blank" rel="noopener" title="Voir la loi n°2018-1021 du 23 novembre 2018 - nouvelle fenêtre">la loi n°2018-1021 du 23 novembre 2018</a> :
                         « Le bailleur est tenu de remettre au locataire un logement décent ne laissant pas apparaître de risques manifestes
                          pouvant porter atteinte à la sécurité physique ou à la santé, exempt de toute infestation d'espèces nuisibles et parasites ».
                         <br>

--- a/templates/front/mentions-legales.html.twig
+++ b/templates/front/mentions-legales.html.twig
@@ -347,7 +347,8 @@
             à caractère personnel qui incombe au responsable de traitement, votre demande ne sera traitée 
             que si vous rapportez la preuve de votre identité. Pour vous aider dans votre démarche, 
             vous trouverez ici 
-            <a href="https://www.cnil.fr/fr/modele/courrier/exercer-son-droit-dacces" target="_blank" rel="noopener">
+            <a href="https://www.cnil.fr/fr/modele/courrier/exercer-son-droit-dacces" target="_blank" rel="noopener"
+                title="CNIL - nouvelle fenêtre">
                 https://www.cnil.fr/fr/modele/courrier/exercer-son-droit-dacces
             </a>, 
             un modèle de courrier élaboré par la CNIL. 
@@ -398,7 +399,8 @@
                         <td>Hébergement</td>
                         <td>France</td>
                         <td>
-                            <a href="https://scalingo.com/fr/contrat-gestion-traitements-donnees-personnelles" target="_blank" rel="noopener">
+                            <a href="https://scalingo.com/fr/contrat-gestion-traitements-donnees-personnelles" target="_blank" rel="noopener"
+                                title="Scalingo - contrat - nouvelle fenêtre">
                                 https://scalingo.com/fr/contrat-gestion-traitements-donnees-personnelles
                             </a>
                         </td>

--- a/templates/front/politique-de-confidentialite.html.twig
+++ b/templates/front/politique-de-confidentialite.html.twig
@@ -130,7 +130,9 @@
                     amenés à vous demander une preuve de votre identité.</p>
                 <p>Pour vous aider dans votre démarche, vous trouverez un modèle de courrier élaboré par la CNIL ici :
                     <a href="https://www.cnil.fr/fr/modele/courrier/exercer-son-droit-dacces" target="_blank"
-                       rel="noopener noreferrer">Modèle de Courrier CNIL</a></p>
+                       rel="noopener noreferrer"
+                       title="Modèle de Courrier CNIL - nouvelle fenêtre"
+                       >Modèle de Courrier CNIL</a></p>
                 <p>Nous nous engageons à vous répondre dans un délai raisonnable qui ne saurait dépasser 1 mois à
                     compter de la réception de votre demande.</p>
 
@@ -180,7 +182,8 @@
                             <td>Hébergement</td>
                             <td><a href="https://scalingo.com/fr/contrat-gestion-traitements-donnees-personnelles"
                                         target="_blank"
-                                        rel="noreferrer noopener">Lien vers le contrat</a>
+                                        rel="noreferrer noopener"
+                                        title="Voir le contrat Scalingo - nouvelle fenêtre">Lien vers le contrat</a>
                             </td>
                         </tr>
                         <tr>
@@ -189,7 +192,8 @@
                             <td>Mesure d’audience</td>
                             <td><a href="https://fr.matomo.org/matomo-cloud-privacy-policy/"
                                    target="_blank"
-                                   rel="noreferrer noopener">Lien vers la politique de confidentialité de Matomo</a>
+                                   rel="noreferrer noopener"
+                                   title="Voir la politique de confidentialité de Matomo - nouvelle fenêtre">Lien vers la politique de confidentialité de Matomo</a>
                             </td>
                         </tr>
                         </tbody>
@@ -228,10 +232,12 @@
                 <p>Pour aller plus loin, vous pouvez consulter les ﬁches proposées par la Commission Nationale de
                     l'Informatique et des Libertés (CNIL) :</p>
                 <ul>
-                    <li><a href="https://www.cnil.fr/fr/cookies-traceurs-que-dit-la-loi" target="_blank" rel="noreferrer noopener">Cookies &
-                            traceurs : que dit la loi ?</a></li>
-                    <li><a href="https://www.cnil.fr/fr/cookies-les-outils-pour-les-maitriser" target="_blank" rel="noreferrer noopener">Cookies :
-                            les outils pour les maîtriser</a></li>
+                    <li><a href="https://www.cnil.fr/fr/cookies-traceurs-que-dit-la-loi" target="_blank" rel="noreferrer noopener"
+                        title="Que dit la loi sur les cookies et traceurs ? - nouvelle fenêtre"
+                        >Cookies & traceurs : que dit la loi ?</a></li>
+                    <li><a href="https://www.cnil.fr/fr/cookies-les-outils-pour-les-maitriser" target="_blank" rel="noreferrer noopener"
+                        title="Les outils pour maîtriser les cookies - nouvelle fenêtre"
+                        >Cookies : les outils pour les maîtriser</a></li>
                 </ul>
             </div>
         </section>

--- a/templates/signalement_list/erp-transports.html.twig
+++ b/templates/signalement_list/erp-transports.html.twig
@@ -34,7 +34,25 @@
     </div>
 
     <div class="fr-container fr-mt-3w">
-        <h2 id="liste-signalements-title" role="status"><span id="count-signalement">0 signalement trouvé</h2>
+        <h2 id="liste-signalements-title" role="status"><span id="count-signalement">0</span> signalements trouvés</h2>
+    
+        <div class="fr-grid-row fr-grid-row--right fr-mb-5v">
+            <div class="fr-select-group fr-col-12 fr-col-lg-3">
+                <label class="fr-label" for="select-sort-table-by">
+                    Trier la liste par
+                </label>
+                <select class="fr-select" id="select-sort-table-by" name="select">
+                    <option value="" selected disabled hidden>Sélectionner une option</option>
+                    <option value="0">ID</option>
+                    <option value="1">Date de création</option>
+                    <option value="2">Type</option>
+                    <option value="3">Nom</option>
+                    <option value="4">Code postal</option>
+                    <option value="5">Territoire</option>
+                </select>
+            </div>
+        </div>
+
         {% if signalements is not empty %}
             <table id="datatable" class="liste-signalements-erp-transports nowrap" aria-labelledby="liste-signalements-title">
                 <thead>

--- a/templates/signalement_list/erp-transports.html.twig
+++ b/templates/signalement_list/erp-transports.html.twig
@@ -62,7 +62,9 @@
                             <td>{{ signalement.codePostal }} {{ signalement.ville }}</td>
                             <td>{{ signalement.territoire.zip }}</td>
                             <td class="button-view">
-                                <button class="fr-btn fr-icon-arrow-right-fill" data-fr-opened="false" aria-controls="fr-modal-signalement-erp-transports-{{signalement.uuid}}"></button>
+                                <button class="fr-btn fr-icon-arrow-right-fill" data-fr-opened="false" aria-controls="fr-modal-signalement-erp-transports-{{signalement.uuid}}" title="Voir le signalement {{ signalement.reference }}">
+                                    Voir le signalement {{ signalement.reference }}
+                                </button>
                             </td>
                         </tr>
                     {% endfor %}

--- a/templates/signalement_list/historique.html.twig
+++ b/templates/signalement_list/historique.html.twig
@@ -85,7 +85,11 @@
                                 <td>{{ signalement.entreprise ? signalement.entreprise.nom : '/' }}</td>
                             {% endif %}
                             <td>{{ signalement.codePostal }} {{ signalement.ville }}</td>
-                            <td class="button-view"><a href="{{ path('app_signalement_historique_view',{uuid:signalement.uuid}) }}" class="fr-btn fr-icon-arrow-right-fill" title="Voir le signalement {{ signalement.reference }}"></a></td>
+                            <td class="button-view">
+                                <a href="{{ path('app_signalement_historique_view',{uuid:signalement.uuid}) }}" class="fr-btn fr-icon-arrow-right-fill" title="Voir le signalement {{ signalement.reference }}">
+                                    Voir le signalement {{ signalement.reference }}
+                                </a>
+                            </td>
                         </tr>
                     {% endfor %}
                 </tbody>

--- a/templates/signalement_list/historique.html.twig
+++ b/templates/signalement_list/historique.html.twig
@@ -54,7 +54,30 @@
     </div>
 
     <div class="fr-container fr-mt-3w">
-        <h2 id="liste-signalements-title" role="status"><span id="count-signalement">0 signalement trouvé</h2>
+        <h2 id="liste-signalements-title" role="status"><span id="count-signalement">0</span> signalements trouvés</h2>
+
+        <div class="fr-grid-row fr-grid-row--right fr-mb-5v">
+            <div class="fr-select-group fr-col-12 fr-col-lg-3">
+                <label class="fr-label" for="select-sort-table-by">
+                    Trier la liste par
+                </label>
+                <select class="fr-select" id="select-sort-table-by" name="select">
+                    <option value="" selected disabled hidden>Sélectionner une option</option>
+                    <option value="0">ID</option>
+                    <option value="1">Date de création</option>
+                    <option value="2">Intervention</option>
+                    <option value="3">Date</option>
+                    <option value="4">Infestation</option>
+                    {% if is_granted('ROLE_ADMIN') %}
+                        <option value="5">Entreprise</option>
+                        <option value="6">Commune</option>
+                    {% else %}
+                        <option value="5">Commune</option>
+                    {% endif %}
+                </select>
+            </div>
+        </div>
+
         {% if signalements is not empty %}
             <table id="datatable" class="liste-signalements-historique nowrap" aria-labelledby="liste-signalements-title">
                 <thead>

--- a/templates/signalement_list/hors-perimetre.html.twig
+++ b/templates/signalement_list/hors-perimetre.html.twig
@@ -30,7 +30,23 @@
     </div>
 
     <div class="fr-container fr-mt-3w">
-        <h2 id="liste-signalements-title" role="status"><span id="count-signalement">0 signalement trouvé</h2>
+        <h2 id="liste-signalements-title" role="status"><span id="count-signalement">0</span> signalements trouvés</h2>
+
+        <div class="fr-grid-row fr-grid-row--right fr-mb-5v">
+            <div class="fr-select-group fr-col-12 fr-col-lg-3">
+                <label class="fr-label" for="select-sort-table-by">
+                    Trier la liste par
+                </label>
+                <select class="fr-select" id="select-sort-table-by" name="select">
+                    <option value="" selected disabled hidden>Sélectionner une option</option>
+                    <option value="0">ID</option>
+                    <option value="1">Date de création</option>
+                    <option value="2">Territoire</option>
+                    <option value="3">Code postal</option>
+                </select>
+            </div>
+        </div>
+
         {% if signalements is not empty %}
             <table id="datatable" class="liste-signalements-hors-perimetres nowrap" aria-labelledby="liste-signalements-title">
                 <thead>

--- a/templates/signalement_list/modal-signalement-erp-transports.html.twig
+++ b/templates/signalement_list/modal-signalement-erp-transports.html.twig
@@ -39,7 +39,7 @@
                             {% endif %}
                             {% if signalement.photos %}
                                 {% for index,photo in signalement.photos %}
-                                    <a href="{{ path('show_uploaded_file',{filename:photo.file}) }}?_csrf_token={{ csrf_token('signalement_ext_file_view') }}" title="Voir la photo" target="_blank" rel="noopener">
+                                    <a href="{{ path('show_uploaded_file',{filename:photo.file}) }}?_csrf_token={{ csrf_token('signalement_ext_file_view') }}" title="Voir la photo {{photo.file}} - nouvelle fenêtre" target="_blank" rel="noopener">
                                         Voir la photo
                                     </a>
                                     <br>

--- a/templates/signalement_list/signalements.html.twig
+++ b/templates/signalement_list/signalements.html.twig
@@ -86,7 +86,28 @@
     </div>
 
     <div class="fr-container fr-mt-3w">
-        <h2 id="liste-signalements-title" role="status"><span id="count-signalement">0 signalement trouvé</h2>
+        <h2 id="liste-signalements-title" role="status"><span id="count-signalement">0</span> signalements trouvés</h2>
+
+        <div class="fr-grid-row fr-grid-row--right fr-mb-5v">
+            <div class="fr-select-group fr-col-12 fr-col-lg-3">
+                <label class="fr-label" for="select-sort-table-by">
+                    Trier la liste par
+                </label>
+                <select class="fr-select" id="select-sort-table-by" name="select">
+                    <option value="" selected disabled hidden>Sélectionner une option</option>
+                    <option value="0">Statut</option>
+                    <option value="1">ID</option>
+                    <option value="2">Date de création</option>
+                    <option value="3">Infestation</option>
+                    <option value="4">Commune</option>
+                    {% if is_granted('ROLE_ADMIN') %}
+                        <option value="5">Type</option>
+                        <option value="6">Procédure</option>
+                    {% endif %}
+                </select>
+            </div>
+        </div>
+
         <table id="datatable-ajax" class="liste-signalements-usagers nowrap" aria-labelledby="liste-signalements-title">
             <thead>
                 <tr>

--- a/templates/signalement_view/tab-intervention.html.twig
+++ b/templates/signalement_view/tab-intervention.html.twig
@@ -70,16 +70,16 @@
                 <div class="fr-col-6 fr-col-md-3">
                     <div style="background: url('{{ photo.url }}?_csrf_token={{ csrf_token('signalement_ext_file_view') }}')no-repeat center center/cover">
                         <a class="fr-btn fr-icon-eye-line" href="{{ photo.url }}?_csrf_token={{ csrf_token('signalement_ext_file_view') }}"
-                           title="{{ 'Photo ' ~ (index + 1) ~ ' envoyée par l\'usager' }}"
-                           aria-label="{{ 'Photo ' ~ (index + 1) ~ 'envoyée par l\'usager'  }}"
+                           title="Voir la photo {{ index + 1 }} {{ photo.file }} - nouvelle fenêtre"
+                           aria-label="Voir la photo {{ index + 1 }} {{ photo.file }} - nouvelle fenêtre"
                            target="_blank"
-                           rel="noopener"></a>
+                           rel="noopener">Voir la photo {{ index + 1 }} {{ photo.file }}</a>
                         {% if is_granted('ROLE_ADMIN') or (is_granted('ROLE_ENTREPRISE')
                             and signalement.entreprise is not null
                             and signalement.entreprise.id == app.user.entreprise.id) %}
                             <form action="{{ path('app_delete_photo', {'uuid': signalement.uuid, 'filename': photo.file }) }}" method="POST">
                                 <input type="hidden" name="_csrf_token" value="{{ csrf_token('signalement_delete_file_'~signalement.id) }}">
-                                <button class="fr-btn fr-icon-delete-line" title="Supprimer la photo"></button>
+                                <button class="fr-btn fr-icon-delete-line" title="Supprimer la photo {{ index + 1 }} {{ photo.file }}">Supprimer la photo {{ index + 1 }} {{ photo.file }}</button>
                             </form>
                         {% endif %}
                     </div>

--- a/templates/signalement_view/tab-logement.html.twig
+++ b/templates/signalement_view/tab-logement.html.twig
@@ -20,7 +20,8 @@
             Construction avant 1948 : {{ signalement.construitAvant1948|construction_avant_1948 }}
             <br>
             {% if can_display_adresse %}
-                <a href="https://www.openstreetmap.org/search?query={{ signalement.adresseComplete|url_encode }}" target="_blank" rel="noopener">Afficher la carte</a>
+                <a href="https://www.openstreetmap.org/search?query={{ signalement.adresseComplete|url_encode }}" target="_blank" rel="noopener"
+                title="Afficher la carte - nouvelle fenêtre">Afficher la carte</a>
             {% endif %}
         </div>
         <div class="fr-col-12 fr-col-lg-5 edit-zone">


### PR DESCRIPTION
## Ticket

#672
#685   

## Description
Différentes modifications pour utiliser la plateforme sans feuille de style 

## Changements apportés
- ajout de `nouvelle fenêtre` dans l'attribut `title` de différents liens sur le site
- les boutons de visualisation et suppression de photos sur la fiche signalement sont accessibles sans feuille de style
- dans les listes de signalements / entreprises / employés, les boutons d'accès sont accessibles sans feuille de style
- sur ces mêmes listes, une liste déroulante permet de trier les tableaux par colonne, dans le sens ASC

## Tests
- [ ] BO - Fiche signalement : Vérifier les boutons d'affichage / suppression de photos dans l'onglet Signalement
- [ ] BO - Fiche signalement : Vérifier le bouton d'affichage de photos dans l'onglet Messages
- [ ] BO - Liste de signalements/entreprises/employés : Vérifier les boutons d'accès aux pages des éléments du tableau
- [ ] BO - Liste de signalements/entreprises/employés : Vérifier le fonctionnement de la liste déroulante de tri
