### PR TITLE
  [Matomo] Très peu de tracking depuis la mise en ligne du 16 février

### DIFF
--- a/.env
+++ b/.env
@@ -24,7 +24,7 @@ INCONNU_EMAIL=inconnu@stop-punaises.beta.gouv.fr
 MESSENGER_TRANSPORT_DSN=doctrine://default
 REDIS_URL=redis://stopunaises_redis:6379
 FEATURE_THREE_FORMS_ENABLE=1
-SECURITY_CSP_HEADER_VALUE="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.matomo.cloud https://unpkg.com; style-src 'self' 'unsafe-inline' https://unpkg.com; img-src 'self' data: blob: https://*.tile.openstreetmap.org https://unpkg.com; connect-src 'self' https://api-adresse.data.gouv.fr https://cdn.matomo.cloud; font-src 'self'; frame-src 'none'; object-src 'none'"
+SECURITY_CSP_HEADER_VALUE="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.matomo.cloud https://unpkg.com; style-src 'self' 'unsafe-inline' https://unpkg.com; img-src 'self' data: blob: https://*.tile.openstreetmap.org https://unpkg.com; connect-src 'self' https://api-adresse.data.gouv.fr https://cdn.matomo.cloud; font-src 'self'; frame-src 'none'; object-src 'none'"
 MATOMO_ENABLE=0
 MATOMO_SITE_ID=
 SESSION_MAXLIFETIME=151200 # 151200 secondes = 42 heures

--- a/.env
+++ b/.env
@@ -24,7 +24,7 @@ INCONNU_EMAIL=inconnu@stop-punaises.beta.gouv.fr
 MESSENGER_TRANSPORT_DSN=doctrine://default
 REDIS_URL=redis://stopunaises_redis:6379
 FEATURE_THREE_FORMS_ENABLE=1
-SECURITY_CSP_HEADER_VALUE="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.matomo.cloud https://unpkg.com; style-src 'self' 'unsafe-inline' https://unpkg.com; img-src 'self' data: blob: https://*.tile.openstreetmap.org https://unpkg.com; connect-src 'self' https://api-adresse.data.gouv.fr https://cdn.matomo.cloud; font-src 'self'; frame-src 'none'; object-src 'none'"
+SECURITY_CSP_HEADER_VALUE="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.matomo.cloud https://unpkg.com; style-src 'self' 'unsafe-inline' https://unpkg.com; img-src 'self' data: blob: https://*.tile.openstreetmap.org https://unpkg.com; connect-src 'self' https://api-adresse.data.gouv.fr https://cdn.matomo.cloud https://histologe.matomo.cloud; font-src 'self'; frame-src 'none'; object-src 'none';"
 MATOMO_ENABLE=0
 MATOMO_SITE_ID=
 SESSION_MAXLIFETIME=151200 # 151200 secondes = 42 heures

--- a/.env.sample
+++ b/.env.sample
@@ -24,7 +24,7 @@ INCONNU_EMAIL=inconnu@stop-punaises.beta.gouv.fr
 MESSENGER_TRANSPORT_DSN=doctrine://default
 REDIS_URL=redis://stopunaises_redis:6379
 FEATURE_THREE_FORMS_ENABLE=1
-SECURITY_CSP_HEADER_VALUE="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.matomo.cloud https://unpkg.com; style-src 'self' 'unsafe-inline' https://unpkg.com; img-src 'self' data: blob: https://*.tile.openstreetmap.org https://unpkg.com; connect-src 'self' https://api-adresse.data.gouv.fr https://cdn.matomo.cloud; font-src 'self'; frame-src 'none'; object-src 'none'"
+SECURITY_CSP_HEADER_VALUE="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.matomo.cloud https://unpkg.com; style-src 'self' 'unsafe-inline' https://unpkg.com; img-src 'self' data: blob: https://*.tile.openstreetmap.org https://unpkg.com; connect-src 'self' https://api-adresse.data.gouv.fr https://cdn.matomo.cloud; font-src 'self'; frame-src 'none'; object-src 'none'"
 MATOMO_ENABLE=0
 MATOMO_SITE_ID=
 SESSION_MAXLIFETIME=151200 # 151200 secondes = 42 heures

--- a/.env.sample
+++ b/.env.sample
@@ -24,7 +24,7 @@ INCONNU_EMAIL=inconnu@stop-punaises.beta.gouv.fr
 MESSENGER_TRANSPORT_DSN=doctrine://default
 REDIS_URL=redis://stopunaises_redis:6379
 FEATURE_THREE_FORMS_ENABLE=1
-SECURITY_CSP_HEADER_VALUE="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.matomo.cloud https://unpkg.com; style-src 'self' 'unsafe-inline' https://unpkg.com; img-src 'self' data: blob: https://*.tile.openstreetmap.org https://unpkg.com; connect-src 'self' https://api-adresse.data.gouv.fr https://cdn.matomo.cloud; font-src 'self'; frame-src 'none'; object-src 'none'"
+SECURITY_CSP_HEADER_VALUE="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.matomo.cloud https://unpkg.com; style-src 'self' 'unsafe-inline' https://unpkg.com; img-src 'self' data: blob: https://*.tile.openstreetmap.org https://unpkg.com; connect-src 'self' https://api-adresse.data.gouv.fr https://cdn.matomo.cloud https://histologe.matomo.cloud; font-src 'self'; frame-src 'none'; object-src 'none';"
 MATOMO_ENABLE=0
 MATOMO_SITE_ID=
 SESSION_MAXLIFETIME=151200 # 151200 secondes = 42 heures


### PR DESCRIPTION
## Ticket

#726   

## Description
Ajout du "unsafe-eval" dans la CSP pour Matomo. (cf description dans le ticket)
:warning: n'ayant pas le souci en local, je ne sais pas commemnt le tester, je ne suis même pas sûre que ce soit le vrai pb... c'est juste de la déduction.

## Changements apportés
* Changement des .env

## Pré-requis

## Tests
- [ ] ?
