### PR TITLE
[QA - Sentry] Corrections liées aux montants entiers ou non

### DIFF
--- a/src/Controller/SignalementViewController.php
+++ b/src/Controller/SignalementViewController.php
@@ -223,7 +223,7 @@ class SignalementViewController extends AbstractController
                     $userEntreprise
                 );
                 $intervention->setCommentaireEstimation($request->get('commentaire'));
-                $intervention->setMontantEstimation($montant);
+                $intervention->setMontantEstimation(ceil($montant));
                 $intervention->setEstimationSentAt(new DateTimeImmutable());
                 $interventionManager->save($intervention);
                 $this->addFlash('success', 'L\'estimation a bien été transmise.');

--- a/src/Form/SignalementHistoryType.php
+++ b/src/Form/SignalementHistoryType.php
@@ -18,6 +18,7 @@ use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\Extension\Core\Type\EnumType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\TelType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -338,7 +339,7 @@ class SignalementHistoryType extends AbstractType
                 'label' => 'Date de la visite post-traitement',
                 'required' => false,
             ])
-            ->add('prixFactureHT', TextType::class, [
+            ->add('prixFactureHT', NumberType::class, [
                 'attr' => [
                     'class' => 'fr-input',
                     'maxlength' => '100',


### PR DESCRIPTION
## Ticket

#688
#689

## Description
Sentry remonte des bugs sur des montants saisis en tant qu'entier ou non.
Une partie sera corrigée par des retours accessibilité, je me suis contenté d'ajuster la partie back dans l'immédiat.
Lorsqu'une entreprise fait une estimation avec un nombre avec décimale, automatiquement, ça arrondissait à l'inférieur.
Lorsqu'une entreprise crée un signalement historique avec un texte à la place du prix, ça plante.

## Changements apportés
* Pour l'estimation, arrondi au supérieur
* Pour le texte à la place du prix, changement de type de champ dans le FormType

## Tests
- [ ] Tester des nombres imprévus lors de l'envoi de l'estimation
- [ ] Tester des prix imprévus lors de la création de signalement via BO
