### PR TITLE
[Accessibilité] Afficher le niveau d'accessibilité sur toutes les pages après l'audit

### DIFF
--- a/templates/common/footer.html.twig
+++ b/templates/common/footer.html.twig
@@ -35,7 +35,7 @@
                     <a class="fr-footer__bottom-link" href="{{ path('app_front_plan_du_site') }}">Plan du site</a>
                 </li>
                 <li class="fr-footer__bottom-item">
-                    <a class="fr-footer__bottom-link" href="{{ path('app_front_accessibilite') }}">Accessibilité : non-conforme</a>
+                    <a class="fr-footer__bottom-link" href="{{ path('app_front_accessibilite') }}">Accessibilité : partiellement conforme</a>
                 </li>
                 <li class="fr-footer__bottom-item">
                     <a class="fr-footer__bottom-link" href="{{ path('app_front_mentions_legales') }}">Mentions légales</a>

--- a/templates/front/accessibilite.html.twig
+++ b/templates/front/accessibilite.html.twig
@@ -221,7 +221,7 @@
             <li><a href="{{ path('app_front_contact') }}">Contact</a></li>
             <li><a href="{{ path('app_front_mentions_legales') }}">Mentions légales</a></li>
             <li><a href="{{ path('app_front_accessibilite') }}">Déclaration d'accessibilité</a></li>
-            <li><a href="{{ path('app_front_plan_du_site') }}">Plan du site automatisé en XML</a></li>
+            <li><a href="{{ path('app_front_plan_du_site') }}">Plan du site</a></li>
             <li><a href="{{ path('app_front_information') }}">Informations (Tout savoir sur les punaises de lit)</a></li>
             <li><a href="{{ path('app_front_signalement_type_list') }}">Signaler un problème de punaises de lit</a></li>
             <li><a href="{{ path('app_front_signalement_logement') }}">Déposer un signalement pour mon logement</a></li>
@@ -231,7 +231,6 @@
             <li><a href="{{ path('app_historique_list') }}">Signalements usagers & Historique (espace pro))</a></li>
             <li><a href="{{ path('app_signalement_create') }}">Ajouter un signalement (espace pro)</a></li>
             <li>Gérer le signalement #2024-1 (signalement passé - espace pro)</li>
-            <li><a href="{{ path('app_cartographie') }}">Cartographie des signalements (admin)</a></li>
         </ul>
         <h2>Amélioration et contact</h2>
         <p>

--- a/templates/front/accessibilite.html.twig
+++ b/templates/front/accessibilite.html.twig
@@ -23,7 +23,7 @@
         <p>Le site est partiellement conforme avec le référentiel général d’amélioration de l’accessibilité (<abbr
                     title="Référentiel général d’amélioration de l’accessibilité">RGAA</abbr>), version 4.1.</p>
         <h2>Résultats des tests</h2>
-        <p>L’audit de conformité réalisé <span>en auto-évaluation</span> révèle que <span>78</span>% des critères
+        <p>L’audit de conformité réalisé <span>par évaluation externe</span> révèle que <span>78</span>% des critères
             sont respectés.</p>
         <p>Dans le détail :</p>
         <ul>

--- a/templates/front/accessibilite.html.twig
+++ b/templates/front/accessibilite.html.twig
@@ -7,42 +7,244 @@
     <section class="fr-container fr-my-3w fr-my-md-5w">
         <h1>Déclaration d’accessibilité</h1>
 
-        <p>Établie le <span>14 novembre 2023</span>.</p>
+        <p>Établie le <span>25 avril 2024</span>.</p>
 
         <p>
             Le <span>Ministère de la Transition Ecologique et de la Cohésion des Territoires</span>
-            s’engage à rendre son service accessible, conformément à l’article 47 de la loi n° 2005-102 du 11 février 2005.
+            s’engage à rendre son service accessible, conformément à l’article 47 de la loi n° 2005-102 du 11 février
+            2005.
         </p>
