### PR TITLE
[Accessibilité] Corrections d'affichage des infographies

### DIFF
--- a/templates/front/information.html.twig
+++ b/templates/front/information.html.twig
@@ -279,83 +279,80 @@
                                 Agrandir l'image
                             </button>
                         </div>
-                        <figcaption class="fr-content-media__caption">
-                            Crédit : Citizen
-                            <br>
-                        </figcaption>
-                        <div class="fr-transcription" id="transcription-ou-se-cachent-elles">
-                            <button
-                                class="fr-transcription__btn"
-                                aria-expanded="false"
-                                aria-controls="fr-transcription-collapse-transcription-ou-se-cachent-elles"
-                                data-fr-js-collapse-button="true"
-                                >
-                                Transcription
-                            </button>
-                            <div
-                                class="fr-collapse"
-                                id="fr-transcription-collapse-transcription-ou-se-cachent-elles"
-                                data-fr-js-collapse="true"
-                                >
-                                <div class="fr-transcription__footer">
-                                    <div class="fr-transcription__actions-group">
-                                    <button
-                                        class="fr-btn--fullscreen fr-btn"
-                                        aria-controls="fr-transcription-modal-transcription-ou-se-cachent-elles"
-                                        aria-label="Agrandir la transcription"
-                                        data-fr-opened="false"
-                                        id="button-agrandir-ou-se-cachent-elles"
-                                        data-fr-js-modal-button="true"
-                                        >
-                                        Agrandir
-                                    </button>
-                                    </div>
-                                </div>
-                                <div
-                                    id="fr-transcription-modal-transcription-ou-se-cachent-elles"
-                                    class="fr-modal"
-                                    aria-labelledby="fr-transcription-modal-transcription-ou-se-cachent-elles-title"
-                                    data-fr-js-modal="true"
+                        <figcaption class="fr-content-media__caption">Crédit : Citizen</figcaption>
+                    </figure>
+                    <div class="fr-transcription" id="transcription-ou-se-cachent-elles">
+                        <button
+                            class="fr-transcription__btn"
+                            aria-expanded="false"
+                            aria-controls="fr-transcription-collapse-transcription-ou-se-cachent-elles"
+                            data-fr-js-collapse-button="true"
+                            >
+                            Transcription
+                        </button>
+                        <div
+                            class="fr-collapse"
+                            id="fr-transcription-collapse-transcription-ou-se-cachent-elles"
+                            data-fr-js-collapse="true"
+                            >
+                            <div class="fr-transcription__footer">
+                                <div class="fr-transcription__actions-group">
+                                <button
+                                    class="fr-btn--fullscreen fr-btn"
+                                    aria-controls="fr-transcription-modal-transcription-ou-se-cachent-elles"
+                                    aria-label="Agrandir la transcription"
+                                    data-fr-opened="false"
+                                    id="button-agrandir-ou-se-cachent-elles"
+                                    data-fr-js-modal-button="true"
                                     >
-                                    <div class="fr-container fr-container--fluid fr-container-md">
-                                        <div class="fr-grid-row fr-grid-row--center">
-                                            <div class="fr-col-12 fr-col-md-10 fr-col-lg-8">
-                                                <div class="fr-modal__body" data-fr-js-modal-body="true">
-                                                    <div class="fr-modal__header">
-                                                        <button
-                                                            class="fr-btn--close fr-btn"
-                                                            aria-controls="fr-transcription-modal-transcription-ou-se-cachent-elles"
-                                                            id="button-fermer-ou-se-cachent-elles"
-                                                            title="Fermer"
-                                                            data-fr-js-modal-button="true"
-                                                            >
-                                                            Fermer
-                                                        </button>
-                                                        </div>
-                                                        <div class="fr-modal__content">
-                                                        <h1
-                                                            id="fr-transcription-modal-transcription-ou-se-cachent-elles-title"
-                                                            class="fr-modal__title"
+                                    Agrandir
+                                </button>
+                                </div>
+                            </div>
+                            <div
+                                id="fr-transcription-modal-transcription-ou-se-cachent-elles"
+                                class="fr-modal"
+                                aria-labelledby="fr-transcription-modal-transcription-ou-se-cachent-elles-title"
+                                data-fr-js-modal="true"
+                                >
+                                <div class="fr-container fr-container--fluid fr-container-md">
+                                    <div class="fr-grid-row fr-grid-row--center">
+                                        <div class="fr-col-12 fr-col-md-10 fr-col-lg-8">
+                                            <div class="fr-modal__body" data-fr-js-modal-body="true">
+                                                <div class="fr-modal__header">
+                                                    <button
+                                                        class="fr-btn--close fr-btn"
+                                                        aria-controls="fr-transcription-modal-transcription-ou-se-cachent-elles"
+                                                        id="button-fermer-ou-se-cachent-elles"
+                                                        title="Fermer"
+                                                        data-fr-js-modal-button="true"
                                                         >
