### PR TITLE
[Technique] Améliorer la CSP

### DIFF
--- a/.env
+++ b/.env
@@ -24,7 +24,7 @@ INCONNU_EMAIL=inconnu@stop-punaises.gouv.fr
 MESSENGER_TRANSPORT_DSN=doctrine://default
 REDIS_URL=redis://stopunaises_redis:6379
 FEATURE_THREE_FORMS_ENABLE=1
-SECURITY_CSP_HEADER_VALUE="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.matomo.cloud https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: blob: https://*.tile.openstreetmap.org https://cdn.jsdelivr.net; connect-src 'self' https://api-adresse.data.gouv.fr https://cdn.matomo.cloud https://histologe.matomo.cloud; font-src 'self'; frame-src 'none'; object-src 'none';"
+CSP_ENABLE=1
 MATOMO_ENABLE=0
 MATOMO_SITE_ID=
 SESSION_MAXLIFETIME=151200 # 151200 secondes = 42 heures

--- a/.env.sample
+++ b/.env.sample
@@ -24,7 +24,7 @@ INCONNU_EMAIL=inconnu@stop-punaises.gouv.fr
 MESSENGER_TRANSPORT_DSN=doctrine://default
 REDIS_URL=redis://stopunaises_redis:6379
 FEATURE_THREE_FORMS_ENABLE=1
-SECURITY_CSP_HEADER_VALUE="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.matomo.cloud https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: blob: https://*.tile.openstreetmap.org https://cdn.jsdelivr.net; connect-src 'self' https://api-adresse.data.gouv.fr https://cdn.matomo.cloud https://histologe.matomo.cloud; font-src 'self'; frame-src 'none'; object-src 'none';"
+CSP_ENABLE=1
 MATOMO_ENABLE=0
 MATOMO_SITE_ID=
 SESSION_MAXLIFETIME=151200 # 151200 secondes = 42 heures

--- a/assets/app.js
+++ b/assets/app.js
@@ -30,3 +30,4 @@ import './controllers/list_employes';
 import './controllers/list_entreprises_publiques';
 
 import './controllers/weekly_slider';
+import './controllers/form_helper';

--- a/assets/controllers/form_helper.js
+++ b/assets/controllers/form_helper.js
@@ -1,0 +1,24 @@
+document.addEventListener('DOMContentLoaded', function () {
+    const inputs = document.querySelectorAll('input[data-error]');
+
+    inputs.forEach(input => {
+        const errorText = input.getAttribute('data-error');
+        const errorId = input.getAttribute('data-error-id');
+
+        input.addEventListener('invalid', function () {
+            this.setCustomValidity(errorText);
+            const errorElement = document.getElementById(errorId);
+            if (errorElement) {
+                errorElement.classList.remove('fr-hidden');
+            }
+        });
+
+        input.addEventListener('input', function () {
+            this.setCustomValidity('');
+            const errorElement = document.getElementById(errorId);
+            if (errorElement) {
+                errorElement.classList.add('fr-hidden');
+            }
+        });
+    });
+});

