### PR TITLE
[BO - Signalement] Suppression boutons de tri

### DIFF
--- a/assets/controllers/list_employes.js
+++ b/assets/controllers/list_employes.js
@@ -36,6 +36,10 @@ function startListeEmployesApp() {
       }
     },
     drawCallback: function(settings, json) {
+      $('table th').removeClass('sortable');
+      $('table th').removeAttr('aria-controls');
+      $('table th').removeAttr('aria-label');
+      $('table th').removeAttr('aria-sort');
       $('#datatable_paginate').attr('role', 'navigation');
       $('#datatable_paginate').attr('aria-label', 'Pagination');
       $('#datatable_previous').attr('title', 'Page précédente');

--- a/assets/controllers/list_entreprises.js
+++ b/assets/controllers/list_entreprises.js
@@ -37,6 +37,10 @@ function startListeEntreprisesApp() {
       }
     },
     drawCallback: function(settings, json) {
+      $('table th').removeClass('sortable');
+      $('table th').removeAttr('aria-controls');
+      $('table th').removeAttr('aria-label');
+      $('table th').removeAttr('aria-sort');
       $('#datatable_paginate').attr('role', 'navigation');
       $('#datatable_paginate').attr('aria-label', 'Pagination');
       $('#datatable_previous').attr('title', 'Page précédente');

--- a/assets/controllers/list_signalement.js
+++ b/assets/controllers/list_signalement.js
@@ -38,6 +38,10 @@ function startListeSignalementsApp() {
       }
     },
     drawCallback: function( oSettings ) {
+      $('table th').removeClass('sortable');
+      $('table th').removeAttr('aria-controls');
+      $('table th').removeAttr('aria-label');
+      $('table th').removeAttr('aria-sort');
       $('#datatable-ajax_paginate').attr('role', 'navigation');
       $('#datatable-ajax_paginate').attr('aria-label', 'Pagination');
       $('#datatable-ajax_previous').attr('title', 'Page précédente');

--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -122,6 +122,11 @@ span.statut-infestation {
         border: 0px;
         background: var(--blue-france-850-200);
     }
+
+    thead > tr > th[class*="sort"]:before,
+    thead > tr > th[class*="sort"]:after {
+        content: "" !important;
+    }
 }
 
 .fr-header {

--- a/templates/entreprise_list/index.html.twig
+++ b/templates/entreprise_list/index.html.twig
@@ -39,7 +39,7 @@
             </div>
 
             {% if entreprises is not empty %}
-                <table id="datatable" class="nowrap">
+                <table id="datatable" class="fr-table nowrap">
                     <caption id="count-entreprise-caption" class="fr-hidden">0 entreprises trouvées</caption>
                     <thead>
                         <tr>

--- a/templates/entreprise_view/index.html.twig
+++ b/templates/entreprise_view/index.html.twig
@@ -73,7 +73,7 @@
             </div>
 
             {% if entreprise.employes is not empty %}
-                <table id="datatable" class="nowrap">
+                <table id="datatable" class="fr-table nowrap">
                     <caption id="count-entreprise-caption" class="fr-hidden">Liste des employés de l'entreprise {{entreprise.nom}}</caption>
                     <thead>
                         <tr>

--- a/templates/signalement_list/erp-transports.html.twig
+++ b/templates/signalement_list/erp-transports.html.twig
@@ -54,7 +54,7 @@
         </div>
 
         {% if signalements is not empty %}
-            <table id="datatable" class="liste-signalements-erp-transports nowrap">
+            <table id="datatable" class="fr-table liste-signalements-erp-transports nowrap">
                 <caption id="count-signalement-caption" class="fr-hidden">0 signalements trouvés</caption>
                 <thead>
                     <tr>

--- a/templates/signalement_list/historique.html.twig
+++ b/templates/signalement_list/historique.html.twig
@@ -79,7 +79,7 @@
         </div>
 
         {% if signalements is not empty %}
-            <table id="datatable" class="liste-signalements-historique nowrap">
+            <table id="datatable" class="fr-table liste-signalements-historique nowrap">
                 <caption id="count-signalement-caption" class="fr-hidden">0 signalements trouvés</caption>
                 <thead>
                     <tr>
@@ -98,7 +98,7 @@
                 <tbody>
                     {% for signalement in signalements %}
                         <tr>
-                            <td data-order="{{ signalement.reference|reference_sortable }}">{{ signalement.reference }} <span class="fr-hidden">{{ signalement.nomOccupant }} {{ signalement.prenomOccupant }} {{ signalement.emailOccupant }}</span></td>
+                            <td data-order="{{ signalement.reference|reference_sortable }}">{{ signalement.reference }} <span class="fr-hidden" hidden>{{ signalement.nomOccupant }} {{ signalement.prenomOccupant }} {{ signalement.emailOccupant }}</span></td>
                             <td data-order="{{ signalement.createdAt.format('Y-m-d') }}">{{ signalement.createdAt.format('d/m/Y') }}</td>
                             <td><span>{{ signalement.typeIntervention|capitalize }}</span></td>
                             <td>{{ signalement.dateIntervention ? signalement.dateIntervention.format('d/m/Y') : '/' }}</td>

--- a/templates/signalement_list/hors-perimetre.html.twig
+++ b/templates/signalement_list/hors-perimetre.html.twig
@@ -48,7 +48,7 @@
         </div>
 
         {% if signalements is not empty %}
-            <table id="datatable" class="liste-signalements-hors-perimetres nowrap">
+            <table id="datatable" class="fr-table liste-signalements-hors-perimetres nowrap">
                 <caption id="count-signalement-caption" class="fr-hidden">0 signalements trouvés</caption>
                 <thead>
                     <tr>

--- a/templates/signalement_list/signalements.html.twig
+++ b/templates/signalement_list/signalements.html.twig
@@ -108,7 +108,7 @@
             </div>
         </div>
 
-        <table id="datatable-ajax" class="liste-signalements-usagers nowrap">
+        <table id="datatable-ajax" class="fr-table liste-signalements-usagers nowrap">
             <caption id="count-signalement-caption" class="fr-hidden">0 signalements trouvés</caption>
             <thead>
                 <tr>


### PR DESCRIPTION
## Ticket

#710   

## Description
Suite à l'audit accessibilité, il est conseillé de supprimer les boutons de tri de DataTable.
On intègre aussi le style fr-table au tableau.
Et on masque les infos des signalements historiques qui apparaissent quand on affiche la page sans style.

## Tests
- [ ] Vérifier sur les différentes pages que le style est ok
- [ ] Vérifier que les tableaux se trient toujours avec la liste déroulante