-                                                            Punaises de lit : où se cachent-elles ?
-                                                        </h1>
-                                                        <div>
-                                                            Les punaises de lit sont visibles à l'oeil nu et sont généralement brunes.
-                                                            <br>
-                                                            L'adulte a les dimensions d'un pépin de pomme. L'oeuf, de couleur blanche, mesure environ 1mm. Elles ne sautent pas et ne volent pas.
-                                                            <br>
-                                                            La chambre, leur espace préféré.
-                                                            <br>
-                                                            On les trouve en grande majorité :
-                                                            <br>
-                                                            <ul>
-                                                                <li>dans les matelas et sommiers qu'il ne faut pas hésiter à retourner pour une inspection complète</li>
-                                                                <li>derrière les cadres, les raccords de papier peint, sous les meubles, dans les plinthes, sous les prises électriques...</li>
-                                                                <li>dans les fissures et les fentes du parquet</li>
-                                                                <li>dans les canapés</li>
-                                                                <li>sous les tapis</li>
-                                                            </ul>
-                                                        </div>
+                                                        Fermer
+                                                    </button>
+                                                    </div>
+                                                    <div class="fr-modal__content">
+                                                    <h1
+                                                        id="fr-transcription-modal-transcription-ou-se-cachent-elles-title"
+                                                        class="fr-modal__title"
+                                                    >
+                                                        Punaises de lit : où se cachent-elles ?
+                                                    </h1>
+                                                    <div>
+                                                        Les punaises de lit sont visibles à l'oeil nu et sont généralement brunes.
+                                                        <br>
+                                                        L'adulte a les dimensions d'un pépin de pomme. L'oeuf, de couleur blanche, mesure environ 1mm. Elles ne sautent pas et ne volent pas.
+                                                        <br>
+                                                        La chambre, leur espace préféré.
+                                                        <br>
+                                                        On les trouve en grande majorité :
+                                                        <br>
+                                                        <ul>
+                                                            <li>dans les matelas et sommiers qu'il ne faut pas hésiter à retourner pour une inspection complète</li>
+                                                            <li>derrière les cadres, les raccords de papier peint, sous les meubles, dans les plinthes, sous les prises électriques...</li>
+                                                            <li>dans les fissures et les fentes du parquet</li>
+                                                            <li>dans les canapés</li>
+                                                            <li>sous les tapis</li>
+                                                        </ul>
                                                     </div>
                                                 </div>
                                             </div>
@@ -364,7 +361,7 @@
                                 </div>
                             </div>
                         </div>
-                    </figure>
+                    </div>
                     <dialog aria-labelledby="fr-modal-title-modal-flyer-cache" id="fr-modal-flyer-cache" class="fr-modal">
                         <div class="fr-container fr-container--fluid fr-container-md">
                             <div class="fr-grid-row fr-grid-row--center">
@@ -642,75 +639,75 @@
                             </button>
                         </div>
                         <figcaption class="fr-content-media__caption">Crédit : Citizen</figcaption>
