### PR TITLE
Fixer des contraintes de longueur et de complexité des mots de passe

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -22,6 +22,7 @@ import './controllers/form_back_stop_intervention';
 import './controllers/component_search_address';
 import './controllers/component_search_commune';
 import './controllers/component_file_auto_submit';
+import './controllers/reinit_password';
 
 import './controllers/list_signalement';
 import './controllers/list_entreprises';

--- a/assets/controllers/reinit_password.js
+++ b/assets/controllers/reinit_password.js
@@ -1,0 +1,79 @@
+document?.querySelector('form[name="login-creation-mdp-form"]')?.querySelectorAll('[name^="password"]').forEach(pwd => {
+    pwd.addEventListener('input', canSubmitFormReinitPassword)
+})
+document?.querySelector('form[name="login-creation-mdp-form"]')?.addEventListener('submit', (event) => {
+    event.preventDefault();
+    if(canSubmitFormReinitPassword()){
+        event.target.submit();
+    }
+})
+
+function canSubmitFormReinitPassword() {
+    const pass = document?.querySelector('form[name="login-creation-mdp-form"] #login-password').value;
+    const repeat = document?.querySelector('form[name="login-creation-mdp-form"] #login-password-repeat').value;
+    const pwdMatchError = document?.querySelector('form[name="login-creation-mdp-form"] #password-match-error');
+    const submitBtn = document?.querySelector('form[name="login-creation-mdp-form"] #submitter');
+    const messageLength = document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-length');
+    const messageMaj = document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-maj');
+    const messageMin = document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-min');
+    const messageNb = document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-nb');
+    const messageSpecial = document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-special');
+    const groupInputPassword = document?.querySelector('form[name="login-creation-mdp-form"] .fr-input-group-password');
+    const groupInputPasswordRepeat = document?.querySelector('form[name="login-creation-mdp-form"] .fr-input-group-password-repeat');
+    let canSubmit = true;
+    pwdMatchError.classList.add('fr-hidden')
+    submitBtn.disabled = false;
+    if (pass !== repeat) {
+        canSubmit = false;
+        pwdMatchError.classList.remove('fr-hidden')
+    }
+    if (pass.length < 8) {
+        messageLength.classList.remove('fr-message--info', 'fr-message--valid')
+        messageLength.classList.add('fr-message--error')
+        canSubmit = false;
+    }else{
+        messageLength.classList.remove('fr-message--info', 'fr-message--valid')
+        messageLength.classList.add('fr-message--valid')
+    }
+    if (!/[A-Z]/.test(pass)) {
+        messageMaj.classList.remove('fr-message--info', 'fr-message--valid')
+        messageMaj.classList.add('fr-message--error')
+        canSubmit = false;
+    }else{
+        messageMaj.classList.remove('fr-message--info', 'fr-message--valid')
+        messageMaj.classList.add('fr-message--valid')
+    }
+    if(!/[a-z]/.test(pass)){
+        messageMin.classList.remove('fr-message--info', 'fr-message--valid')
+        messageMin.classList.add('fr-message--error')
+        canSubmit = false;
+    }else{
+        messageMin.classList.remove('fr-message--info', 'fr-message--valid')
+        messageMin.classList.add('fr-message--valid')
+    }
+    if(!/[0-9]/.test(pass)){
+        messageNb.classList.remove('fr-message--info', 'fr-message--valid')
+        messageNb.classList.add('fr-message--error')
+        canSubmit = false;
+    }else{
+        messageNb.classList.remove('fr-message--info', 'fr-message--valid')
+        messageNb.classList.add('fr-message--valid')
+    }
+    if(!/[^a-zA-Z0-9]/.test(pass)){
+        messageSpecial.classList.remove('fr-message--info', 'fr-message--valid')
+        messageSpecial.classList.add('fr-message--error')
+        canSubmit = false;
+    }else{
+        messageSpecial.classList.remove('fr-message--info', 'fr-message--valid')
+        messageSpecial.classList.add('fr-message--valid')
+    }
+    if(!canSubmit){
+        groupInputPassword.classList.add('fr-input-group--error')
+        groupInputPasswordRepeat.classList.add('fr-input-group--error')
+        submitBtn.disabled = true;
+    }else{
+        groupInputPassword.classList.remove('fr-input-group--error')
+        groupInputPasswordRepeat.classList.remove('fr-input-group--error')
+    }
+    return canSubmit;
+}

--- a/config/packages/translation.yaml
+++ b/config/packages/translation.yaml
@@ -1,5 +1,5 @@
 framework:
-    default_locale: en
+    default_locale: fr
     translator:
         default_path: '%kernel.project_dir%/translations'
         fallbacks:

--- a/migrations/Version20240319132426.php
+++ b/migrations/Version20240319132426.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Symfony\Component\Uid\Uuid;
+
+final class Version20240319132426 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add UUID to user and generate it for existing users.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE user ADD uuid CHAR(36) NOT NULL COMMENT \'(DC2Type:guid)\'');
+
+        $users = $this->connection->fetchAllAssociative(
+            'SELECT id FROM user'
+        );
+
+        foreach ($users as $user) {
+            $id = $user['id'];
+            $code = Uuid::v4()->toRfc4122();
+
+            $this->addSql(
+                'UPDATE user SET uuid = :code WHERE id = :id',
+                ['code' => $code, 'id' => $id]
+            );
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE user DROP uuid');
+    }
+}

