### PR TITLE
[BO - Listes] Corrections d'accessibilité sur les titres et textes

### DIFF
--- a/assets/controllers/list_employes.js
+++ b/assets/controllers/list_employes.js
@@ -23,11 +23,16 @@ function startListeEmployesApp() {
       infoEmpty: "Résultats 0 - 0 sur 0",
       infoFiltered: "(sur un total de _MAX_)",
       zeroRecords: "Aucun employé trouvé",
+      search: 'Rechercher',
       paginate: {
         first: "|&lt;",
         previous: "&lt; Page précédente",
         next: "Page suivante &gt;",
         last: "&gt;|"
+      },
+      aria: {
+        sortAscending: ' - activez pour trier dans un ordre croissant',
+        sortDescending: ' - activez pour trier dans un ordre décroissant'
       }
     },
     drawCallback: function(settings, json) {

--- a/assets/controllers/list_entreprises.js
+++ b/assets/controllers/list_entreprises.js
@@ -24,11 +24,16 @@ function startListeEntreprisesApp() {
       infoEmpty: "Résultats 0 - 0 sur 0",
       infoFiltered: "(sur un total de _MAX_)",
       zeroRecords: "Aucune entreprise trouvée",
+      search: 'Rechercher',
       paginate: {
         first: "|&lt;",
         previous: "&lt; Page précédente",
         next: "Page suivante &gt;",
         last: "&gt;|"
+      },
+      aria: {
+        sortAscending: ' - activez pour trier dans un ordre croissant',
+        sortDescending: ' - activez pour trier dans un ordre décroissant'
       }
     },
     drawCallback: function(settings, json) {

--- a/assets/controllers/list_entreprises.js
+++ b/assets/controllers/list_entreprises.js
@@ -54,6 +54,7 @@ function startListeEntreprisesApp() {
 
   listTable.on('draw', function() {
     $("span#count-entreprise").text(generateTableTitleFromDatatable('entreprise'));
+    $("caption#count-entreprise-caption").text(generateTableTitleFromDatatable('entreprise'));
     document.title = generatePageTitleFromDatatable('Les entreprises partenaires', 'entreprise');
   })
   

--- a/assets/controllers/list_signalement.js
+++ b/assets/controllers/list_signalement.js
@@ -25,11 +25,16 @@ function startListeSignalementsApp() {
       infoEmpty: "Résultats 0 - 0 sur 0",
       infoFiltered: "(sur un total de _MAX_)",
       zeroRecords: "Aucun signalement trouvé",
+      search: 'Rechercher',
       paginate: {
         first: "|&lt;",
         previous: "&lt; Page précédente",
         next: "Page suivante &gt;",
         last: "&gt;|"
+      },
+      aria: {
+        sortAscending: ' - activez pour trier dans un ordre croissant',
+        sortDescending: ' - activez pour trier dans un ordre décroissant'
       }
     },
     drawCallback: function( oSettings ) {

--- a/assets/controllers/list_signalement.js
+++ b/assets/controllers/list_signalement.js
@@ -49,7 +49,9 @@ function startListeSignalementsApp() {
 
       // refresh count when ajax call is done
       if (oSettings.json !== undefined) {
-        $("span#count-signalement").text(generateTableTitleFromDatatable('signalement'), oSettings.json.recordsFiltered);
+        let textCount = generateTableTitleFromDatatable('signalement', oSettings.json.recordsFiltered);
+        $("span#count-signalement").text(textCount);
+        $("caption#count-signalement-caption").text(textCount);
         document.title = generatePageTitleFromDatatable('Les signalements usagers', 'signalement', oSettings.json.recordsFiltered);
       }
     }
@@ -61,7 +63,9 @@ function startListeSignalementsApp() {
     options.serverSide = true;
     // refresh count when ajax call is done
     options.fnDrawCallback = function( oSettings ) {
-      $("span#count-signalement").text(generateTableTitleFromDatatable('signalement'));
+      let textCount = generateTableTitleFromDatatable('signalement');
+      $("span#count-signalement").text(textCount);
+      $("caption#count-signalement-caption").text(textCount);
       document.title = generatePageTitleFromDatatable('Les signalements usagers', 'signalement');
     }
   }
@@ -172,7 +176,9 @@ function refreshTableHorsPerimetre() {
     listTable.columns(3).search(territoire);
   }
   listTable.draw();
-  $("span#count-signalement").text(generateTableTitleFromDatatable('signalement'));
+  let textCount = generateTableTitleFromDatatable('signalement')
+  $("span#count-signalement").text(textCount);
+  $("caption#count-signalement-caption").text(textCount);
   document.title = generatePageTitleFromDatatable('Les signalements hors périmètre', 'signalement');
 }
 
@@ -199,7 +205,9 @@ function refreshTableErpTransports() {
     listTable.columns(5).search(territoire);
   }
   listTable.draw();
-  $("span#count-signalement").text(generateTableTitleFromDatatable('signalement'));
+  let textCount = generateTableTitleFromDatatable('signalement')
+  $("span#count-signalement").text(textCount);
+  $("caption#count-signalement-caption").text(textCount);
   document.title = generatePageTitleFromDatatable('Les signalements ERP et transports', 'signalement');
 }
 
@@ -239,7 +247,9 @@ function refreshTableUsagers() {
   }
 
   listTable.draw();
-  $("span#count-signalement").text(generateTableTitleFromDatatable('signalement'));
+  let textCount = generateTableTitleFromDatatable('signalement')
+  $("span#count-signalement").text(textCount);
+  $("caption#count-signalement-caption").text(textCount);
   document.title = generatePageTitleFromDatatable('Les signalements usagers', 'signalement');
 }
 
@@ -263,7 +273,9 @@ function refreshTableHistorique() {
   let typeSignalement = $('#filter-type').val();
   listTable.columns(indexColumnType).search(typeSignalement);
   listTable.draw();
-  $("span#count-signalement").text(generateTableTitleFromDatatable('signalement'));
+  let textCount = generateTableTitleFromDatatable('signalement')
+  $("span#count-signalement").text(textCount);
+  $("caption#count-signalement-caption").text(textCount);
   document.title = generatePageTitleFromDatatable('Les données historiques', 'signalement');
 }
 

--- a/assets/controllers/list_signalement.js
+++ b/assets/controllers/list_signalement.js
@@ -49,7 +49,7 @@ function startListeSignalementsApp() {
 
       // refresh count when ajax call is done
       if (oSettings.json !== undefined) {
-        $("span#count-signalement").text(oSettings.json.recordsFiltered);
+        $("span#count-signalement").text(generateTableTitleFromDatatable('signalement'), oSettings.json.recordsFiltered);
       }
     }
   }
