### PR TITLE
[INFRA] Migration de MySQL 5.7 vers 8.0

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -17,7 +17,7 @@ APP_ENV=dev
 APP_SECRET=
 APP_URL=http://localhost:8090
 MAILER_DSN=smtp://stopunaises_mailer:1025
-DATABASE_URL="mysql://stopunaises:stopunaises@stopunaises_mysql:3308/stopunaises_db?serverVersion=5.7&charset=utf8"
+DATABASE_URL="mysql://stopunaises:stopunaises@stopunaises_mysql:3308/stopunaises_db?serverVersion=8.0&charset=utf8"
 NOTIFICATIONS_EMAIL=notifications@stop-punaises.beta.gouv.fr
 CONTACT_EMAIL=contact@stop-punaises.beta.gouv.fr
 INCONNU_EMAIL=inconnu@stop-punaises.beta.gouv.fr

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
     services:
       # https://docs.docker.com/samples/library/mysql/
       mysql:
-        image: mysql:5.7
+        image: mysql:8.0
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: false
           MYSQL_ROOT_PASSWORD: stopunaises

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Service|Version
 -------|-------
 Nginx | 1.20.2
 PHP | 8.1.x (latest)
-MySQL | 5.7.38
+MySQL | 8.0.31
 Redis | 7.0.x (latest)
 
 ### URL(s)

--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -6,7 +6,7 @@ doctrine:
                 url: '%env(resolve:DATABASE_URL)%'
                 # IMPORTANT: You MUST configure your server version,
                 # either here or in the DATABASE_URL env var (see .env file)
-                server_version: '5.7.38'
+                server_version: '8.0.31'
     orm:
         report_fields_where_declared: true
         enable_lazy_ghost_objects: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.8"
 
 services:
   stopunaises_mysql:
-    image: 'mysql:5.7.38'
+    image: 'mysql:8.0.31'
     container_name: stopunaises_mysql
     restart: always
     environment:


### PR DESCRIPTION
## Ticket

#742   

## Description
Scalingo nous propose de passer rapidement à MySQL 8, puisqu'ils vont arrêter la maintenance de MySQL 5.7 et migreront à partir du 1er juillet.
Par ailleurs, on pourra en profiter pour utiliser des fonctionnalités plus avancées à présent.

Afin de passer en MySQL 8, il y avait 2 vérifications à faire sur les tables (cf ici : https://doc.scalingo.com/databases/mysql/mysql-8-prerequisites) :
- Toutes les tables utilisent le moteur InnoDB
- Toutes les tables ont des clés primaires
C'est bien le cas.

J'ai fait pas mal de tests, le passage à la version 8 semble indolore.
Lors du passage sur develop (lors du merge), il faudra 
- faire une sauvegarde de la base
- passer MySQL en version 8 via le dashboard Scalingo sur l'app de staging
- faire des tests sur staging

## Changements apportés
* Modification de la version de MySQL dans tous les fichiers de conf, environnements et doc.

## Pré-requis
`make build`

**Attention :** quand vous revenez sur une autre branche, il faut faire
```
docker volume rm stop-punaises_dbdata
make build
```

## Tests
- [ ] Faire des tests de navigation sur différentes pages sensibles (listes de signalements, actions utilisateurs, carto...)
