### PR TITLE
[Accessibilité - Audit] [Toutes les pages - 13.1] Augmenter la limite de temps avant la fin de la session d'au moins 20 heures

### DIFF
--- a/.env
+++ b/.env
@@ -27,6 +27,7 @@ FEATURE_THREE_FORMS_ENABLE=1
 SECURITY_CSP_HEADER_VALUE="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.matomo.cloud https://unpkg.com; style-src 'self' 'unsafe-inline' https://unpkg.com; img-src 'self' data: blob: https://*.tile.openstreetmap.org https://unpkg.com; connect-src 'self' https://api-adresse.data.gouv.fr https://cdn.matomo.cloud; font-src 'self'; frame-src 'none'; object-src 'none'"
 MATOMO_ENABLE=0
 MATOMO_SITE_ID=
+SESSION_MAXLIFETIME=151200 # 151200 secondes = 42 heures
 
 ###> sentry/sentry-symfony ###
 SENTRY_DSN=

--- a/.env.sample
+++ b/.env.sample
@@ -27,6 +27,7 @@ FEATURE_THREE_FORMS_ENABLE=1
 SECURITY_CSP_HEADER_VALUE="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.matomo.cloud https://unpkg.com; style-src 'self' 'unsafe-inline' https://unpkg.com; img-src 'self' data: blob: https://*.tile.openstreetmap.org https://unpkg.com; connect-src 'self' https://api-adresse.data.gouv.fr https://cdn.matomo.cloud; font-src 'self'; frame-src 'none'; object-src 'none'"
 MATOMO_ENABLE=0
 MATOMO_SITE_ID=
+SESSION_MAXLIFETIME=151200 # 151200 secondes = 42 heures
 
 ###> sentry/sentry-symfony ###
 SENTRY_DSN=

--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -16,7 +16,6 @@ framework:
         cookie_samesite: lax
         storage_factory_id: session.storage.factory.native
         cookie_lifetime: '%env(int:SESSION_MAXLIFETIME)%'
-        gc_maxlifetime: '%env(int:SESSION_MAXLIFETIME)%'
 
     #esi: true
     #fragments: true

--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -15,6 +15,8 @@ framework:
         cookie_secure: auto
         cookie_samesite: lax
         storage_factory_id: session.storage.factory.native
+        cookie_lifetime: '%env(int:SESSION_MAXLIFETIME)%'
+        gc_maxlifetime: '%env(int:SESSION_MAXLIFETIME)%'
 
     #esi: true
     #fragments: true

--- a/public/index.php
+++ b/public/index.php
@@ -5,6 +5,7 @@ use App\Kernel;
 require_once dirname(__DIR__).'/vendor/autoload_runtime.php';
 
 return function (array $context) {
+    ini_set('session.gc_maxlifetime', (int) $_ENV['SESSION_MAXLIFETIME']);
     if (null !== $csp = $_SERVER['SECURITY_CSP_HEADER_VALUE'] ?? null) {
         header('Content-Security-Policy: '.$csp);
     }


### PR DESCRIPTION
## Ticket

#639    

## Description
Augmentation de la durée de session par défaut (celle du PHP)

N'est pas défini dans le buildpack PHP de scalingo https://github.com/Scalingo/php-buildpack/blob/master/conf/php/php.ini  elle prend donc la valeur par défaut de PHP (1440s = 24 minutes)

[session.cookie_lifetime](https://www.php.net/manual/fr/session.configuration.php#ini.session.cookie-lifetime:~:text=session.cookie_lifetime%20int,et%20session_set_cookie_params().) (0 par défaut)
> Spécifie la durée de vie du cookie en secondes. La valeur de 0 signifie : "Jusqu'à ce que le navigateur soit éteint". La valeur par défaut est 0. Voir aussi [session_get_cookie_params()](https://www.php.net/manual/fr/function.session-get-cookie-params.php) et [session_set_cookie_params()](https://www.php.net/manual/fr/function.session-set-cookie-params.php).

[session.gc_maxlifetime](https://www.php.net/manual/fr/session.configuration.php#ini.session.cookie-lifetime:~:text=session.gc_maxlifetime%20int,(24%20minutes).) (24 minutes par défaut)
> Spécifie la durée de vie des données sur le serveur, en nombre de secondes. Après cette durée, les données seront considérées comme obsolètes, et peuvent potentiellement être supprimées. Les données peuvent devenir obsolètes lors du démarrage de la session (suivant [session.gc_probability](https://www.php.net/manual/fr/session.configuration.php#ini.session.gc-probability) et [session.gc_divisor](https://www.php.net/manual/fr/session.configuration.php#ini.session.gc-divisor)). La valeur par défaut est 1440 (24 minutes).


> [!NOTE]   
> **C'est donc la durée de session des 24 minutes qui prévaut : (Voir colonne Expires / Max-Age => Session)**

![image](https://github.com/MTES-MCT/stop-punaises/assets/5757116/04659274-2042-4f93-86e7-d7cc413cda75)



## Changements apportés
* Ajout du paramètre `cookie_lifetime` pour surcharger la configuration par défaut de PHP
* Ajout du paramètre `gc_maxlifetime` pour surchager la configuration par défaut de PHP

## Pré-requis
Pour éviter des comportements inattendus, `gc_maxlifetime` doit être égal ou supérieur à `cookie_lifetime` pour assurer une cohérence entre la durée de vie côté serveur et côté client des sessions. 

```
SESSION_MAXLIFETIME=151200 # 151200 secondes = 42 heures
```

## Tests
![image](https://github.com/MTES-MCT/stop-punaises/assets/5757116/7778aa94-2cf5-4998-890f-3128f468d61f)

**Mettre à jour la variable d'environnement à 10 secondes**
- [ ] Connecter vous sans cocher 'Se souvenir de moi pendant 1 mois.' et vérifier que vous faites déconnecter au bout de 10 secondes d'inactivité.
- [ ] Connecter vous en cochant 'Se souvenir de moi pendant 1 mois.' et vérifier que vous soyez toujours connecter au bout de 10 secondes

**Mettre à jour la variable d'environnement à 42 heures**
- [ ] Connecter vous sans cocher `Se souvenir de moi pendant 1 mois.`  et vérifier la date d'expiration du cookie puis revenir sur le site 24 minutes après:-D (l'idée c'est de voir si la configuration de symfony surcharge bien celle défini dans le php.ini)