-
         <p>
             Cette déclaration d’accessibilité s’applique à <strong>Stop-Punaises</strong>
             (https://stop-punaises.beta.gouv.fr).
         </p>
 
         <h2>État de conformité</h2>
-        <p>
-            <strong>Stop-Punaises</strong> est  <strong>non conforme</strong> avec le 
-            <abbr title="Référentiel général d’amélioration de l’accessibilité">RGAA</abbr>.
-            <br>
-            Le site n’a encore pas été audité.
-        </p>
-
+        <p>Le site est partiellement conforme avec le référentiel général d’amélioration de l’accessibilité (<abbr
+                    title="Référentiel général d’amélioration de l’accessibilité">RGAA</abbr>), version 4.1.</p>
+        <h2>Résultats des tests</h2>
+        <p>L’audit de conformité réalisé <span>en auto-évaluation</span> révèle que <span>78</span>% des critères
+            sont respectés.</p>
+        <p>Dans le détail :</p>
+        <ul>
+            <li>Nombre de critères conformes : 62</li>
+            <li>Nombre de critères non conformes : 17</li>
+        </ul>
         <h2>Contenus non accessibles</h2>
-        <p>
-            Le site n’a encore pas été audité.
-        </p>
-
+        <p>Les contenus listés ci-dessous ne sont pas accessibles pour les raisons suivantes.</p>
+        <h3>Non conformité</h3>
+        <p>Malgré nos efforts, certains contenus sont inaccessibles. Vous trouverez ci-dessous les limitations connues&nbsp;:</p>
+        <div class="fr-table">
+            <table>
+                <caption>Liste des 17 critères non conformes</caption>
+                <thead>
+                <tr>
+                    <th scope="col">Critère</th>
+                    <th scope="col">Intitulé du critère</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                    <td>1.3</td>
+                    <td>Pour chaque image porteuse d’information ayant une alternative textuelle, cette alternative
+                        est-elle pertinente (hors cas particuliers) ?
+                    </td>
+                </tr>
+                <tr>
+                    <td>4.2</td>
+                    <td>Pour chaque média temporel pré-enregistré ayant une transcription textuelle ou une
+                        audiodescription synchronisée, celles-ci sont-elles pertinentes (hors cas particuliers) ?
+                    </td>
+                </tr>
+                <tr>
+                    <td>4.3</td>
+                    <td>Chaque média temporel synchronisé pré-enregistré a-t-il, si nécessaire, des sous-titres
+                        synchronisés (hors cas particuliers) ?
+                    </td>
+                </tr>
+                <tr>
+                    <td>4.7</td>
+                    <td>Chaque média temporel est-il clairement identifiable (hors cas particuliers) ?</td>
+                </tr>
+                <tr>
+                    <td>5.5</td>
+                    <td>Pour chaque tableau de données ayant un titre , celui-ci est-il pertinent ?</td>
+                </tr>
+                <tr>
+                    <td>6.1</td>
+                    <td>Chaque lien est-il explicite (hors cas particuliers) ?</td>
+                </tr>
+                <tr>
+                    <td>7.1</td>
+                    <td>Chaque script est-il, si nécessaire, compatible avec les technologies d’assistance ?</td>
+                </tr>
+                <tr>
+                    <td>7.3</td>
+                    <td>Chaque script est-il contrôlable par le clavier et par tout dispositif de pointage (hors cas
+                        particuliers) ?
+                    </td>
+                </tr>
+                <tr>
+                    <td>7.5</td>
+                    <td>Dans chaque page web, les messages de statut sont-ils correctement restitués par les
+                        technologies d’assistance ?
+                    </td>
+                </tr>
+                <tr>
+                    <td>9.1</td>
+                    <td>Dans chaque page web, l’information est-elle structurée par l’utilisation appropriée de titres
+                        ?
+                    </td>
+                </tr>
+                <tr>
+                    <td>10.2</td>
+                    <td>Dans chaque page web, le contenu visible porteur d’information reste-t-il présent lorsque les
+                        feuilles de styles sont désactivées ?
+                    </td>
+                </tr>
+                <tr>
+                    <td>10.7</td>
+                    <td>Dans chaque page web, pour chaque élément recevant le focus, la prise de focus est-elle visible
+                        ?
+                    </td>
+                </tr>
+                <tr>
+                    <td>10.11</td>
+                    <td>Pour chaque page web, les contenus peuvent-ils être présentés sans perte d’information ou de
+                        fonctionnalité et sans avoir recours soit à un défilement vertical pour une fenêtre ayant une
+                        hauteur de 256&nbsp;px, soit à un défilement horizontal pour une fenêtre ayant une largeur de
+                        320&nbsp;px (hors cas particuliers) ?
+                    </td>
+                </tr>
+                <tr>
+                    <td>11.2</td>
+                    <td>Chaque étiquette associée à un champ de formulaire est-elle pertinente (hors cas particuliers)
+                        ?
+                    </td>
+                </tr>
+                <tr>
+                    <td>11.10</td>
+                    <td>Dans chaque formulaire, le contrôle de saisie est-il utilisé de manière pertinente (hors cas
+                        particuliers) ?
+                    </td>
+                </tr>
+                <tr>
+                    <td>11.11</td>
+                    <td>Dans chaque formulaire, le contrôle de saisie est-il accompagné, si nécessaire, de suggestions
+                        facilitant la correction des erreurs de saisie ?
+                    </td>
+                </tr>
+                <tr>
+                    <td>13.3</td>
+                    <td>Dans chaque page web, chaque document bureautique en téléchargement possède-t-il, si nécessaire,
+                        une version accessible (hors cas particuliers) ?
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+        <h2>Établissement de cette déclaration d‘accessibilité</h2>
+        <p>Cette déclaration a été établie le 25/04/2024.</p>
+        <h2>Technologies utilisées pour la réalisation de l‘audit</h2>
+        <ul>
+            <li>HTML5</li>
+            <li>CSS</li>
+            <li>Javascript</li>
+            <li>Webpack</li>
+        </ul>
+        <h3>Environnement de test</h3>
+        <p>La restitution des contenus avec les outils d’assistance a été testée conformément aux environnements de test
+            suivants :</p>
+        <h4>Ordinateur</h4>
+        <div class="fr-table fr-table--bordered fr-table--no-caption fr-mb-3w">
+            <table>
+                <caption> Environnements de test sur ordinateur</caption>
+                <thead>
+                <tr>
+                    <th scope="col">Technologie d’assistance</th>
+                    <th scope="col">Navigateur</th>
+                    <th scope="col">Système d’exploitation</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                    <td>VoiceOver 10</td>
+                    <td>Safari 16.6.1</td>
+                    <td>MacOS 11.7.10</td>
+                </tr>
+                <tr>
+                    <td>NVDA</td>
+                    <td>Firefox</td>
+                    <td>Windows</td>
+                </tr>
+                <tr>
+                    <td>JAWS</td>
+                    <td>Firefox</td>
+                    <td>Windows</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+        <h4>Mobile</h4>
+        <div class="fr-table fr-table--bordered fr-table--no-caption fr-mb-3w">
+            <table>
+                <caption> Environnements de test sur mobile</caption>
+                <thead>
+                <tr>
+                    <th scope="col">Technologie d’assistance</th>
+                    <th scope="col">Navigateur</th>
+                    <th scope="col">Système d’exploitation</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                    <td>VoiceOver</td>
+                    <td>Safari</td>
+                    <td>iOS</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+        <h3>Outils pour évaluer l‘accessibilité</h3>
+        <ul>
+            <li>Web Developer Toolbar</li>
+            <li>Colour Contrast Analyser</li>
+            <li>HeadingsMap</li>
+            <li>Validateur HTML du W3C</li>
+            <li>Assistant RGAA</li>
+            <li>Inspecteur de composants</li>
+            <li>WAVE</li>
+        </ul>
+        <h3>Pages du site ayant fait l‘objet de la vérification de conformité :</h3>
+        <ul>
+            <li><a href="{{ path('home') }}">Accueil</a></li>
+            <li><a href="{{ path('app_front_contact') }}">Contact</a></li>
+            <li><a href="{{ path('app_front_mentions_legales') }}">Mentions légales</a></li>
+            <li><a href="{{ path('app_front_accessibilite') }}">Déclaration d'accessibilité</a></li>
+            <li><a href="{{ path('app_front_plan_du_site') }}">Plan du site automatisé en XML</a></li>
+            <li><a href="{{ path('app_front_information') }}">Informations (Tout savoir sur les punaises de lit)</a></li>
+            <li><a href="{{ path('app_front_signalement_type_list') }}">Signaler un problème de punaises de lit</a></li>
+            <li><a href="{{ path('app_front_signalement_logement') }}">Déposer un signalement pour mon logement</a></li>
+            <li><a href="{{ path('app_login') }}">Connexion à l'espace pro</a></li>
+            <li>Page de suivi de signalement (via lien de suivi en retour de mail)</li>
+            <li><a href="{{ path('app_dashboard_home') }}">Tableau de bord (espace pro)</a></li>
+            <li><a href="{{ path('app_historique_list') }}">Signalements usagers & Historique (espace pro))</a></li>
+            <li><a href="{{ path('app_signalement_create') }}">Ajouter un signalement (espace pro)</a></li>
+            <li>Gérer le signalement #2024-1 (signalement passé - espace pro)</li>
+            <li><a href="{{ path('app_cartographie') }}">Cartographie des signalements (admin)</a></li>
+        </ul>
         <h2>Amélioration et contact</h2>