--- a/assets/controllers/form_signalement_erp_transport.js
+++ b/assets/controllers/form_signalement_erp_transport.js
@@ -110,7 +110,7 @@ function handleFileUpload() {
             } else {
                 let filename = file.name;
                 let imgSrc = URL.createObjectURL(file);
-                let strAppend = '<div class="fr-col-6 fr-col-md-3" style="text-align: center;">';
+                let strAppend = '<div class="fr-col-6 fr-col-md-3 align-center">';
                 strAppend += '<img src="' + imgSrc + '" width="100" height="100">';
                 strAppend += '<br><button type="button" data-filename="' + filename  +'" class="fr-link fr-icon-close-circle-line fr-link--icon-left link--error file-uploaded"> Supprimer </button>';
                 strAppend += '</div>';

--- a/assets/controllers/form_signalement_front.js
+++ b/assets/controllers/form_signalement_front.js
@@ -479,7 +479,7 @@ class PunaisesFrontSignalementController {
           inputDiv.attr('aria-describedby', 'file-upload-error');
         } else {
             let imgSrc = URL.createObjectURL(file);
-            let strAppend = '<div class="fr-col-6 fr-col-md-3" style="text-align: center;">';
+            let strAppend = '<div class="fr-col-6 fr-col-md-3 align-center">';
             strAppend += '<img src="' + imgSrc + '" width="100" height="100">';
             strAppend += '</div>';
             $('.fr-front-signalement-photos').append(strAppend);

--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -322,6 +322,10 @@ span.statut-infestation {
     font-size: 1.2rem;
 }
 
+.overflow-hidden {
+    overflow: hidden;
+}
+
 .message-list {
 
     &.message-scroll {

--- a/config/app/csp.yaml
+++ b/config/app/csp.yaml
@@ -1,9 +1,9 @@
 parameters:
   csp_parameters:
     default-src: "'none'"
-    script-src: "'self' 'unsafe-inline' https://cdn.matomo.cloud/histologe.matomo.cloud/matomo.js https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/ https://cdn.jsdelivr.net/npm/leaflet.heat@0.2.0/dist/"
+    script-src: "'self' 'unsafe-inline' 'unsafe-eval' https://cdn.matomo.cloud/histologe.matomo.cloud/matomo.js https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/ https://cdn.jsdelivr.net/npm/leaflet.heat@0.2.0/dist/"
     style-src: "'self' https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/"
-    style-src-attr: "'self'"
+    style-src-attr: "'self' 'unsafe-inline'"
     img-src: "'self' data: blob: https://*.tile.openstreetmap.org https://cdn.jsdelivr.net"
     connect-src: "'self' https://api-adresse.data.gouv.fr https://cdn.matomo.cloud https://histologe.matomo.cloud https://sentry.incubateur.net"
     font-src: "'self'"

--- a/config/app/csp.yaml
+++ b/config/app/csp.yaml
@@ -1,0 +1,15 @@
+parameters:
+  csp_parameters:
+    default-src: "'none'"
+    script-src: "'self' 'unsafe-inline' https://cdn.matomo.cloud/histologe.matomo.cloud/matomo.js https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/ https://cdn.jsdelivr.net/npm/leaflet.heat@0.2.0/dist/"
+    style-src: "'self' https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/"
+    style-src-attr: "'self'"
+    img-src: "'self' data: blob: https://*.tile.openstreetmap.org https://cdn.jsdelivr.net"
+    connect-src: "'self' https://api-adresse.data.gouv.fr https://cdn.matomo.cloud https://histologe.matomo.cloud https://sentry.incubateur.net"
+    font-src: "'self'"
+    frame-src: "'none'"
+    object-src: "'none'"
+    base-uri: "'self'"
+    form-action: "'self'"
+    frame-ancestors: "'none'"
+    media-src: "'self'"

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -3,6 +3,8 @@
 
 # Put parameters here that don't need to change on each machine where the app is deployed
 # https://symfony.com/doc/current/best_practices.html#use-parameters-for-application-configuration
+imports:
+    - { resource: 'app/csp.yaml'}
 parameters:
     .container.dumper.inline_factories: true
     from: '%env(resolve:NOTIFICATIONS_EMAIL)%'
@@ -19,6 +21,7 @@ parameters:
     admin_email: '%env(resolve:CONTACT_EMAIL)%'
     inconnu_email: '%env(resolve:INCONNU_EMAIL)%'
     feature_three_forms: '%env(bool:FEATURE_THREE_FORMS_ENABLE)%'
+    csp_enable: '%env(bool:CSP_ENABLE)%'
     matomo_enable: '%env(bool:MATOMO_ENABLE)%'
     matomo_site_id: '%env(resolve:MATOMO_SITE_ID)%'
 
@@ -38,7 +41,12 @@ services:
             - '../src/Kernel.php'
 
     # add more service definitions when explicit configuration is needed
-    # please note that last definitions always *replace* previous ones
+    # please note that last definitions always *replace* previous ones    
+
+    App\EventListener\ContentSecurityPolicyListener:
+        tags:
+            - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest }
+            - { name: kernel.event_listener, event: kernel.response, method: onKernelResponse }
 
     App\Service\Mailer\MessageFactory:
         arguments:

--- a/public/index.php
+++ b/public/index.php
@@ -6,8 +6,5 @@ require_once dirname(__DIR__).'/vendor/autoload_runtime.php';
 
 return function (array $context) {
     ini_set('session.gc_maxlifetime', (int) $_ENV['SESSION_MAXLIFETIME']);
-    if (null !== $csp = $_SERVER['SECURITY_CSP_HEADER_VALUE'] ?? null) {
-        header('Content-Security-Policy: '.$csp);
-    }
     return new Kernel($context['APP_ENV'], (bool) $context['APP_DEBUG']);
 };

--- a/src/EventListener/ContentSecurityPolicyListener.php
+++ b/src/EventListener/ContentSecurityPolicyListener.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\EventListener;
+
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+
+class ContentSecurityPolicyListener
+{
+    public function __construct(
+        private ParameterBagInterface $parameterBag,
+    ) {
+    }
+
+    public function onKernelRequest(RequestEvent $event)
+    {
+        $request = $event->getRequest();
+
+        $scriptNonce = bin2hex(random_bytes(16));
+
+        $request->attributes->set('csp_script_nonce', $scriptNonce);
+    }
+
+    public function onKernelResponse(ResponseEvent $event)
+    {
+        $response = $event->getResponse();
+        $request = $event->getRequest();
+
+        $scriptNonce = $request->attributes->get('csp_script_nonce');
+
+        $cspParameters = $this->parameterBag->get('csp_parameters');
+
+        $csp = 'default-src '.$cspParameters['default-src'].'; '.
+                'script-src '.$cspParameters['script-src']." 'nonce-$scriptNonce'; ".
+                'style-src '.$cspParameters['style-src'].'; '.
+                'style-src-attr '.$cspParameters['style-src-attr'].'; '.
+                'img-src '.$cspParameters['img-src'].'; '.
+                'connect-src '.$cspParameters['connect-src'].'; '.
+                'font-src '.$cspParameters['font-src'].'; '.
+                'frame-src '.$cspParameters['frame-src'].'; '.
+                'object-src '.$cspParameters['object-src'].'; '.
+                'base-uri '.$cspParameters['base-uri'].'; '.
+                'form-action '.$cspParameters['form-action'].'; '.
+                'frame-ancestors '.$cspParameters['frame-ancestors'].'; '.
+                'media-src '.$cspParameters['media-src'];
+
+        if ($this->parameterBag->get('csp_enable')) {
+            $response->headers->set('Content-Security-Policy', $csp);
+        }
+    }
+}

--- a/templates/cartographie/curseur.html.twig
+++ b/templates/cartographie/curseur.html.twig
@@ -3,7 +3,7 @@
     <h1 class="fr-h6">Evolution des foyers d'infestation <br>
     de punaises de lit en France</h1>
         </div>
-    <form action="#" name="bo-carto-filter" id="bo_carto_filter" method="POST" class="fr-background--white" style="overflow: hidden">
+    <form action="#" name="bo-carto-filter" id="bo_carto_filter" method="POST" class="fr-background--white overflow-hidden">
         <div class="fr-pb-5v fr-px-5v">
             <div class="fr-pb-3v">
                 <label>Voir l'évolution hebdomadaire :</label>

--- a/templates/common/analytics.html.twig
+++ b/templates/common/analytics.html.twig
@@ -1,6 +1,6 @@
 {% if matomo is defined and matomo.enable == 1 %}
     <!-- Matomo -->
-    <script>
+    <script nonce="{{ app.request.attributes.get('csp_script_nonce') }}">
         var _paq = window._paq = window._paq || [];
         {% if platform.url starts with 'https' %}
             _paq.push(['setSecureCookie', true]);

--- a/templates/common/components/macro-forms.html.twig
+++ b/templates/common/components/macro-forms.html.twig
@@ -5,11 +5,9 @@
             {{ form_label(form_view) }}
             {{ form_widget(form_view, { 'attr': {
                 'aria-describedby': form_view.vars.id ~ '-error',
-                'oninvalid': "this.setCustomValidity('" ~ error_text ~ "')",
-                'onvalid': "this.setCustomValidity('')",
-                'onchange': "this.setCustomValidity('')",
                 'title': error_text,
-                'data-error': error_text
+                'data-error': error_text,
+                'data-error-id': form_view.vars.id ~ '-error'
             } }) }}
             <div id="{{ form_view.vars.id }}-error" class="fr-error-text fr-mt-1v">
                 {{ form_errors(form_view) }}
@@ -19,11 +17,9 @@
         <div class="fr-input-group">
             {{ form_label(form_view) }}
             {{ form_widget(form_view, { 'attr': {
-                'oninvalid': "this.setCustomValidity('" ~ error_text ~ "')",
-                'onvalid': "this.setCustomValidity('')",
-                'onchange': "this.setCustomValidity('')",
                 'title': error_text,
-                'data-error': error_text
+                'data-error': error_text,
+                'data-error-id': form_view.vars.id ~ '-error'
             } }) }}
             <p id="{{ form_view.vars.id }}-error" class="fr-error-text fr-hidden">
                 {{ error_text}}
@@ -38,11 +34,9 @@
             {{ form_label(form_view) }}
             {{ form_widget(form_view, { 'attr': {
                 'aria-describedby': form_view.vars.id ~ '-error',
-                'oninvalid': "this.setCustomValidity('" ~ error_text ~ "')",
-                'onvalid': "this.setCustomValidity('')",
-                'onchange': "this.setCustomValidity('')",
                 'title': error_text,
-                'data-error': error_text
+                'data-error': error_text,
+                'data-error-id': form_view.vars.id ~ '-error'
             } }) }}
             <div id="{{ form_view.vars.id }}-error" class="fr-error-text fr-mt-1v">
                 {{ form_errors(form_view) }}
@@ -52,11 +46,9 @@
         <div class="fr-select-group">
             {{ form_label(form_view) }}
             {{ form_widget(form_view, { 'attr': {
-                'oninvalid': "this.setCustomValidity('" ~ error_text ~ "')",
-                'onvalid': "this.setCustomValidity('')",
-                'onchange': "this.setCustomValidity('')",
                 'title': error_text,
-                'data-error': error_text
+                'data-error': error_text,
+                'data-error-id': form_view.vars.id ~ '-error'
             } }) }}
             <p id="{{ form_view.vars.id }}-error" class="fr-error-text fr-hidden">
                 {{ error_text}}

--- a/templates/front/signalement-type-list.html.twig
+++ b/templates/front/signalement-type-list.html.twig
@@ -37,9 +37,9 @@
                     <div class="fr-tile__header">
                         <div class="fr-tile__pictogram">
                             <svg aria-hidden="true" class="fr-artwork" viewBox="0 0 80 80" width="80px" height="80px">
-                                <use class="fr-artwork-decorative" href="/build/dsfr/artwork/pictograms/buildings/house.svg#artwork-decorative"></use>
-                                <use class="fr-artwork-minor" href="/build/dsfr/artwork/pictograms/buildings/house.svg#artwork-minor"></use>
-                                <use class="fr-artwork-major" href="/build/dsfr/artwork/pictograms/buildings/house.svg#artwork-major"></use>
+                                <image class="fr-artwork-decorative" href="/build/dsfr/artwork/pictograms/buildings/house.svg#artwork-decorative"></image>
+                                <image class="fr-artwork-minor" href="/build/dsfr/artwork/pictograms/buildings/house.svg#artwork-minor"></image>
+                                <image class="fr-artwork-major" href="/build/dsfr/artwork/pictograms/buildings/house.svg#artwork-major"></image>
                             </svg>
                         </div>
                     </div>
@@ -60,9 +60,9 @@
                     <div class="fr-tile__header">
                         <div class="fr-tile__pictogram">
                             <svg aria-hidden="true" class="fr-artwork" viewBox="0 0 80 80" width="80px" height="80px">
-                                <use class="fr-artwork-decorative" href="/build/dsfr/artwork/pictograms/map/luggage.svg#artwork-decorative"></use>
-                                <use class="fr-artwork-minor" href="/build/dsfr/artwork/pictograms/map/luggage.svg#artwork-minor"></use>
-                                <use class="fr-artwork-major" href="/build/dsfr/artwork/pictograms/map/luggage.svg#artwork-major"></use>
+                                <image class="fr-artwork-decorative" href="/build/dsfr/artwork/pictograms/map/luggage.svg#artwork-decorative"></image>
+                                <image class="fr-artwork-minor" href="/build/dsfr/artwork/pictograms/map/luggage.svg#artwork-minor"></image>
+                                <image class="fr-artwork-major" href="/build/dsfr/artwork/pictograms/map/luggage.svg#artwork-major"></image>
                             </svg>
                         </div>
                     </div>
@@ -82,9 +82,9 @@
                     <div class="fr-tile__header">
                         <div class="fr-tile__pictogram">
                             <svg aria-hidden="true" class="fr-artwork" viewBox="0 0 80 80" width="80px" height="80px">
-                                <use class="fr-artwork-decorative" href="/build/dsfr/artwork/pictograms/buildings/city-hall.svg#artwork-decorative"></use>
-                                <use class="fr-artwork-minor" href="/build/dsfr/artwork/pictograms/buildings/city-hall.svg#artwork-minor"></use>
-                                <use class="fr-artwork-major" href="/build/dsfr/artwork/pictograms/buildings/city-hall.svg#artwork-major"></use>
+                                <image class="fr-artwork-decorative" href="/build/dsfr/artwork/pictograms/buildings/city-hall.svg#artwork-decorative"></image>
+                                <image class="fr-artwork-minor" href="/build/dsfr/artwork/pictograms/buildings/city-hall.svg#artwork-minor"></image>
+                                <image class="fr-artwork-major" href="/build/dsfr/artwork/pictograms/buildings/city-hall.svg#artwork-major"></image>
                             </svg>
                         </div>
                     </div>


### PR DESCRIPTION
## Ticket

#772    


## Description
Tentative d'avoir une CSP plus stricte

## Changements apportés
* Génération d'une CSP via un listener src/EventListener/ContentSecurityPolicyListener.php et ajout de nonces à la volée, les différents paramètres étant définis dans config/app/csp.yaml (et ils sont plus stricts)
* Externalisation de tous les scripts inline pouvant l'être
* Externalisation de tous les styles inline pouvant l'être
* Utilisation de nonces sur tous les styles et les scripts ne pouvant être externalisés (certains pourraient l'être en fait)
* Utilisation de <image à la place de <use dans les svg

## Pré-requis
Supprimer les variables SECURITY_CSP_HEADER_VALUE des fichiers d'environnement
`npm run watch`

## Tests
:warning: Les tests sont à faire console ouverte pour voir les erreurs en plus de l'aspect fonctionnel. 
- [ ] Tester l'aspect et le fonctionnement globaux de la plateforme
- [ ] Tester l'ajout et l'affichage de photos
- [ ] Tester  l'affichage de la carto