--- a/src/Controller/Security/AccountActivationController.php
+++ b/src/Controller/Security/AccountActivationController.php
@@ -3,16 +3,18 @@
 namespace App\Controller\Security;
 
 use App\Controller\Security\Utils\ValidatorPasswordResetableTrait;
+use App\Entity\Enum\Status;
+use App\Entity\User;
 use App\Exception\User\UserAccountAlreadyActiveException;
 use App\Exception\User\UserEmailNotFoundException;
 use App\Manager\UserManager;
-use App\Security\AppAuthenticator;
 use App\Service\Token\ActivationToken;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Component\Security\Http\Authentication\UserAuthenticatorInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class AccountActivationController extends AbstractController
 {
@@ -52,43 +54,55 @@ class AccountActivationController extends AbstractController
         return $this->render('security/reset_password.html.twig');
     }
 
-    #[Route(path: '/activation-compte/{token}', name: 'activate_account', requirements: ['token' => '.+'])]
+    #[Route(path: '/activation-compte/{id}/{token}', name: 'activate_account', requirements: ['token' => '.+'])]
     public function resetPassword(
         Request $request,
         ActivationToken $activationToken,
         UserManager $userManager,
-        UserAuthenticatorInterface $userAuthenticator,
-        AppAuthenticator $authenticator,
+        ValidatorInterface $validator,
+        Security $security,
+        User $user,
         string $token
     ): Response {
-        if ($this->getUser()) {
-            return $this->redirectToRoute('app_dashboard_home');
-        }
-
-        if (false === ($user = $activationToken->validateToken($token))) {
+        if (false === $activationToken->validateToken($user, $token)) {
             $this->addFlash('error', 'Votre lien est invalide ou expiré');
+
+            return $this->render('security/reset_password_new.html.twig', ['user' => $user, 'displayForm' => false]);
+        }
+        if ($security->getUser()) {
+            $security->logout(false);
+        }
+        if ($request->isMethod('POST') &&
+            $this->isCsrfTokenValid('create_password_'.$user->getId(), $request->get('_csrf_token'))
+        ) {
+            if ($request->get('password') !== $request->get('password-repeat')) {
+                $this->addFlash('error', 'Les mots de passe ne correspondent pas.');
+
+                return $this->render('security/reset_password_new.html.twig', ['user' => $user, 'displayForm' => true]);
+            }
+            $status = $user->getStatus();
+            $user->setPassword($request->get('password'));
+            $errors = $validator->validate($user, null, ['password']);
+            if (\count($errors) > 0) {
+                $errorMessage = '<ul>';
+                foreach ($errors as $error) {
+                    $errorMessage .= '<li>'.$error->getMessage().'</li>';
+                }
+                $errorMessage .= '</ul>';
+                $this->addFlash('error error-raw', $errorMessage);
+
+                return $this->render('security/reset_password_new.html.twig', ['user' => $user, 'displayForm' => true]);
+            }
+            $user = $userManager->resetPassword($user, $request->get('password'));
+            if (Status::ACTIVE == $status) {
+                $this->addFlash('success', 'Votre mot de passe a été mis à jour, vous pouvez vous connecter');
+            } else {
+                $this->addFlash('success', 'Votre compte est maintenant activé, vous pouvez vous connecter');
+            }
 
             return $this->redirectToRoute('app_login');
         }
-        $errors = [];
-        if ($request->isMethod('POST')) { /* @todo: check csrf_token */
-            $errors = $this->validate($request);
-            if (empty($errors)) {
-                $user = $userManager->resetPassword($user, $request->get('password'));
 
-                return $userAuthenticator->authenticateUser(
-                    $user,
-                    $authenticator,
-                    $request
-                );
-            }
-        }
-
-        return $this->render('security/reset_password_new.html.twig', [
-            'email' => $user->getEmail(),
-            'id' => $user->getId(),
-            'from' => 'acivate_account',
-            'errors' => $errors,
-        ]);
+        return $this->render('security/reset_password_new.html.twig', ['user' => $user, 'displayForm' => true]);
     }
 }

--- a/src/Controller/Security/AccountActivationController.php
+++ b/src/Controller/Security/AccountActivationController.php
@@ -54,7 +54,7 @@ class AccountActivationController extends AbstractController
         return $this->render('security/reset_password.html.twig');
     }
 
