### PR TITLE
[Import CSV] Ajout du type de signalement

### DIFF
--- a/src/Service/Import/Signalement/SignalementImportLoader.php
+++ b/src/Service/Import/Signalement/SignalementImportLoader.php
@@ -4,6 +4,7 @@ namespace App\Service\Import\Signalement;
 
 use App\Entity\Entreprise;
 use App\Entity\Enum\Declarant;
+use App\Entity\Enum\SignalementType;
 use App\Manager\SignalementManager;
 use App\Repository\SignalementRepository;
 use App\Repository\TerritoireRepository;
@@ -82,6 +83,7 @@ class SignalementImportLoader
                 $zipCode = $this->zipCodeService->getByCodePostal($signalement->getCodePostal());
                 $territoire = $this->territoireRepository->findOneBy(['zip' => $zipCode]);
                 $signalement->setTerritoire($territoire);
+                $signalement->setType(SignalementType::TYPE_LOGEMENT);
 
                 $this->signalementManager->save($signalement);
 


### PR DESCRIPTION
## Ticket

#754    

## Description
Lorsqu'on a ajouté le principe de type de signalement, on ne l'a pas répercuté dans la procédure d'import CSV.

## Tests
- [ ] Faire un import csv et vérifier le fonctionnement
  - Exemple : `make console app="import-signalement 655cb685dbe6a"`
