### PR TITLE
[Accessibilité] Suppression des liens inutiles dans les accès rapides

### DIFF
--- a/templates/common/skiplink-back.html.twig
+++ b/templates/common/skiplink-back.html.twig
@@ -2,12 +2,6 @@
     <nav class="fr-container" role="navigation" aria-label="Accès rapide">
         <ul class="fr-skiplinks__list">
             <li>
-                <a class="fr-link" href="#header-menu">Menu</a>
-            </li>
-            <li>
-                <a class="fr-link" href="#header-navigation">Menu secondaire</a>
-            </li>
-            <li>
                 <a class="fr-link" href="#contenu">Contenu</a>
             </li>
             <li>

--- a/templates/common/skiplink.html.twig
+++ b/templates/common/skiplink.html.twig
@@ -2,9 +2,6 @@
     <nav class="fr-container" role="navigation" aria-label="Accès rapide">
         <ul class="fr-skiplinks__list">
             <li>
-                <a class="fr-link" href="#header-menu">Menu</a>
-            </li>
-            <li>
                 <a class="fr-link" href="#contenu">Contenu</a>
             </li>
             <li>


### PR DESCRIPTION
## Ticket

#717    

## Description
L'auditeur nous signale que certains liens d'accès rapides (Menu et Menu secondaire) ne sont pas fonctionnels.
Par ailleurs, il nous avait fortement encouragé à les supprimer. C'est chose faite.

## Tests
- [ ] Vérifier les liens d'accès rapides FO
- [ ] Idem BO
