### PR TITLE
[Accessibilité] Ajout d'indication sur les niveaux d'infestation pour faciliter la lecture par synthèse vocale

### DIFF
--- a/src/Entity/Enum/InfestationLevel.php
+++ b/src/Entity/Enum/InfestationLevel.php
@@ -27,7 +27,7 @@ enum InfestationLevel: int
             '0 - Nulle',
             '1 - Faible',
             '2 - Moyenne',
-            '3 - Elevée',
+            '3 - Élevée',
             '4 - Très élevée',
         ];
     }

--- a/src/Service/Signalement/SignalementOccupantDataTableHandler.php
+++ b/src/Service/Signalement/SignalementOccupantDataTableHandler.php
@@ -156,8 +156,13 @@ class SignalementOccupantDataTableHandler
             return 'Non communiqué';
         }
 
-        return '<span class="niveau-infestation niveau-'.$niveauInfestation.'">'
-                .$this->appExtension->formatLabelInfestation($niveauInfestation).
+        $label = $this->appExtension->formatLabelInfestation($niveauInfestation);
+
+        return '<span class="niveau-infestation niveau-'.$niveauInfestation.'"
+                title="infestation de niveau '.$label.'"
+                aria-label="infestation de niveau '.$label.'"
+                >'
+                .$label.
                 '</span>';
     }
 

--- a/templates/common/components/niveau-infestation.html.twig
+++ b/templates/common/components/niveau-infestation.html.twig
@@ -1,3 +1,6 @@
-<span class="niveau-infestation niveau-{{ signalement.niveauInfestation }}">
+<span class="niveau-infestation niveau-{{ signalement.niveauInfestation }}"
+    title="infestation de niveau {{ signalement.niveauInfestation|label_infestation }}"
+    aria-label="infestation de niveau {{ signalement.niveauInfestation|label_infestation }}"
+    >
     {{ signalement.niveauInfestation|label_infestation }}
 </span>


### PR DESCRIPTION
## Ticket

#718   

## Description
La lecture des niveaux d'infestation pouvait se faire directement avec les champs suivants ce qui ne facilitait pas la compréhension. On ajoute donc des informations via les attributs.

## Tests
- [ ] Vérifier le `title` et le `aria-label` dans la liste des signalements BO
- [ ] Idem dans une fiche BO
- [ ] Idem dans la page de suivi usager