-
         <p>
-            Si vous n’arrivez pas à accéder à un contenu ou à un service, vous pouvez contacter le responsable de 
+            Si vous n’arrivez pas à accéder à un contenu ou à un service, vous pouvez contacter le responsable de
             Stop-Punaises pour être orienté vers une alternative accessible ou obtenir le contenu sous une autre forme.
         </p>
 
         <ul class="basic-information feedback h-card">
             <li>Téléphone&nbsp;: <span>+33 1 40 81 21 22</span></li>
-            <li>E-mail&nbsp;: <a href="mailto:contact@stop-punaises.beta.gouv.fr">contact@stop-punaises.beta.gouv.fr</a></li>
-            <li>Formulaire de contact&nbsp;: <a href="{{ path('app_front_contact') }}">https://stop-punaises.beta.gouv.fr/contact</a></li>
+            <li>E-mail&nbsp;: <a href="mailto:contact@stop-punaises.beta.gouv.fr">contact@stop-punaises.beta.gouv.fr</a>
+            </li>
+            <li>Formulaire de contact&nbsp;: <a href="{{ path('app_front_contact') }}">https://stop-punaises.beta.gouv.fr/contact</a>
+            </li>
             <li>Adresse&nbsp;: <span>DGALN, Tour Sequoia, La Défense</span></li>
         </ul>
 