-    #[Route(path: '/activation-compte/{id}/{token}', name: 'activate_account', requirements: ['token' => '.+'])]
+    #[Route(path: '/activation-compte/{uuid}/{token}', name: 'activate_account', requirements: ['token' => '.+'])]
     public function resetPassword(
         Request $request,
         ActivationToken $activationToken,

--- a/src/Controller/Security/ResetPasswordController.php
+++ b/src/Controller/Security/ResetPasswordController.php
@@ -6,13 +6,10 @@ use App\Controller\Security\Utils\ValidatorPasswordResetableTrait;
 use App\Exception\User\RequestPasswordNotAllowedException;
 use App\Exception\User\UserEmailNotFoundException;
 use App\Manager\UserManager;
-use App\Security\AppAuthenticator;
-use App\Service\Token\ResetPasswordToken;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Component\Security\Http\Authentication\UserAuthenticatorInterface;
 
 class ResetPasswordController extends AbstractController
 {
@@ -49,45 +46,5 @@ class ResetPasswordController extends AbstractController
         }
 
         return $this->render('security/reset_password.html.twig');
-    }
-
-    #[Route(path: '/nouveau-mot-de-passe/{token}', name: 'reset_password', requirements: ['token' => '.+'])]
-    public function resetPassword(
-        Request $request,
-        ResetPasswordToken $resetPasswordToken,
-        UserManager $userManager,
-        UserAuthenticatorInterface $userAuthenticator,
-        AppAuthenticator $authenticator,
-        string $token
-    ): Response {
-        if ($this->getUser()) {
-            return $this->redirectToRoute('app_dashboard_home');
-        }
-
-        if (false === ($user = $resetPasswordToken->validateToken($token))) {
-            $this->addFlash('error', 'Votre lien est invalide ou expiré');
-
-            return $this->redirectToRoute('app_login');
-        }
-        $errors = [];
-        if ($request->isMethod('POST')) { /* @todo: check csrf_token */
-            $errors = $this->validate($request);
-            if (empty($errors)) {
-                $user = $userManager->resetPassword($user, $request->get('password'));
-
-                return $userAuthenticator->authenticateUser(
-                    $user,
-                    $authenticator,
-                    $request
-                );
-            }
-        }
-
-        return $this->render('security/reset_password_new.html.twig', [
-            'email' => $user->getEmail(),
-            'id' => $user->getId(),
-            'from' => 'reset_password',
-            'errors' => $errors,
-        ]);
     }
 }

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -35,13 +35,13 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
 
     #[ORM\Column]
     #[Assert\NotBlank(groups: ['password'])]
-    #[Assert\Length(min: 8, max: 200, minMessage: 'Le mot de passe doit contenir au moins {{ limit }} caratères.', groups: ['password'])]
+    #[Assert\Length(min: 8, max: 200, minMessage: 'Le mot de passe doit contenir au moins {{ limit }} caractères.', groups: ['password'])]
     #[Assert\Regex(pattern: '/[A-Z]/', message: 'Le mot de passe doit contenir au moins une lettre majuscule.', groups: ['password'])]
     #[Assert\Regex(pattern: '/[a-z]/', message: 'Le mot de passe doit contenir au moins une lettre minuscule.', groups: ['password'])]
     #[Assert\Regex(pattern: '/[0-9]/', message: 'Le mot de passe doit contenir au moins un chiffre.', groups: ['password'])]
     #[Assert\Regex(pattern: '/[^a-zA-Z0-9]/', message: 'Le mot de passe doit contenir au moins un caractère spécial.', groups: ['password'])]
     #[Assert\NotCompromisedPassword(message: 'Ce mot de passe est compromis, veuillez en choisir un autre.', groups: ['password'])]
-    #[Assert\NotEqualTo(propertyPath: 'email', message: 'Le mot de passe ne doit pas être votre email.', groups: ['password'])]
+    #[Assert\NotEqualTo(propertyPath: 'email', message: 'Le mot de passe ne doit pas être votre e-mail.', groups: ['password'])]
     private ?string $password = null;
 
     #[ORM\Column(nullable: true)]

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -34,10 +34,14 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     private array $roles = [];
 
     #[ORM\Column]
-    #[Assert\NotBlank]
-    #[Assert\Length(min: 8, max: 200, minMessage: 'Votre mot de passe doit contenir au moins {{ limit }} caratères')]
-    #[Assert\NotCompromisedPassword(message: 'Ce mot de passe est compromis, veuillez en choisir un autre.')]
-    #[Assert\NotEqualTo(propertyPath: 'email', message: 'Votre mot de passe ne doit pas contenir votre email.')]
+    #[Assert\NotBlank(groups: ['password'])]
+    #[Assert\Length(min: 8, max: 200, minMessage: 'Le mot de passe doit contenir au moins {{ limit }} caratères.', groups: ['password'])]
+    #[Assert\Regex(pattern: '/[A-Z]/', message: 'Le mot de passe doit contenir au moins une lettre majuscule.', groups: ['password'])]
+    #[Assert\Regex(pattern: '/[a-z]/', message: 'Le mot de passe doit contenir au moins une lettre minuscule.', groups: ['password'])]
+    #[Assert\Regex(pattern: '/[0-9]/', message: 'Le mot de passe doit contenir au moins un chiffre.', groups: ['password'])]
+    #[Assert\Regex(pattern: '/[^a-zA-Z0-9]/', message: 'Le mot de passe doit contenir au moins un caractère spécial.', groups: ['password'])]
+    #[Assert\NotCompromisedPassword(message: 'Ce mot de passe est compromis, veuillez en choisir un autre.', groups: ['password'])]
+    #[Assert\NotEqualTo(propertyPath: 'email', message: 'Le mot de passe ne doit pas être votre email.', groups: ['password'])]
     private ?string $password = null;
 
     #[ORM\Column(nullable: true)]

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -6,10 +6,12 @@ use App\Entity\Behaviour\ActivableTrait;
 use App\Entity\Behaviour\TimestampableTrait;
 use App\Entity\Enum\Status;
 use App\Repository\UserRepository;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Uid\Uuid;
 use Symfony\Component\Validator\Constraints as Assert;
 
 #[ORM\Entity(repositoryClass: UserRepository::class)]
@@ -24,6 +26,9 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     #[ORM\GeneratedValue]
     #[ORM\Column]
     private ?int $id = null;