-                        <div class="fr-transcription" id="transcription-comment-eviter">
-                            <button
-                                class="fr-transcription__btn"
-                                aria-expanded="false"
-                                aria-controls="fr-transcription-collapse-transcription-comment-eviter"
-                                data-fr-js-collapse-button="true"
-                                >
-                                Transcription
-                            </button>
-                            <div
-                                class="fr-collapse"
-                                id="fr-transcription-collapse-transcription-comment-eviter"
-                                data-fr-js-collapse="true"
-                                >
-                                <div class="fr-transcription__footer">
-                                    <div class="fr-transcription__actions-group">
-                                    <button
-                                        class="fr-btn--fullscreen fr-btn"
-                                        aria-controls="fr-transcription-modal-transcription-comment-eviter"
-                                        aria-label="Agrandir la transcription"
-                                        data-fr-opened="false"
-                                        id="button-agrandir-comment-eviter"
-                                        data-fr-js-modal-button="true"
-                                        >
-                                        Agrandir
-                                    </button>
-                                    </div>
-                                </div>
-                                <div
-                                    id="fr-transcription-modal-transcription-comment-eviter"
-                                    class="fr-modal"
-                                    aria-labelledby="fr-transcription-modal-transcription-comment-eviter-title"
-                                    data-fr-js-modal="true"
+                    </figure>
+                    <div class="fr-transcription" id="transcription-comment-eviter">
+                        <button
+                            class="fr-transcription__btn"
+                            aria-expanded="false"
+                            aria-controls="fr-transcription-collapse-transcription-comment-eviter"
+                            data-fr-js-collapse-button="true"
+                            >
+                            Transcription
+                        </button>
+                        <div
+                            class="fr-collapse"
+                            id="fr-transcription-collapse-transcription-comment-eviter"
+                            data-fr-js-collapse="true"
+                            >
+                            <div class="fr-transcription__footer">
+                                <div class="fr-transcription__actions-group">
+                                <button
+                                    class="fr-btn--fullscreen fr-btn"
+                                    aria-controls="fr-transcription-modal-transcription-comment-eviter"
+                                    aria-label="Agrandir la transcription"
+                                    data-fr-opened="false"
+                                    id="button-agrandir-comment-eviter"
+                                    data-fr-js-modal-button="true"
                                     >
-                                    <div class="fr-container fr-container--fluid fr-container-md">
-                                        <div class="fr-grid-row fr-grid-row--center">
-                                            <div class="fr-col-12 fr-col-md-10 fr-col-lg-8">
-                                                <div class="fr-modal__body" data-fr-js-modal-body="true">
-                                                    <div class="fr-modal__header">
-                                                        <button
-                                                            class="fr-btn--close fr-btn"
-                                                            aria-controls="fr-transcription-modal-transcription-comment-eviter"
-                                                            id="button-fermer-comment-eviter"
-                                                            title="Fermer"
-                                                            data-fr-js-modal-button="true"
-                                                            >
-                                                            Fermer
-                                                        </button>
-                                                        </div>
-                                                        <div class="fr-modal__content">
-                                                        <h1
-                                                            id="fr-transcription-modal-transcription-comment-eviter-title"
-                                                            class="fr-modal__title"
+                                    Agrandir
+                                </button>
+                                </div>
+                            </div>
+                            <div
+                                id="fr-transcription-modal-transcription-comment-eviter"
+                                class="fr-modal"
+                                aria-labelledby="fr-transcription-modal-transcription-comment-eviter-title"
+                                data-fr-js-modal="true"
+                                >
+                                <div class="fr-container fr-container--fluid fr-container-md">
+                                    <div class="fr-grid-row fr-grid-row--center">
+                                        <div class="fr-col-12 fr-col-md-10 fr-col-lg-8">
+                                            <div class="fr-modal__body" data-fr-js-modal-body="true">
+                                                <div class="fr-modal__header">
+                                                    <button
+                                                        class="fr-btn--close fr-btn"
+                                                        aria-controls="fr-transcription-modal-transcription-comment-eviter"
+                                                        id="button-fermer-comment-eviter"
+                                                        title="Fermer"
+                                                        data-fr-js-modal-button="true"
                                                         >
-                                                            Punaises de lit : comment les éviter ?
-                                                        </h1>
-                                                        <div>
-                                                            Des gestes de prévention simples permettent de limiter leur venue ou installation.
-                                                            <br>
-                                                            En voyageant, soyez vigilants :
-                                                            <br>
-                                                            <ul>
-                                                                <li>Ne posez pas votre bagage sur le lit et encore moins sous le lit</li>
-                                                                <li>Contrôlez vos effets personnels à votre retour</li>
-                                                                <li>Evitez d'encombrer les espaces</li>
-                                                                <li>Attention aux achats d'occasion. Lavez bien les vêtements à 60°C.</li>
-                                                                <li>Nettoyez les meubles récupérés</li>
-                                                            </ul>
-                                                        </div>
+                                                        Fermer
+                                                    </button>
+                                                    </div>
+                                                    <div class="fr-modal__content">
+                                                    <h1
+                                                        id="fr-transcription-modal-transcription-comment-eviter-title"
+                                                        class="fr-modal__title"
+                                                    >
+                                                        Punaises de lit : comment les éviter ?
+                                                    </h1>
+                                                    <div>
+                                                        Des gestes de prévention simples permettent de limiter leur venue ou installation.
+                                                        <br>
+                                                        En voyageant, soyez vigilants :
+                                                        <br>
+                                                        <ul>
+                                                            <li>Ne posez pas votre bagage sur le lit et encore moins sous le lit</li>
+                                                            <li>Contrôlez vos effets personnels à votre retour</li>
+                                                            <li>Evitez d'encombrer les espaces</li>
+                                                            <li>Attention aux achats d'occasion. Lavez bien les vêtements à 60°C.</li>
+                                                            <li>Nettoyez les meubles récupérés</li>
+                                                        </ul>
                                                     </div>
                                                 </div>
                                             </div>
