### PR TITLE
[Menu] Focus sur le logo lors de la navigation par clavier

### DIFF
--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -150,8 +150,6 @@ span.statut-infestation {
             }
         }
     }
-}
-.fr-header {
     .fr-header__tools-links {
         ul.fr-btns-group {
             li {
@@ -159,6 +157,14 @@ span.statut-infestation {
                     border-bottom: 1px solid var(--text-action-high-blue-france);
                 }
             }
+        }
+    }
+    .fr-header__service {
+        a:focus {
+            outline-color:#0a76f6;
+            outline-offset:2px;
+            outline-style:solid;
+            outline-width:2px;
         }
     }
 }


### PR DESCRIPTION
## Ticket

#697   

## Description
Le DSFR ne prévoit pas de focus sur le logo lors de la navigation au clavier. On l'ajoute dans la css.

## Tests
- [ ] Parcourir au clavier pour vérifier que le focus apparait bien sur le logo du menu