@@ -278,8 +278,8 @@ function generatePageTitleFromDatatable(prefix, element) {
   return prefix +  ' - ' + countElements + ' ' + element + plural +'  trouvé' + plural + ' - page ' + currentPage + ' sur ' + totalPage + ' - Stop punaises';
 }
 
-function generateTableTitleFromDatatable(element) {
-  let countElements = listTable.page.info().recordsDisplay;
+function generateTableTitleFromDatatable(element, nbRecords = undefined) {
+  let countElements = nbRecords !== undefined ? nbRecords : listTable.page.info().recordsDisplay;
   let plural = '';
   if(countElements > 1) {
     plural = 's';

--- a/assets/controllers/list_signalement.js
+++ b/assets/controllers/list_signalement.js
@@ -50,6 +50,7 @@ function startListeSignalementsApp() {
       // refresh count when ajax call is done
       if (oSettings.json !== undefined) {
         $("span#count-signalement").text(generateTableTitleFromDatatable('signalement'), oSettings.json.recordsFiltered);
+        document.title = generatePageTitleFromDatatable('Les signalements usagers', 'signalement', oSettings.json.recordsFiltered);
       }
     }
   }
@@ -266,8 +267,8 @@ function refreshTableHistorique() {
   document.title = generatePageTitleFromDatatable('Les données historiques', 'signalement');
 }
 
-function generatePageTitleFromDatatable(prefix, element) {
-  let countElements = listTable.page.info().recordsDisplay;
+function generatePageTitleFromDatatable(prefix, element, nbRecords = undefined) {
+  let countElements = nbRecords !== undefined ? nbRecords : listTable.page.info().recordsDisplay;
   let plural = '';
   if(countElements > 1) {
     plural = 's';

--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -11,23 +11,26 @@ span.niveau-infestation {
     padding: 5px 10px;
     margin-bottom: 2px;
     border-radius: 20px;
-    color: var(--grey-1000-50);
+    color: var(--grey-200-850);
 
     &.niveau-0 {
         background-color: var(--success-425-625);
+        color: var(--grey-1000-50);
     }
     &.niveau-1 {
         background-color: var(--yellow-tournesol-925-125);
-        color: var(--grey-200-850);
     }
     &.niveau-2 {
         background-color: var(--warning-425-625);
+        color: var(--grey-1000-50);
     }
     &.niveau-3 {
         background-color: var(--error-425-625);
+        color: var(--grey-1000-50);
     }
     &.niveau-4 {
         background-color: var(--grey-50-1000);
+        color: var(--grey-1000-50);
     }
 }
 

--- a/src/DataFixtures/Loader/LoadSignalementData.php
+++ b/src/DataFixtures/Loader/LoadSignalementData.php
@@ -108,7 +108,7 @@ class LoadSignalementData extends Fixture implements OrderedFixtureInterface
             $signalement->setTypeDiagnostic($row['type_diagnostic']);
         }
 
-        if (!empty($row['niveau_infestation'])) {
+        if (isset($row['niveau_infestation'])) {
             $signalement->setNiveauInfestation($row['niveau_infestation']);
         }
 

--- a/src/Service/Signalement/SignalementOccupantDataTableHandler.php
+++ b/src/Service/Signalement/SignalementOccupantDataTableHandler.php
@@ -152,8 +152,8 @@ class SignalementOccupantDataTableHandler
 
     private function formatNiveauInfestation(?string $niveauInfestation): string
     {
-        if (empty($niveauInfestation)) {
-            return 'N/C';
+        if (empty($niveauInfestation) && 0 !== $niveauInfestation) {
+            return 'Non communiqué';
         }
 
         return '<span class="niveau-infestation niveau-'.$niveauInfestation.'">'

--- a/src/Twig/AppExtension.php
+++ b/src/Twig/AppExtension.php
@@ -77,7 +77,7 @@ class AppExtension extends AbstractExtension
     public function formatLabelInfestation(?int $niveau = 0): string
     {
         if (empty($niveau) && 0 !== $niveau) {
-            return '-';
+            return 'Non communiqué';
         }
 
         return InfestationLevel::from($niveau)->label();

--- a/templates/entreprise_list/index.html.twig
+++ b/templates/entreprise_list/index.html.twig
@@ -19,7 +19,7 @@
         </div>
 
         <div class="fr-mt-3w">
-            <h2 id="liste-entreprises-title" role="status"><span id="count-entreprise">0</span> entreprises trouvées</h2>
+            <h2 id="liste-entreprises-title" role="status"><span id="count-entreprise">0 entreprises trouvées</span></h2>
 
             <div class="fr-grid-row fr-grid-row--right fr-mb-5v">
                 <div class="fr-select-group fr-col-12 fr-col-lg-3">
@@ -39,7 +39,8 @@
             </div>
 
             {% if entreprises is not empty %}
-                <table id="datatable" class="nowrap" aria-labelledby="liste-entreprises-title">
+                <table id="datatable" class="nowrap">
+                    <caption id="count-entreprise-caption" class="fr-hidden">0 entreprises trouvées</caption>
                     <thead>
                         <tr>
                             <th>ID</th>

--- a/templates/entreprise_view/index.html.twig
+++ b/templates/entreprise_view/index.html.twig
@@ -51,7 +51,7 @@
                 </div>
                 <div class="fr-col-12 fr-col-lg-3">
                     <div class="add-button-container">
-                        <button class="fr-btn fr-btn--icon-left fr-icon-add-line"  data-fr-opened="false" aria-controls="fr-modal-create-employe">Ajouter un employé</button>
+                        <button class="fr-btn fr-btn--icon-left fr-icon-add-line" data-fr-opened="false" aria-controls="fr-modal-create-employe">Ajouter un employé</button>
                     </div>
                 </div>
             </div>
@@ -73,7 +73,8 @@
             </div>
 
             {% if entreprise.employes is not empty %}
-                <table id="datatable" class="nowrap" aria-labelledby="liste-employes-title">
+                <table id="datatable" class="nowrap">
+                    <caption id="count-entreprise-caption" class="fr-hidden">Liste des employés de l'entreprise {{entreprise.nom}}</caption>
                     <thead>
                         <tr>
                             <th>ID</th>

--- a/templates/signalement_list/erp-transports.html.twig
+++ b/templates/signalement_list/erp-transports.html.twig
@@ -34,7 +34,7 @@
     </div>
 
     <div class="fr-container fr-mt-3w">
-        <h2 id="liste-signalements-title" role="status"><span id="count-signalement">0</span> signalements trouvés</h2>
+        <h2 id="liste-signalements-title" role="status"><span id="count-signalement">0 signalements trouvés</span></h2>
     
         <div class="fr-grid-row fr-grid-row--right fr-mb-5v">
             <div class="fr-select-group fr-col-12 fr-col-lg-3">
@@ -54,7 +54,8 @@
         </div>
 
         {% if signalements is not empty %}
-            <table id="datatable" class="liste-signalements-erp-transports nowrap" aria-labelledby="liste-signalements-title">
+            <table id="datatable" class="liste-signalements-erp-transports nowrap">
+                <caption id="count-signalement-caption" class="fr-hidden">0 signalements trouvés</caption>
                 <thead>
                     <tr>
                         <th>ID</th>

--- a/templates/signalement_list/historique.html.twig
+++ b/templates/signalement_list/historique.html.twig
@@ -27,9 +27,9 @@
             </div>
 
             <div class="fr-input-group fr-col-12 fr-col-lg-3">
-                <label class="fr-label" for="search-address">Adresse</label>
+                <label class="fr-label" for="search-address">Ville ou CP</label>
                 <div class="fr-input-wrap fr-icon-search-line">
-                    <input type="text" class="fr-input" id="search-address" placeholder="Ville, CP...">
+                    <input type="text" class="fr-input" id="search-address">
                 </div>
             </div>
 
@@ -79,7 +79,8 @@
         </div>
 
         {% if signalements is not empty %}
-            <table id="datatable" class="liste-signalements-historique nowrap" aria-labelledby="liste-signalements-title">
+            <table id="datatable" class="liste-signalements-historique nowrap">
+                <caption id="count-signalement-caption" class="fr-hidden">0 signalements trouvés</caption>
                 <thead>
                     <tr>
                         <th>ID</th>

--- a/templates/signalement_list/historique.html.twig
+++ b/templates/signalement_list/historique.html.twig
@@ -54,7 +54,7 @@
     </div>
 
     <div class="fr-container fr-mt-3w">
-        <h2 id="liste-signalements-title" role="status"><span id="count-signalement">0</span> signalements trouvés</h2>
+        <h2 id="liste-signalements-title" role="status"><span id="count-signalement">0 signalements trouvés</span></h2>
 
         <div class="fr-grid-row fr-grid-row--right fr-mb-5v">
             <div class="fr-select-group fr-col-12 fr-col-lg-3">

--- a/templates/signalement_list/hors-perimetre.html.twig
+++ b/templates/signalement_list/hors-perimetre.html.twig
@@ -30,7 +30,7 @@
     </div>
 
     <div class="fr-container fr-mt-3w">
-        <h2 id="liste-signalements-title" role="status"><span id="count-signalement">0</span> signalements trouvés</h2>
+        <h2 id="liste-signalements-title" role="status"><span id="count-signalement">0 signalements trouvés</span></h2>
 
         <div class="fr-grid-row fr-grid-row--right fr-mb-5v">
             <div class="fr-select-group fr-col-12 fr-col-lg-3">
@@ -48,7 +48,8 @@
         </div>
 
         {% if signalements is not empty %}
-            <table id="datatable" class="liste-signalements-hors-perimetres nowrap" aria-labelledby="liste-signalements-title">
+            <table id="datatable" class="liste-signalements-hors-perimetres nowrap">
+                <caption id="count-signalement-caption" class="fr-hidden">0 signalements trouvés</caption>
                 <thead>
                     <tr>
                         <th>ID</th>

--- a/templates/signalement_list/signalements.html.twig
+++ b/templates/signalement_list/signalements.html.twig
@@ -86,7 +86,7 @@
     </div>
 
     <div class="fr-container fr-mt-3w">
-        <h2 id="liste-signalements-title" role="status"><span id="count-signalement">0</span> signalements trouvés</h2>
+        <h2 id="liste-signalements-title" role="status"><span id="count-signalement">0 signalements trouvés</span></h2>
 
         <div class="fr-grid-row fr-grid-row--right fr-mb-5v">
             <div class="fr-select-group fr-col-12 fr-col-lg-3">

--- a/templates/signalement_list/signalements.html.twig
+++ b/templates/signalement_list/signalements.html.twig
@@ -108,7 +108,8 @@
             </div>
         </div>
 
-        <table id="datatable-ajax" class="liste-signalements-usagers nowrap" aria-labelledby="liste-signalements-title">
+        <table id="datatable-ajax" class="liste-signalements-usagers nowrap">
+            <caption id="count-signalement-caption" class="fr-hidden">0 signalements trouvés</caption>
             <thead>
                 <tr>
                     <th>Statut</th>


### PR DESCRIPTION
## Ticket

#701   

## Description
- Correction sur l'affichage et l'accord des différents titres
- Correction de l'affichage pour les niveaux d'infestation vides
- Correction de textes de DataTables qui étaient restés en anglais

## Tests
- [ ] Liste signalements usager :
  - [ ] Vérifier la balise title, la balise h2 et la balise caption (invisible) : au chargement, et en faisant des ajustements de filtres
  - [ ] Vérifier si les textes masqués du tableau sont tous en français
  - [ ] Vérifier que les niveaux d'infestation s'affichent correctement
- [ ] Liste signalements historiques : idem
- [ ] Liste signalements ERP : idem
- [ ] Liste signalements hors-périmètres : idem
- [ ] Liste entreprises : idem
- [ ] Liste employés : idem
