### PR TITLE
[Import] Possibilité d'importer des signalements pour plusieurs entreprises

### DIFF
--- a/scripts/upload-s3.sh
+++ b/scripts/upload-s3.sh
@@ -41,6 +41,11 @@ else
       aws s3 cp data/signalement/signalements_${uuid}.csv s3://${BUCKET_URL}/csv/ ${debug}
       aws s3 ls s3://${BUCKET_URL}/csv/signalements_${uuid}.csv
       ;;
+    "signalements-multi")
+      echo "Upload signalements.csv to cloud..."
+      aws s3 cp data/signalement/signalements.csv s3://${BUCKET_URL}/csv/ ${debug}
+      aws s3 ls s3://${BUCKET_URL}/csv/signalements.csv
+      ;;
     "entreprisespubliques")
       echo "Upload entreprises.csv to cloud..."
       aws s3 cp data/entreprises.csv s3://${BUCKET_URL}/csv/ ${debug}

--- a/src/Service/Import/Signalement/SignalementImportLoader.php
+++ b/src/Service/Import/Signalement/SignalementImportLoader.php
@@ -68,8 +68,8 @@ class SignalementImportLoader
                 if (!empty($commandEntreprise)) {
                     $dataMapped['entreprise'] = $commandEntreprise;
                 } else {
-                    if (empty($currentEntreprise) || $currentEntreprise->getUuid() !== $dataMapped['entreprise']) {
-                        $currentEntreprise = $this->entityManager->getRepository(Entreprise::class)->findOneBy(['uuid' => $dataMapped['entreprise']]);
+                    if (empty($currentEntreprise) || $currentEntreprise->getUuid() !== $dataMapped['entrepriseUUID']) {
+                        $currentEntreprise = $this->entityManager->getRepository(Entreprise::class)->findOneBy(['uuid' => $dataMapped['entrepriseUUID']]);
                     }
                     if (!empty($currentEntreprise)) {
                         $dataMapped['entreprise'] = $currentEntreprise;

--- a/src/Service/Import/Signalement/SignalementImportMapper.php
+++ b/src/Service/Import/Signalement/SignalementImportMapper.php
@@ -31,6 +31,7 @@ class SignalementImportMapper
             'Type de traitement' => 'typeTraitement',
             'Nom biocide (si pertinent)' => 'nomBiocide',
             'Prix facturé' => 'prixFactureHT',
+            'Entreprise' => 'entrepriseUUID',
         ];
     }
 
@@ -59,7 +60,6 @@ class SignalementImportMapper
                         $fieldValue = $this->transformToNiveauInfestation($fieldValue);
                         break;
                     case 'construitAvant1948':
-                    case 'faitVisitePostTraitement':
                     case 'faitVisitePostTraitement':
                         $fieldValue = ('Oui' === $fieldValue) ? 1 : 0;
                         break;


### PR DESCRIPTION
## Ticket

#756   

## Description
On ne pouvait importer les signalements qu'entreprise par entreprise. Mais on a plus de 100 fichiers à importer d'un coup.
On rend facultatif l'option de l'uuid de l'entreprise pour ajouter une colonne dans le fichier.

## Changements apportés
* Il existe à présent une colonne possible dans les fichiers d'import dont le nom est `Entreprise` et qui prend l'uuid d'une entreprise.
* Modification de la commande d'upload
  * `./scripts/upload-s3.sh signalement [uuid_entreprise]` existe toujours, mais on peut aussi appeler `./scripts/upload-s3.sh signalements-multi`
* Modification de la commande d'import
  * `make console app="import-signalement [uuid_entreprise]"` existe toujours, mais on peut aussi appeler `make console app="import-signalement"`

## Infos tests
J'ai uploadé un fichier qui fonctionne avec les fixtures et qui importe pour les uuid des 4 premières entreprises.

## Tests
- [ ] `make console app="import-signalement"`
- [ ] Vérifier que les signalements se sont importés correctement