@@ -719,7 +716,7 @@
                                 </div>
                             </div>
                         </div>
-                    </figure>
+                    </div>
                     <dialog aria-labelledby="fr-modal-title-modal-flyer-eviter" id="fr-modal-flyer-eviter" class="fr-modal">
                         <div class="fr-container fr-container--fluid fr-container-md">
                             <div class="fr-grid-row fr-grid-row--center">

--- a/templates/front/information.html.twig
+++ b/templates/front/information.html.twig
@@ -372,13 +372,15 @@
                                         </div>
                                         <div class="fr-modal__content">
                                             <h1 id="fr-modal-title-modal-flyer-cache" class="fr-modal__title">Punaises de lit : où se cachent-elles ?</h1>
-                                            <figure class="fr-content-media" aria-label="Où se cachent les punaises de lit ?">
-                                                <div class="fr-content-media__img">
-                                                    <img src="{{ asset('build/images/flyer-ou-se-cachent-elles.jpg') }}"
-                                                        alt="Punaises de lit : où se cachent-elles ?"
-                                                        >
-                                                </div>
-                                            </figure>
+                                            <p>
+                                                <figure class="fr-content-media" aria-label="Où se cachent les punaises de lit ?">
+                                                    <div class="fr-content-media__img">
+                                                        <img src="{{ asset('build/images/flyer-ou-se-cachent-elles.jpg') }}"
+                                                            alt="Punaises de lit : où se cachent-elles ?"
+                                                            >
+                                                    </div>
+                                                </figure>
+                                            </p>
                                         </div>
                                     </div>
                                 </div>
@@ -727,13 +729,15 @@
                                         </div>
                                         <div class="fr-modal__content">
                                             <h1 id="fr-modal-title-modal-flyer-eviter" class="fr-modal__title">Punaises de lit : comment les éviter ?</h1>
-                                            <figure class="fr-content-media" aria-label="Comment éviter les punaises de lit ?">
-                                                <div class="fr-content-media__img">
-                                                    <img src="{{ asset('build/images/flyer-comment-les-eviter.jpg') }}"
-                                                        alt="Punaises de lit : comment les éviter ?"
-                                                        >
-                                                </div>
-                                            </figure>
+                                            <p>
+                                                <figure class="fr-content-media" aria-label="Comment éviter les punaises de lit ?">
+                                                    <div class="fr-content-media__img">
+                                                        <img src="{{ asset('build/images/flyer-comment-les-eviter.jpg') }}"
+                                                            alt="Punaises de lit : comment les éviter ?"
+                                                            >
+                                                    </div>
+                                                </figure>
+                                            </p>
                                         </div>
                                     </div>
                                 </div>


### PR DESCRIPTION
## Ticket

#716    

## Description
On sort la transcription de la balise `<figure>`, car la balise `<figcaption>` doit être premier ou dernier enfant (Erreur qu'on avait reprise depuis le composant DSFR)

Autre souci que je ne sais pas comment reproduire : certaines synthèses vocales (je ne sais pas comment activer) sortent de la modale quand elle est ouverte. 
J'ai regardé les différences avec le composant modal du DSFR.
Le contenu est dans un paragraphe `<p>`, je l'ai remis, au cas où.
Il y a un `role="dialog"`, mais celui-ci est déconseillé par le w3c parce qu'il fait doublon avec la balise `<dialog>`
Donc je ne sais pas comment corriger...

## Tests
- [ ] Vérifier que l'affichage et le fonctionnement sont toujours ok
