### PR TITLE
[BO - Signalement] Affichage responsive et message d'erreur d'upload

### DIFF
--- a/assets/controllers/component_file_auto_submit.js
+++ b/assets/controllers/component_file_auto_submit.js
@@ -11,11 +11,11 @@ function initFileAutoSubmit() {
       let errorDiv = $('.fr-upload-group .fr-error-text');
       let inputDiv = $('.fr-upload-group .fr-upload');
       if (file.size > 10 * 1024 * 1024) {
-          errorDiv.text('Merci d\'ajouter une photo de moins de 10 Mo.').removeClass('fr-hidden');
+          errorDiv.text('Le fichier est trop lourd. Merci d\'ajouter une photo de moins de 10 Mo.').removeClass('fr-hidden');
           inputDiv.attr('aria-describedby', 'file-upload-error');
           break;
       } else if(file.type !== 'image/jpeg' && file.type !== 'image/png') {
-          errorDiv.text('Merci de choisir un fichier au format jpg ou png.').removeClass('fr-hidden');
+          errorDiv.text('Format de fichier non supporté. Merci de choisir un fichier au format jpg ou png.').removeClass('fr-hidden');
           inputDiv.attr('aria-describedby', 'file-upload-error');
           break;
       } else {

--- a/assets/controllers/form_signalement_erp_transport.js
+++ b/assets/controllers/form_signalement_erp_transport.js
@@ -99,12 +99,12 @@ function handleFileUpload() {
             let inputDiv = $('.fr-upload-group .fr-upload');
             if (file.size > 10 * 1024 * 1024) {
                 let errorDiv = $('.fr-upload-group').next();
-                errorDiv.text('Merci d\'ajouter une photo de moins de 10 Mo.').removeClass('fr-hidden');
+                errorDiv.text('Le fichier est trop lourd. Merci d\'ajouter une photo de moins de 10 Mo.').removeClass('fr-hidden');
                 inputDiv.attr('aria-describedby', 'file-upload-error');
                 break;
             } else if(file.type !== 'image/jpeg' && file.type !== 'image/png') {
                 let errorDiv = $('.fr-upload-group').next();
-                errorDiv.text('Merci de choisir un fichier au format jpg ou png.').removeClass('fr-hidden');
+                errorDiv.text('Format de fichier non supporté. Merci de choisir un fichier au format jpg ou png.').removeClass('fr-hidden');
                 inputDiv.attr('aria-describedby', 'file-upload-error');
                 break;
             } else {

--- a/assets/controllers/form_signalement_front.js
+++ b/assets/controllers/form_signalement_front.js
@@ -459,9 +459,9 @@ class PunaisesFrontSignalementController {
       for (let file of event.target.files) {
         let errorText = '';
         if (file.size > 10 * 1024 * 1024) {
-          errorText += 'Merci d\'ajouter une photo de moins de 10 Mo. ';
+          errorText += 'Le fichier est trop lourd. Merci d\'ajouter une photo de moins de 10 Mo. ';
         } else if(file.type !== 'image/jpeg' && file.type !== 'image/png') {
-          errorText += 'Merci de choisir un fichier au format jpg ou png. ';
+          errorText += 'Format de fichier non supporté. Merci de choisir un fichier au format jpg ou png. ';
         } 
         if (errorText != ''){
           errorDiv.text(errorText).removeClass('fr-hidden');

--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -732,6 +732,7 @@ span.image-caption {
             background-color: var(--grey-1000-50);
             filter: drop-shadow(var(--raised-shadow));
             font-weight: normal;
+            word-wrap: break-word;
         }
     }
 

--- a/src/Form/SignalementFrontType.php
+++ b/src/Form/SignalementFrontType.php
@@ -288,7 +288,7 @@ class SignalementFrontType extends AbstractType
             ->add('nomOccupant', TextType::class, [
                 'attr' => [
                     'class' => 'fr-input',
-                    'maxlength' => '100',
+                    'maxlength' => '50',
                     'autocomplete' => 'family-name',
                 ],
                 'label_attr' => [
@@ -300,7 +300,7 @@ class SignalementFrontType extends AbstractType
             ->add('prenomOccupant', TextType::class, [
                 'attr' => [
                     'class' => 'fr-input',
-                    'maxlength' => '100',
+                    'maxlength' => '50',
                     'autocomplete' => 'given-name',
                 ],
                 'label_attr' => [

--- a/templates/front_signalement/_partial_step_autotraitement_info.html.twig
+++ b/templates/front_signalement/_partial_step_autotraitement_info.html.twig
@@ -1,7 +1,7 @@
 {% extends 'front_signalement/base_step.html.twig' %}
 
 {% block content %}
-    <div>
+    <div class="word-wrap">
         <h1 class="fr-h2">Auto-traitement</h1>
 
         <p>

--- a/templates/front_signalement/_partial_step_professionnel_info.html.twig
+++ b/templates/front_signalement/_partial_step_professionnel_info.html.twig
@@ -1,7 +1,7 @@
 {% extends 'front_signalement/base_step.html.twig' %}
 
 {% block content %}
-    <div>
+    <div class="word-wrap">
         <h1 class="fr-h2">Prise en charge professionnelle</h1>
 
         <p>


### PR DESCRIPTION
## Ticket

#703    

## Description
Dans l'affichage d'un signalement dans le BO :
- avec une longue adresse e-mail (par exemple), on avait un scroll horizontal
- lors de l'envoi de photo, le messsage d'erreur n'était pas assez précis

## Tests
- [ ] Créer un signalement avec une longue adresse e-mail et vérifier l'affichage responsive
- [ ] Aller voir un signalement historique (c'est le plus simple pour tester), vérifier les messages d'erreur liés à l'upload (fichier trop lourd, ou format non supporté)
