### PR TITLE
[Sécurité] Ajout de controles sur la route "app_signalement_estimation_choice

### DIFF
--- a/src/Controller/Front/SuiviUsagerViewController.php
+++ b/src/Controller/Front/SuiviUsagerViewController.php
@@ -228,13 +228,13 @@ class SuiviUsagerViewController extends AbstractController
         EventDispatcherInterface $eventDispatcher,
     ): Response {
         if (!$this->isCsrfTokenValid('signalement_estimation_choice', $request->get('_csrf_token'))) {
-            return $this->redirectToRoute('app_suivi_usager_view', ['uuidPublic' => $intervention->getSignalement()->getUuidPublic()]);
+            return $this->redirectToRoute('app_suivi_usager_view', ['uuidPublic' => $signalement->getUuidPublic()]);
         }
         if ($intervention->getSignalement()->getId() !== $signalement->getId()) {
-            return $this->redirectToRoute('app_suivi_usager_view', ['uuidPublic' => $intervention->getSignalement()->getUuidPublic()]);
+            return $this->redirectToRoute('app_suivi_usager_view', ['uuidPublic' => $signalement->getUuidPublic()]);
         }
         if (!$intervention->getEstimationSentAt() || $intervention->getChoiceByUsagerAt()) {
-            return $this->redirectToRoute('app_suivi_usager_view', ['uuidPublic' => $intervention->getSignalement()->getUuidPublic()]);
+            return $this->redirectToRoute('app_suivi_usager_view', ['uuidPublic' => $signalement->getUuidPublic()]);
         }
 
         if ('accept' == $request->get('action')) {
@@ -282,7 +282,7 @@ class SuiviUsagerViewController extends AbstractController
             $mailerProvider->sendSignalementEstimationRefused($intervention->getEntreprise()->getUser()->getEmail(), $intervention->getSignalement());
         }
 
-        return $this->redirectToRoute('app_suivi_usager_view', ['uuidPublic' => $intervention->getSignalement()->getUuidPublic()]);
+        return $this->redirectToRoute('app_suivi_usager_view', ['uuidPublic' => $signalement->getUuidPublic()]);
     }
 
     #[Route(

--- a/templates/front_suivi_usager/modal-choice-estimation.html.twig
+++ b/templates/front_suivi_usager/modal-choice-estimation.html.twig
@@ -44,7 +44,7 @@
                         </div>
                         {% endif %}
 
-                        <form action="{{ path('app_signalement_estimation_choice', {'id': intervention.id }) }}" method="POST" class="align-center fr-mt-3v">
+                        <form action="{{ path('app_signalement_estimation_choice', {'uuid': intervention.signalement.uuid, 'id': intervention.id }) }}" method="POST" class="align-center fr-mt-3v">
                             <input type="hidden" name="_csrf_token" value="{{ csrf_token('signalement_estimation_choice') }}">
                             <button type="submit" class="fr-btn fr-btn--sm fr-btn--icon-left fr-icon-check-line color-check fr-mb-3v" name="action" value="accept">Accepter</button>
                             <button type="submit" class="fr-btn fr-btn--sm fr-btn--icon-left fr-icon-close-line color-close" name="action" value="refuse">Refuser</button>


### PR DESCRIPTION
## Ticket

#747

## Description
Sécurisation de la route `app_signalement_estimation_choice` afin qu'une réponse acceptation/refus ne puisse être envoyé qu'une seule fois et pour un signalement dont le lien m'as été transmis

## Tests
- [ ] Accepter / Refuser une proposition d'entreprise et vérifier que cela fonctionne correctement
