### PR TITLE
[Formulaire - Upload] Ajout de sécurité pour bloquer les fichiers qui ne sont pas des images

### DIFF
--- a/templates/signalement_view/tab-intervention.html.twig
+++ b/templates/signalement_view/tab-intervention.html.twig
@@ -58,6 +58,7 @@
     <div class="fr-mt-2w">
         <h3>Photos de la situation</h3>
         <form action="{{ path('app_add_photos', {'uuid': signalement.uuid }) }}" method="POST" enctype="multipart/form-data" class="fr-my-3w file-auto-submit">
+            <input type="hidden" name="_csrf_token" value="{{ csrf_token('signalement_add_file') }}">
             <div class="fr-upload-group">
                 <label class="fr-label" for="file-upload">Ajouter des photos
                     <span class="fr-hint-text">Taille maximale : 10 Mo. Formats supportés : jpg, png. Plusieurs fichiers possibles.</span>


### PR DESCRIPTION
## Ticket

#783   

## Description
Il n'y avait pas de contrôle côté serveur pour le type de fichier envoyé par l'utilisateur.

## Changements apportés
* Ajout de contrôles côté back end

## Tests
- [ ] Intercépter un envoi de formulaire front avec une image lambda, puis modifier l'appel (`Edit and Resend` sur Firefox) en mettant un code javascript à la place du fichier
- [ ] Vérifier côté back que le signalement a été ajouté, mais sans le fichier
- [ ] Faire le même test d'ajout d'image avec un signalement historique, dans le bo