@@ -54,7 +256,7 @@
 
         <p>
             Cette procédure est à utiliser dans le cas suivant&nbsp;: vous avez signalé au responsable du site internet
-            un défaut d’accessibilité qui vous empêche d’accéder à un contenu ou à un des services du portail 
+            un défaut d’accessibilité qui vous empêche d’accéder à un contenu ou à un des services du portail
             et vous n’avez pas obtenu de réponse satisfaisante.
         </p>
 
@@ -62,9 +264,9 @@
 
         <ul>
             <li>Écrire un message au <a href="https://formulaire.defenseurdesdroits.fr/" target="_blank" rel="noopener"
-                title="Défenseur des droits - nouvelle fenêtre">Défenseur des droits</a></li>
+                                        title="Défenseur des droits - nouvelle fenêtre">Défenseur des droits</a></li>
             <li>Contacter <a href="https://www.defenseurdesdroits.fr/saisir/delegues" target="_blank" rel="noopener"
-                title="Délégué régional du Défenseur des droits - nouvelle fenêtre"
+                             title="Délégué régional du Défenseur des droits - nouvelle fenêtre"
                 >le délégué du Défenseur des droits dans votre région</a></li>
             <li>
                 Envoyer un courrier par la poste (gratuit, ne pas mettre de timbre)&nbsp;:<br>
@@ -75,12 +277,12 @@
         </ul>
 
         <hr>
-        
+
         <p>
-            Cette déclaration d’accessibilité a été créé le <span>14 novembre 2023</span> grâce au 
+            Cette déclaration d’accessibilité a été créé le <span>14 novembre 2023</span> grâce au
             <a href="https://betagouv.github.io/a11y-generateur-declaration/#create" target="_blank" rel="noopener"
-                title="Générateur de Déclaration d’Accessibilité de BetaGouv - nouvelle fenêtre"
-                >Générateur de Déclaration d’Accessibilité de BetaGouv</a>.
+               title="Générateur de Déclaration d’Accessibilité de BetaGouv - nouvelle fenêtre"
+            >Générateur de Déclaration d’Accessibilité de BetaGouv</a>.
         </p>
     </section>
 

--- a/templates/sitemap/index.html.twig
+++ b/templates/sitemap/index.html.twig
@@ -125,15 +125,6 @@
                         </li>
                     </ul>
                 </section>
-                <section class="fr-py-6v">
-                    <h2>Administration</h2>
-                    <ul>
-                        <li>
-                            <span class="fr-icon-account-line" title="Page réservée aux utilisateurs connectés" aria-hidden="true"></span>
-                            <a href="{{ path('app_cartographie') }}">Cartographie des signalements (connexion nécessaire)</a>
-                        </li>
-                    </ul>
-                </section>
             </div>
         </div>
     </div>

--- a/templates/sitemap/index.html.twig
+++ b/templates/sitemap/index.html.twig
@@ -125,6 +125,15 @@
                         </li>
                     </ul>
                 </section>
+                <section class="fr-py-6v">
+                    <h2>Administration</h2>
+                    <ul>
+                        <li>
+                            <span class="fr-icon-account-line" title="Page réservée aux utilisateurs connectés" aria-hidden="true"></span>
+                            <a href="{{ path('app_cartographie') }}">Cartographie des signalements (connexion nécessaire)</a>
+                        </li>
+                    </ul>
+                </section>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Ticket

#494    

## Description
Sur la base des éléments de https://ara.numerique.gouv.fr/rapports/sCeFoDWFkfkhCJxlnM7Jw/declaration-daccessibilite, il est nécéssaire de compléter la déclaration d'accessibilité. 

Regard sur ce qui a été fait sur dossier facile qui est partiellement conforme également 
* https://www.dossierfacile.logement.gouv.fr/accessibilite


## Changements apportés
* Ajout des sections manquantes dans la déclaration d'accessibilité

## Pré-requis

## Tests
- [ ] La page s'affiche correctement avec les bonnes mentions
- [ ] La code HTML de la page est valide W3C
- [ ] La hiérarchie des titres est respecté
- [ ] Le pied de page a bien la mention "partiellement conforme"
- [ ] Vérifier qu'il n'y'ai pas de régression d’accessibilité sur la page