+
+    #[ORM\Column(type: Types::GUID)]
+    private $uuid;
 
     #[ORM\Column(length: 180, unique: true)]
     #[Assert\Email]
@@ -62,6 +67,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     public function __construct()
     {
         $this->status = Status::INACTIVE;
+        $this->uuid = Uuid::v4();
     }
 
     public function getId(): ?int
@@ -199,6 +205,18 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     public function setStatus(Status $status): self
     {
         $this->status = $status;
+
+        return $this;
+    }
+
+    public function getUuid(): string
+    {
+        return $this->uuid;
+    }
+
+    public function setUuid(string $uuid): self
+    {
+        $this->uuid = $uuid;
 
         return $this;
     }

--- a/src/Service/Mailer/MailerProvider.php
+++ b/src/Service/Mailer/MailerProvider.php
@@ -65,7 +65,7 @@ class MailerProvider implements MailerProviderInterface
 
     public function sendResetPasswordMessage(User $user): void
     {
-        $link = $this->urlGenerator->generate('activate_account', ['id' => $user->getId(), 'token' => $user->getToken()]);
+        $link = $this->urlGenerator->generate('activate_account', ['uuid' => $user->getUuid(), 'token' => $user->getToken()]);
         $message = $this
             ->messageFactory
             ->createInstanceFrom(Template::RESET_PASSWORD, ['link' => $link])
@@ -76,7 +76,7 @@ class MailerProvider implements MailerProviderInterface
 
     public function sendActivateMessage(User $user): void
     {
-        $link = $this->urlGenerator->generate('activate_account', ['id' => $user->getId(), 'token' => $user->getToken()]);
+        $link = $this->urlGenerator->generate('activate_account', ['uuid' => $user->getUuid(), 'token' => $user->getToken()]);
         $message = $this
             ->messageFactory
             ->createInstanceFrom(Template::ACCOUNT_ACTIVATION, ['link' => $link])

--- a/src/Service/Mailer/MailerProvider.php
+++ b/src/Service/Mailer/MailerProvider.php
@@ -65,7 +65,7 @@ class MailerProvider implements MailerProviderInterface
 
     public function sendResetPasswordMessage(User $user): void
     {
-        $link = $this->urlGenerator->generate('reset_password', ['token' => $user->getToken()]);
+        $link = $this->urlGenerator->generate('activate_account', ['id' => $user->getId(), 'token' => $user->getToken()]);
         $message = $this
             ->messageFactory
             ->createInstanceFrom(Template::RESET_PASSWORD, ['link' => $link])
@@ -76,7 +76,7 @@ class MailerProvider implements MailerProviderInterface
 
     public function sendActivateMessage(User $user): void
     {
-        $link = $this->urlGenerator->generate('activate_account', ['token' => $user->getToken()]);
+        $link = $this->urlGenerator->generate('activate_account', ['id' => $user->getId(), 'token' => $user->getToken()]);
         $message = $this
             ->messageFactory
             ->createInstanceFrom(Template::ACCOUNT_ACTIVATION, ['link' => $link])

--- a/templates/security/login.html.twig
+++ b/templates/security/login.html.twig
@@ -3,6 +3,20 @@
 {% block title %}Connexion à l'espace pro{% if error %} | Erreur d'identification{% endif %}{% endblock %}
 
 {% block body %}
+{% for label, messages in app.flashes %}
+	{% for message in messages %}
+		<div role="status" class="fr-alert fr-alert--{{ label }} fr-alert--sm fr-mb-3v">
+			{% if label is same as('error') or label is same as('error error-raw')  %}
+				<strong>Erreur...</strong>
+			{% endif %}
+			{% if label is same as('error error-raw')  %}
+				<p>{{ message|raw }}</p>
+			{% else %}
+				<p>{{ message }}</p>
+			{% endif %}
+		</div>
+	{% endfor %}
+{% endfor %}
 <div class="fr-container fr-py-5w">
     <div class="fr-grid-row fr-grid-row--center">
         <div class="fr-col-10 fr-col-md-8 fr-col-lg-6">

--- a/templates/security/reset_password_link_sent.html.twig
+++ b/templates/security/reset_password_link_sent.html.twig
@@ -1,26 +1,44 @@
 {% extends 'base.html.twig' %}
 
-{% block title %}Demande de réinitialisation envoyée{% endblock %}
+{% set submit_route_action = app.request.get('_route') == 'request_password' ? 'request_password' : 'request_account_activation' %}
+
+{% block title %}
+    {{ submit_route_action == 'request_password' ? 'Demande de réinitialisation envoyée' : 'Demande d\'activation envoyée'}}
+{% endblock %}
 
 {% block body %}
 <div class="fr-container fr-py-5w">
     <div class="fr-grid-row fr-grid-row--center">
         <div class="fr-col-10 fr-col-md-8 fr-col-lg-6">
-            <h1>Réinitialiser mon mot de passe</h1>
+            <h1>
+                {% if submit_route_action == 'request_password' %}
+                    Réinitialiser mon mot de passe
+                {% else %}
+                    Activer mon compte
+                {% endif %}
+            </h1>
 
             <div role="status" class="fr-alert fr-alert--success">
-                <h3>Demande de réinitialisation envoyée&nbsp;!</h3>
-                <p>
-                    Vous allez recevoir un email d'ici quelques minutes.
-                    Cliquez sur le lien dans l'email pour réinitialiser votre mot de passe.
-                </p>
-                <p>
-                    <em>
-                        Ce courriel à été envoyé à l'adresse&nbsp;:
-                        <br>
-                        {{ email }}
-                    </em>
-                </p>
+                {% if submit_route_action == 'request_password' %}
+                    <h3>Demande de réinitialisation envoyée&nbsp;!</h3>
+                    <p>
+                        Vous allez recevoir un email d'ici quelques minutes.
+                        Cliquez sur le lien dans l'email pour réinitialiser votre mot de passe.
+                    </p>
+                {% else %}
+                    <h3>Demande d'activation envoyée&nbsp;!</h3>
+                    <p>
+                        Vous allez recevoir un email d'ici quelques minutes.
+                        Cliquez sur le lien dans l'email pour activer votre compte.
+                    </p>
+                {% endif %}
+                    <p>
+                        <em>
+                            Ce courriel à été envoyé à l'adresse&nbsp;:
+                            <br>
+                            {{ email }}
+                        </em>
+                    </p>
             </div>
         </div>
     </div>

--- a/templates/security/reset_password_new.html.twig
+++ b/templates/security/reset_password_new.html.twig
@@ -6,47 +6,106 @@
 <div class="fr-container fr-py-5w">
     <div class="fr-grid-row fr-grid-row--center">
         <div class="fr-col-10 fr-col-md-8 fr-col-lg-6">
-            <h1>Création de votre mot de passe</h1>
+            {% if user.status is same as constant('App\\Entity\\Enum\\Status::INACTIVE')  %}
+                <h1>Création de votre mot de passe</h1>
+            {% else %}
+                <h1>Réinitialisation de votre mot de passe</h1>
+            {% endif %}
 
             <div class="fr-alert fr-alert--info fr-mb-3w">
-                <p>Vous avez demandé la récupération ou la création de votre mot de passe</p>
+                {% if user.status is same as constant('App\\Entity\\Enum\\Status::INACTIVE')  %}
+                    <p class="fr-callout__text">
+                        Vous avez demandé l'activation de votre compte
+                    </p>
+                {% else %}
+                    <p class="fr-callout__text">
+                        Vous avez demandé la réinitialisation de votre mot de passe
+                    </p>
+                {% endif %}
             </div>
-
-            <form class="needs-validation fr-mb-5w" name="login-creation-mdp-form" method="POST" novalidate="">
-                {% for label, messages in app.flashes %}
-                    {% for message in messages %}
-                        <div role="status" class="fr-alert fr-alert--{{ label }} fr-alert--sm fr-mb-3v">
-                            {% if label is same as('error') %}
-                                <strong>Erreur...</strong>
-                            {% endif %}
+            {% for label, messages in app.flashes %}
+                {% for message in messages %}
+                    <div role="status" class="fr-alert fr-alert--{{ label }} fr-alert--sm fr-mb-3v">
+                        {% if label is same as('error') or label is same as('error error-raw')  %}
+                            <strong>Erreur...</strong>
+                        {% endif %}
+                        {% if label is same as('error error-raw')  %}
+                            <p>{{ message|raw }}</p>
+                        {% else %}
                             <p>{{ message }}</p>
-                        </div>
-                    {% endfor %}
+                        {% endif %}
+                    </div>
                 {% endfor %}
-
-                <div class="fr-input-group">
-                    <label class="fr-label" for="login-email" autocomplete="email">Adresse email</label>
-                    <div class="fr-input">{{ email }}</div>
-                </div>
-
-                <div class="fr-input-group">
-                    <label class="fr-label" for="login-password">Mot de passe</label>
-                    <input class="fr-input" type="password" id="login-password" name="password" required minlength="8" autocomplete="new-password">
-                </div>
-
-                <div class="fr-input-group">
-                    <label class="fr-label" for="login-password-repeat">Confirmation du mot de passe</label>
-                    <input class="fr-input" type="password" id="login-password-repeat" name="password-repeat" required minlength="8" autocomplete="new-password">
-                </div>
-
-                <input type="hidden" name="_csrf_token" value="{{ csrf_token('create_password_'~id) }}">
-
-                <div class="fr-input-group">
-                    <button class="fr-btn fr-btn--icon-left fr-icon-check-line">
-                        Se connecter
-                    </button>
-                </div>
-            </form>
+            {% endfor %}
+            {% if displayForm %}
+                <form class="needs-validation fr-mb-5w" name="login-creation-mdp-form" method="POST" novalidate="">
+                        <div class="fr-input-group">
+                            <label class="fr-label" for="login-email" autocomplete="email">Adresse email</label>
+                            <div class="fr-input" id="login-email">{{ user.email }}</div>
+                        </div>
+                        <div class="fr-password fr-input-group fr-input-group-password">
+                            <label class="fr-label" for="login-password">
+                                Mot de passe
+                                <span class="fr-hint-text">Choisissez un mot de passe <u>fort et unique</u></span>
+                            </label>
+                            <div class="fr-input-wrap">
+                                <input class="fr-input fr-password__input" type="password" id="login-password" name="password" required minlength="8" autocomplete="new-password" required>
+                            </div>
+                            <div class="fr-password__checkbox fr-checkbox-group fr-checkbox-group--sm">
+                                <input aria-label="Afficher le mot de passe" id="login-password-show" type="checkbox" aria-describedby="login-password-show-messages">
+                                <label class="fr-password__checkbox fr-label" for="login-password-show">
+                                    Afficher
+                                </label>
+                                <div class="fr-messages-group" id="login-password-show-messages" aria-live="assertive">
+                                </div>
+                            </div>
+                            <div class="fr-messages-group" id="password-input-messages" aria-live="assertive">
+                                <p class="fr-message">Votre mot de passe doit contenir :</p>
+                                <p class="message-password fr-message fr-message--info" id="password-input-message-info-length">8 caractères minimum</p>
+                                <p class="message-password fr-message fr-message--info" id="password-input-message-info-maj">1 caractère majuscule minimum</p>
+                                <p class="message-password fr-message fr-message--info" id="password-input-message-info-min">1 caractère minuscule minimum</p>
+                                <p class="message-password fr-message fr-message--info" id="password-input-message-info-nb">1 chiffre minimum</p>
+                                <p class="message-password fr-message fr-message--info" id="password-input-message-info-special">1 caractère spécial minimum</p>
+                            </div>
+                        </div>
+                        <div class="fr-password fr-input-group fr-input-group-password-repeat">
+                            <label class="fr-label" for="login-password-repeat">Confirmation du mot de passe</label>
+                            <div class="fr-input-wrap">
+                                <input class="fr-input fr-password__input" type="password" id="login-password-repeat" name="password-repeat" required minlength="8" autocomplete="new-password" required>
+                            </div>
+                            <div class="fr-password__checkbox fr-checkbox-group fr-checkbox-group--sm">
+                                <input aria-label="Afficher le mot de passe" id="login-password-repeat-show" type="checkbox" aria-describedby="login-password-repeat-show-messages">
+                                <label class="fr-password__checkbox fr-label" for="login-password-repeat-show">
+                                    Afficher
+                                </label>
+                                <div class="fr-messages-group" id="login-password-repeat-show-messages" aria-live="assertive">
+                                </div>
+                            </div>
+                            <p id="password-match-error" class="fr-error-text fr-hidden fr-col-12">
+                                Les mots de passes ne correspondent pas.
+                            </p>
+                        </div>
+                        <input type="hidden" name="_csrf_token" value="{{ csrf_token('create_password_'~user.id) }}">
+                        <div class="fr-input-group">
+                            <button class="fr-btn fr-btn--icon-left fr-icon-check-line" id="submitter">
+                                Confirmer
+                            </button>
+                        </div>
+                </form>
+                {% else %}
+                    <ul class="">
+                        <li>
+                            <a href="{{ path('app_login') }}" class="">
+                                Se connecter
+                            </a>
+                        </li>
+                        <li>
+                            <a href="{{ path('request_account_activation') }}" class="">
+                                Activer votre compte
+                            </a>
+                        </li>
+                    </ul>
+                {% endif %}
         </div>
     </div>
 </div>

--- a/templates/security/reset_password_new.html.twig
+++ b/templates/security/reset_password_new.html.twig
@@ -82,7 +82,7 @@
                                 </div>
                             </div>
                             <p id="password-match-error" class="fr-error-text fr-hidden fr-col-12">
-                                Les mots de passes ne correspondent pas.
+                                Les mots de passe ne correspondent pas.
                             </p>
                         </div>
                         <input type="hidden" name="_csrf_token" value="{{ csrf_token('create_password_'~user.id) }}">

--- a/templates/security/reset_password_new.html.twig
+++ b/templates/security/reset_password_new.html.twig
@@ -23,13 +23,15 @@
                     </p>
                 {% endif %}
             </div>
+            {% set passwordHasErrors = false %}
             {% for label, messages in app.flashes %}
                 {% for message in messages %}
-                    <div role="status" class="fr-alert fr-alert--{{ label }} fr-alert--sm fr-mb-3v">
-                        {% if label is same as('error') or label is same as('error error-raw')  %}
+                    <div role="status" class="fr-alert fr-alert--{{ label }} fr-alert--sm fr-mb-3v" {% if label is same as('error error-raw') %}id="password-has-error"{% endif %}>
+                        {% if label is same as('error') or label is same as('error error-raw')  %}                       
                             <strong>Erreur...</strong>
                         {% endif %}
                         {% if label is same as('error error-raw')  %}
+                            {% set passwordHasErrors = true %}
                             <p>{{ message|raw }}</p>
                         {% else %}
                             <p>{{ message }}</p>
@@ -49,7 +51,16 @@
                                 <span class="fr-hint-text">Choisissez un mot de passe <u>fort et unique</u></span>
                             </label>
                             <div class="fr-input-wrap">
-                                <input class="fr-input fr-password__input" type="password" id="login-password" name="password" required minlength="8" autocomplete="new-password" required>
+                                <input 
+                                class="fr-input fr-password__input" 
+                                type="password" 
+                                id="login-password" 
+                                name="password" 
+                                minlength="8" 
+                                autocomplete="new-password" 
+                                required
+                                {% if passwordHasErrors %}aria-describedby="password-has-error"{% endif %}
+                                >
                             </div>
                             <div class="fr-password__checkbox fr-checkbox-group fr-checkbox-group--sm">
                                 <input aria-label="Afficher le mot de passe" id="login-password-show" type="checkbox" aria-describedby="login-password-show-messages">
@@ -71,7 +82,7 @@
                         <div class="fr-password fr-input-group fr-input-group-password-repeat">
                             <label class="fr-label" for="login-password-repeat">Confirmation du mot de passe</label>
                             <div class="fr-input-wrap">
-                                <input class="fr-input fr-password__input" type="password" id="login-password-repeat" name="password-repeat" required minlength="8" autocomplete="new-password" required>
+                                <input class="fr-input fr-password__input" type="password" id="login-password-repeat" name="password-repeat" required minlength="8" autocomplete="new-password" >
                             </div>
                             <div class="fr-password__checkbox fr-checkbox-group fr-checkbox-group--sm">
                                 <input aria-label="Afficher le mot de passe" id="login-password-repeat-show" type="checkbox" aria-describedby="login-password-repeat-show-messages">

--- a/tests/Functional/Controller/Security/AccountActivationControllerTest.php
+++ b/tests/Functional/Controller/Security/AccountActivationControllerTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\Tests\Functional\Controller\Security;
+
+use App\Entity\User;
+use App\Repository\UserRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\Routing\RouterInterface;
+
+class AccountActivationControllerTest extends WebTestCase
+{
+    private KernelBrowser $client;
+    private EntityManagerInterface $entityManager;
+    private User $user;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->entityManager = static::getContainer()->get('doctrine.orm.entity_manager');
+        /** @var UserRepository $userRepository */
+        $userRepository = static::getContainer()->get(UserRepository::class);
+        $this->user = $userRepository->findOneBy(['email' => 'company-03@punaises.fr']);
+        $this->user->setToken('test-token');
+        $this->user->setTokenExpiredAt((new \DateTimeImmutable())->modify('+1 hour'));
+        $this->entityManager->flush();
+    }
+
+    public function testActivationUserFormSubmit(): void
+    {
+        /** @var RouterInterface $router */
+        $router = self::getContainer()->get(RouterInterface::class);
+
+        $route = $router->generate('activate_account', ['id' => $this->user->getId(), 'token' => $this->user->getToken()]);
+        $this->client->request('GET', $route);
+
+        $password = 'Stop-Punaise01';
+        $this->client->submitForm('Confirmer', [
+            'password' => $password,
+            'password-repeat' => $password,
+        ]);
+
+        $this->assertResponseRedirects('/login');
+    }
+
+    public function testActivationUserFormSubmitWithMismatchedPassword(): void
+    {
+        /** @var RouterInterface $router */
+        $router = self::getContainer()->get(RouterInterface::class);
+
+        $route = $router->generate('activate_account', ['id' => $this->user->getId(), 'token' => $this->user->getToken()]);
+        $this->client->request('GET', $route);
+
+        $this->client->submitForm('Confirmer', [
+            'password' => 'un',
+            'password-repeat' => 'deux',
+        ]);
+
+        $this->assertSelectorTextContains(
+            '.fr-alert.fr-alert--error.fr-alert--sm',
+            'Les mots de passe ne correspondent pas.'
+        );
+    }
+
+    /**
+     * @dataProvider provideInvalidPassword
+     */
+    public function testActivationUserFormSubmitWithInvalidPassword(string $expectedResult, string $password): void
+    {
+        /** @var RouterInterface $router */
+        $router = self::getContainer()->get(RouterInterface::class);
+
+        $route = $router->generate('activate_account', ['id' => $this->user->getId(), 'token' => $this->user->getToken()]);
+        $this->client->request('GET', $route);
+
+        $this->client->submitForm('Confirmer', [
+            'password' => $password,
+            'password-repeat' => $password,
+        ]);
+
+        $this->assertSelectorTextContains(
+            '.fr-alert.fr-alert--error.fr-alert--sm',
+            $expectedResult
+        );
+    }
+
+    public function provideInvalidPassword(): \Generator
+    {
+        yield 'blank' => ['Cette valeur ne doit pas être vide', ''];
+        yield 'short' => ['Le mot de passe doit contenir au moins 8 caratères', 'short'];
+        yield 'no_uppercase' => ['Le mot de passe doit contenir au moins une lettre majuscule', 'nouppercase'];
+        yield 'no_lowercase' => ['Le mot de passe doit contenir au moins une lettre minuscule', 'NOLOWERCASE'];
+        yield 'no_digit' => ['Le mot de passe doit contenir au moins un chiffre', 'NoDigitNoDigit'];
+        yield 'no_special' => ['Le mot de passe doit contenir au moins un caractère spécial', 'NoSpecial'];
+    }
+}

--- a/tests/Functional/Controller/Security/AccountActivationControllerTest.php
+++ b/tests/Functional/Controller/Security/AccountActivationControllerTest.php
@@ -32,7 +32,7 @@ class AccountActivationControllerTest extends WebTestCase
         /** @var RouterInterface $router */
         $router = self::getContainer()->get(RouterInterface::class);
 
-        $route = $router->generate('activate_account', ['id' => $this->user->getId(), 'token' => $this->user->getToken()]);
+        $route = $router->generate('activate_account', ['uuid' => $this->user->getUuid(), 'token' => $this->user->getToken()]);
         $this->client->request('GET', $route);
 
         $password = 'Stop-Punaise01';
@@ -49,7 +49,7 @@ class AccountActivationControllerTest extends WebTestCase
         /** @var RouterInterface $router */
         $router = self::getContainer()->get(RouterInterface::class);
 
-        $route = $router->generate('activate_account', ['id' => $this->user->getId(), 'token' => $this->user->getToken()]);
+        $route = $router->generate('activate_account', ['uuid' => $this->user->getUuid(), 'token' => $this->user->getToken()]);
         $this->client->request('GET', $route);
 
         $this->client->submitForm('Confirmer', [
@@ -71,7 +71,7 @@ class AccountActivationControllerTest extends WebTestCase
         /** @var RouterInterface $router */
         $router = self::getContainer()->get(RouterInterface::class);
 
-        $route = $router->generate('activate_account', ['id' => $this->user->getId(), 'token' => $this->user->getToken()]);
+        $route = $router->generate('activate_account', ['uuid' => $this->user->getUuid(), 'token' => $this->user->getToken()]);
         $this->client->request('GET', $route);
 
         $this->client->submitForm('Confirmer', [

--- a/tests/Functional/Controller/Security/AccountActivationControllerTest.php
+++ b/tests/Functional/Controller/Security/AccountActivationControllerTest.php
@@ -88,7 +88,7 @@ class AccountActivationControllerTest extends WebTestCase
     public function provideInvalidPassword(): \Generator
     {
         yield 'blank' => ['Cette valeur ne doit pas être vide', ''];
-        yield 'short' => ['Le mot de passe doit contenir au moins 8 caratères', 'short'];
+        yield 'short' => ['Le mot de passe doit contenir au moins 8 caractères', 'short'];
         yield 'no_uppercase' => ['Le mot de passe doit contenir au moins une lettre majuscule', 'nouppercase'];
         yield 'no_lowercase' => ['Le mot de passe doit contenir au moins une lettre minuscule', 'NOLOWERCASE'];
         yield 'no_digit' => ['Le mot de passe doit contenir au moins un chiffre', 'NoDigitNoDigit'];

--- a/tests/Unit/Entity/UserTest.php
+++ b/tests/Unit/Entity/UserTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Tests\Unit\Entity;
+
+use App\Entity\User;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Validator\ConstraintViolationList;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+class UserTest extends KernelTestCase
+{
+    /**
+     * @dataProvider provideInvalidPassword
+     */
+    public function testPasswordValidationError(string $expectedResult, string $password)
+    {
+        /** @var ValidatorInterface $validator */
+        $validator = static::getContainer()->get(ValidatorInterface::class);
+
+        $user = new User();
+        $user->setPassword($password);
+
+        $errors = $validator->validate($user, null, ['password']);
+
+        /** @var ConstraintViolationList $errors */
+        $errorsAsString = (string) $errors;
+        $this->assertStringContainsString($expectedResult, $errorsAsString);
+    }
+
+    public function testPasswordValidationSuccess()
+    {
+        /** @var ValidatorInterface $validator */
+        $validator = static::getContainer()->get(ValidatorInterface::class);
+
+        $user = new User();
+        $user->setPassword('Stop-Punaise01');
+
+        $errors = $validator->validate($user, null, ['password']);
+
+        $this->assertCount(0, $errors);
+    }
+
+    public function provideInvalidPassword(): \Generator
+    {
+        yield 'blank' => ['Cette valeur ne doit pas être vide', ''];
+        yield 'short' => ['Le mot de passe doit contenir au moins 8 caratères', 'short'];
+        yield 'no_uppercase' => ['Le mot de passe doit contenir au moins une lettre majuscule', 'nouppercase'];
+        yield 'no_lowercase' => ['Le mot de passe doit contenir au moins une lettre minuscule', 'NOLOWERCASE'];
+        yield 'no_digit' => ['Le mot de passe doit contenir au moins un chiffre', 'NoDigitNoDigit'];
+        yield 'no_special' => ['Le mot de passe doit contenir au moins un caractère spécial', 'NoSpecial'];
+    }
+}

--- a/tests/Unit/Entity/UserTest.php
+++ b/tests/Unit/Entity/UserTest.php
@@ -43,7 +43,7 @@ class UserTest extends KernelTestCase
     public function provideInvalidPassword(): \Generator
     {
         yield 'blank' => ['Cette valeur ne doit pas être vide', ''];
-        yield 'short' => ['Le mot de passe doit contenir au moins 8 caratères', 'short'];
+        yield 'short' => ['Le mot de passe doit contenir au moins 8 caractères', 'short'];
         yield 'no_uppercase' => ['Le mot de passe doit contenir au moins une lettre majuscule', 'nouppercase'];
         yield 'no_lowercase' => ['Le mot de passe doit contenir au moins une lettre minuscule', 'NOLOWERCASE'];
         yield 'no_digit' => ['Le mot de passe doit contenir au moins un chiffre', 'NoDigitNoDigit'];


### PR DESCRIPTION
## Ticket

#551

## Description
Ajout de contraintes de validation pour des mot de passe plus fort : 
- 8 caractères minimum
- 1 caractère majuscule minimum
- 1 caractère minuscule minimum
- 1 chiffre minimum
- 1 caractère spécial minimum


## Changements apportés
- Passage de l'app en français par défaut
- Route unique `activate_account` pour activer son compte / modifier sont mot de passe
- Ajout de l'option "Afficher" sur les champs mot de passe de la page création/modification de mot de passe
- Affichage du message flash de succès aprés redirection sur la page login
- Ajout de tests

## Pré-requis
`make execute-migration name=Version20240319132426 direction=up`
`make npm-build`

## Tests
- [ ] Vérifier que l'activation de compte / modification du mot de passe fonctionne correctement
- [ ] Vérifier que les indicateurs de contrainte évoluent correctement au fur et à mesure de la complétion du champs
