### PR TITLE
[Socle sécurité] Anti-malware sur le flux de fichiers

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,1 +1,2 @@
+https://github.com/Scalingo/clamav-buildpack
 https://github.com/Scalingo/php-buildpack

--- a/.docker/php-fpm/Dockerfile
+++ b/.docker/php-fpm/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         && pecl install redis \
         && docker-php-ext-enable redis \
         # Install others
-        && docker-php-ext-install -j2 bcmath ctype iconv pdo pdo_mysql pdo_sqlite zip xsl\
+        && docker-php-ext-install -j2 bcmath ctype iconv pdo pdo_mysql pdo_sqlite zip xsl sockets\
         && docker-php-ext-enable opcache \
         && rm /usr/src/php/ext/*.tgz \
         && curl -sS https://getcomposer.org/installer | php && mv composer.phar /usr/local/bin/composer

--- a/.env
+++ b/.env
@@ -30,7 +30,9 @@ MATOMO_SITE_ID=
 SESSION_MAXLIFETIME=151200 # 151200 secondes = 42 heures
 CONTACT_FORM_LIMITER_LIMIT=3
 CONTACT_FORM_LIMITER_INTERVAL='20 minutes'
-
+CLAMAV_HOST=stopunaises_clamav
+CLAMAV_STRATEGY=clamd_unix
+CLAMAV_SCAN_ENABLE=1
 ###> sentry/sentry-symfony ###
 SENTRY_DSN=
 ###< sentry/sentry-symfony ###

--- a/.env.sample
+++ b/.env.sample
@@ -30,7 +30,9 @@ MATOMO_SITE_ID=
 SESSION_MAXLIFETIME=151200 # 151200 secondes = 42 heures
 CONTACT_FORM_LIMITER_LIMIT=3
 CONTACT_FORM_LIMITER_INTERVAL='20 minutes'
-
+CLAMAV_HOST=stopunaises_clamav
+CLAMAV_STRATEGY=clamd_unix
+CLAMAV_SCAN_ENABLE=1
 ###> sentry/sentry-symfony ###
 SENTRY_DSN=
 ###< sentry/sentry-symfony ###

--- a/.slugignore
+++ b/.slugignore
@@ -4,3 +4,4 @@ docker-compose.yml
 tools
 cypress
 cypress.config.js
+/node_modules

--- a/Makefile
+++ b/Makefile
@@ -173,3 +173,6 @@ tools-down: ## [Tools] Shutdown tools containers
 
 k6: ## Run K6 tests
 	@$(DOCKER_COMP) -f $(DOCKER_COMP_FILE_TOOLS) run --rm -T stopunaises_k6 run -<tools/k6/k6-50000.js --env "URL=$(URL)"
+
+clamscan-tmp: ## [Clamscan] Scan a tmp directory
+	@bash -l -c '$(DOCKER_COMP) exec -it stopunaises_clamav clamscan /app/tmp -r'

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "phpdocumentor/reflection-docblock": "^5.3",
         "phpstan/phpdoc-parser": "^1.8",
         "sentry/sentry-symfony": "^4.5",
+        "sineflow/clamav": "^1.1",
         "symfony/asset": "7.1.*",
         "symfony/brevo-mailer": "7.1.*",
         "symfony/console": "7.1.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d03f6b26f40775b6595a4a72b7dffed0",
+    "content-hash": "580fbf56ff92b86029aed7da813a18e2",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -4263,6 +4263,62 @@
                 }
             ],
             "time": "2024-02-26T09:27:19+00:00"
+        },
+        {
+            "name": "sineflow/clamav",
+            "version": "v1.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sineflow/clamav.git",
+                "reference": "e7f8d70041f6c41b2c74ad9f2f9a1ad6c4e5f95f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sineflow/clamav/zipball/e7f8d70041f6c41b2c74ad9f2f9a1ad6c4e5f95f",
+                "reference": "e7f8d70041f6c41b2c74ad9f2f9a1ad6c4e5f95f",
+                "shasum": ""
+            },
+            "require": {
+                "ext-sockets": "*",
+                "php": "^7.3 || ^8.0",
+                "symfony/config": "~4.0 || ~5.0 || ~6.0 || ~7.0",
+                "symfony/dependency-injection": "~4.0 || ~5.0 || ~6.0 || ~7.0",
+                "symfony/http-kernel": "~4.0 || ~5.0 || ~6.0 || ~7.0",
+                "symfony/yaml": "~4.0 || ~5.0 || ~6.0 || ~7.0"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.5",
+                "phpunit/phpunit": "^9.0",
+                "squizlabs/php_codesniffer": "^3.0"
+            },
+            "type": "symfony-bundle",
+            "autoload": {
+                "psr-4": {
+                    "Sineflow\\ClamAV\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Plamen Mishev",
+                    "email": "pmishev@sineflow.com",
+                    "homepage": "http://sineflow.com/"
+                }
+            ],
+            "description": "ClamAV PHP Client for Symfony",
+            "keywords": [
+                "bundle",
+                "clamav",
+                "symfony"
+            ],
+            "support": {
+                "issues": "https://github.com/sineflow/clamav/issues",
+                "source": "https://github.com/sineflow/clamav/tree/v1.1.2"
+            },
+            "time": "2024-04-06T10:59:33+00:00"
         },
         {
             "name": "symfony/asset",

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -16,4 +16,5 @@ return [
     League\FlysystemBundle\FlysystemBundle::class => ['all' => true],
     Sentry\SentryBundle\SentryBundle::class => ['prod' => true],
     DAMA\DoctrineTestBundle\DAMADoctrineTestBundle::class => ['test' => true],
+    Sineflow\ClamAV\Bundle\SineflowClamAVBundle::class => ['all' => true],
 ];

--- a/config/packages/clamav.yaml
+++ b/config/packages/clamav.yaml
@@ -1,0 +1,5 @@
+sineflow_clam_av:
+  strategy: '%env(CLAMAV_STRATEGY)%'
+  host: '%env(CLAMAV_HOST)%'
+  socket: "/app/run/clamd.sock"
+  port: 3310

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,5 +64,10 @@ services:
     image: redis:7.0-alpine
     container_name: stopunaises_redis
 
+  stopunaises_clamav:
+    image: clamav/clamav
+    container_name: stopunaises_clamav
+    volumes:
+      - .:/app/
 volumes:
   dbdata:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "stop-punaises",
+    "name": "app",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/scalingo.json
+++ b/scalingo.json
@@ -4,6 +4,14 @@
     "COMPOSER_DEV": {
       "description": "Install composer dev dependencies",
       "value": "true"
+    },
+    "CLAMD_DISABLE_DAEMON": {
+      "description": "When set, this environment variable instructs the image to NOT start the clamd daemon.",
+      "value": "true"
+    },
+    "FRESHCLAM_DISABLE_DAEMON": {
+      "description": "When set, this environment variable instructs the image to NOT start the freshclam daemon.",
+      "value": "true"
     }
   }
 }

--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -152,7 +152,7 @@ class Signalement
     private ?array $punaisesDetails = null;
 
     #[ORM\Column(type: 'json', nullable: true)]
-    private $photos = [];
+    private array $photos = [];
 
     #[ORM\ManyToOne(inversedBy: 'signalements')]
     private ?Territoire $territoire = null;
@@ -194,7 +194,7 @@ class Signalement
     private ?string $uuidPublic = null;
 
     #[ORM\Column(type: 'json')]
-    private $geoloc = [];
+    private array $geoloc = [];
 
     #[ORM\Column(type: 'string', enumType: SignalementType::class)]
     private SignalementType $type;
@@ -202,7 +202,7 @@ class Signalement
     #[ORM\Column(nullable: true)]
     private ?\DateTimeImmutable $punaisesViewedAt = null;
 
-    #[ORM\Column(type: 'string', enumType: PlaceType::class, nullable: true)]
+    #[ORM\Column(type: 'string', nullable: true, enumType: PlaceType::class)]
     private ?PlaceType $placeType = null;
 
     #[ORM\Column(length: 50, nullable: true)]

--- a/src/Exception/File/MalwareDetectedException.php
+++ b/src/Exception/File/MalwareDetectedException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Exception\File;
+
+class MalwareDetectedException extends \Exception
+{
+    public function __construct(string $filename)
+    {
+        parent::__construct(\sprintf('Le fichier %s est infecté ', $filename));
+    }
+}

--- a/src/Security/FileScanner.php
+++ b/src/Security/FileScanner.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Security;
+
+use Sineflow\ClamAV\Exception\FileScanException;
+use Sineflow\ClamAV\Exception\SocketException;
+use Sineflow\ClamAV\Scanner;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Symfony\Component\Uid\Uuid;
+
+readonly class FileScanner
+{
+    public function __construct(
+        private Scanner $scanner,
+        private ParameterBagInterface $parameterBag,
+        #[Autowire(env: 'CLAMAV_SCAN_ENABLE')]
+        private bool $clamavScanEnable,
+    ) {
+    }
+
+    /**
+     * @throws FileScanException
+     * @throws SocketException
+     */
+    public function isClean(string $filePath, ?bool $copy = true): bool
+    {
+        if (!$this->clamavScanEnable) {
+            return true;
+        }
+        if ($copy) {
+            $copiedFilepath = $this->parameterBag->get('uploads_tmp_dir').'clamav_'.Uuid::v4();
+            file_put_contents($copiedFilepath, file_get_contents($filePath));
+        } else {
+            $copiedFilepath = $filePath;
+        }
+
+        $scannedFile = $this->scanner->scan($copiedFilepath);
+
+        return $scannedFile->isClean();
+    }
+}

--- a/src/Service/Upload/UploadHandlerService.php
+++ b/src/Service/Upload/UploadHandlerService.php
@@ -107,13 +107,14 @@ class UploadHandlerService
                     $this->uploadFromFile($file, $newFilename);
                 } catch (MaxUploadSizeExceededException|MalwareDetectedException $exception) {
                     $newFilename = '';
-                    $this->logger->error($errorMessage = $exception->getMessage());
+                    $this->logger->error($exception->getMessage());
                 }
                 if (!empty($newFilename)) {
                     $filesToSave[] = [
                         'file' => $newFilename,
                         'title' => $title,
                         'date' => (new \DateTimeImmutable())->format('d.m.Y'),
+                        'scannedAt' => (new \DateTimeImmutable())->format('Y-m-d H:i:s'),
                     ];
                 }
             }

--- a/src/Service/Upload/UploadHandlerService.php
+++ b/src/Service/Upload/UploadHandlerService.php
@@ -2,74 +2,42 @@
 
 namespace App\Service\Upload;
 
+use App\Exception\File\MalwareDetectedException;
 use App\Exception\File\MaxUploadSizeExceededException;
+use App\Security\FileScanner;
 use League\Flysystem\FilesystemException;
 use League\Flysystem\FilesystemOperator;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
-use Symfony\Component\HttpFoundation\File\Exception\FileException;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\String\Slugger\SluggerInterface;
 
 class UploadHandlerService
 {
-    public const MAX_FILESIZE = 10 * 1024 * 1024;
+    public const int|float MAX_FILESIZE = 10 * 1024 * 1024;
     public const UPLOAD_ACCEPTED_EXTENSIONS = ['jpg', 'jpeg', 'png'];
     public const UPLOAD_ACCEPTED_MIME_TYPES = ['image/jpeg', 'image/png'];
 
-    private $file;
+    private ?array $file;
 
     public function __construct(
-        private FilesystemOperator $fileStorage,
-        private ParameterBagInterface $parameterBag,
-        private SluggerInterface $slugger,
-        private LoggerInterface $logger,
+        private readonly FilesystemOperator $fileStorage,
+        private readonly SluggerInterface $slugger,
+        private readonly LoggerInterface $logger,
+        private readonly FileScanner $fileScanner,
     ) {
         $this->file = null;
     }
 
-    public function toTempFolder(UploadedFile $file): self|array
-    {
-        $originalFilename = pathinfo($file->getClientOriginalName(), \PATHINFO_FILENAME);
-        $titre = $originalFilename.'.'.$file->guessExtension();
-        // this is needed to safely include the file name as part of the URL
-        $safeFilename = $this->slugger->slug($originalFilename);
-        $newFilename = $safeFilename.'-'.uniqid().'.'.$file->guessExtension();
-        if ($file->getSize() > self::MAX_FILESIZE) {
-            throw new MaxUploadSizeExceededException(self::MAX_FILESIZE);
-        }
-        try {
-            $file->move(
-                $this->parameterBag->get('uploads_tmp_dir'),
-                $newFilename
-            );
-        } catch (FileException $e) {
-            $this->logger->error($e->getMessage());
-
-            return ['error' => 'Erreur lors du téléversement.', 'message' => $e->getMessage(), 'status' => 500];
-        }
-        $this->file = ['file' => $newFilename, 'titre' => $titre];
-
-        return $this;
-    }
-
-    public function uploadFromFilename(string $filename): string
-    {
-        $tmpFilepath = $this->parameterBag->get('uploads_tmp_dir').$filename;
-
-        try {
-            $resourceFile = fopen($tmpFilepath, 'r');
-            $this->fileStorage->writeStream($filename, $resourceFile);
-            fclose($resourceFile);
-        } catch (FilesystemException $exception) {
-            $this->logger->error($exception->getMessage());
-        }
-
-        return $filename;
-    }
-
+    /**
+     * @throws MaxUploadSizeExceededException
+     * @throws MalwareDetectedException
+     */
     public function uploadFromFile(UploadedFile $file, $newFilename): void
     {
+        if (!$this->fileScanner->isClean($file->getPathname())) {
+            throw new MalwareDetectedException($file->getClientOriginalName());
+        }
+
         if ($file->getSize() > self::MAX_FILESIZE) {
             throw new MaxUploadSizeExceededException(self::MAX_FILESIZE);
         }
@@ -82,12 +50,15 @@ class UploadHandlerService
         }
     }
 
+    /**
+     * @throws FilesystemException
+     */
     public function createTmpFileFromBucket($from, $to): void
     {
         $resourceBucket = $this->fileStorage->read($from);
-        $resourceFileSytem = fopen($to, 'w');
-        fwrite($resourceFileSytem, $resourceBucket);
-        fclose($resourceFileSytem);
+        $resourceFileSystem = fopen($to, 'w');
+        fwrite($resourceFileSystem, $resourceBucket);
+        fclose($resourceFileSystem);
     }
 
     public function setKey(string $key): ?array
@@ -116,7 +87,7 @@ class UploadHandlerService
         ?array $filesPosted,
     ): array {
         $filesToSave = [];
-        if (isset($filesPosted) && \is_array($filesPosted)) {
+        if (isset($filesPosted)) {
             /** @var UploadedFile $file */
             foreach ($filesPosted as $file) {
                 if ($file->getError()) {
@@ -134,12 +105,9 @@ class UploadHandlerService
                 $newFilename = $safeFilename.'-'.uniqid().'.'.$file->guessExtension();
                 try {
                     $this->uploadFromFile($file, $newFilename);
-                } catch (FilesystemException $exception) {
+                } catch (MaxUploadSizeExceededException|MalwareDetectedException $exception) {
                     $newFilename = '';
-                    $this->logger->error($exception->getMessage());
-                } catch (MaxUploadSizeExceededException $exception) {
-                    $newFilename = '';
-                    $this->logger->error($exception->getMessage());
+                    $this->logger->error($errorMessage = $exception->getMessage());
                 }
                 if (!empty($newFilename)) {
                     $filesToSave[] = [

--- a/templates/front_signalement_erp/index.html.twig
+++ b/templates/front_signalement_erp/index.html.twig
@@ -116,8 +116,11 @@
                                accept=".jpg, .jpeg, .png"
                         >
                     </div>
-                    <p id="file-upload-error" class="fr-error-text fr-hidden">
+                    <p id="file-upload-error-size" class="fr-error-text fr-hidden">
                         Merci d'ajouter une photo de moins de 10 Mo.
+                    </p>
+                    <p id="file-upload-error-malware" class="fr-error-text fr-hidden">
+                        Un ou plusieurs fichiers téléversés sont infectés. Merci de vérifier et de réessayer.
                     </p>
                     <div class="fr-grid-row fr-grid fr-grid-row--gutters fr-mt-3v fr-front-signalement-photos">
                     </div>

--- a/templates/front_signalement_erp/index.html.twig
+++ b/templates/front_signalement_erp/index.html.twig
@@ -116,11 +116,8 @@
                                accept=".jpg, .jpeg, .png"
                         >
                     </div>
-                    <p id="file-upload-error-size" class="fr-error-text fr-hidden">
+                    <p id="file-upload-error" class="fr-error-text fr-hidden">
                         Merci d'ajouter une photo de moins de 10 Mo.
-                    </p>
-                    <p id="file-upload-error-malware" class="fr-error-text fr-hidden">
-                        Un ou plusieurs fichiers téléversés sont infectés. Merci de vérifier et de réessayer.
                     </p>
                     <div class="fr-grid-row fr-grid fr-grid-row--gutters fr-mt-3v fr-front-signalement-photos">
                     </div>


### PR DESCRIPTION
cf : https://github.com/MTES-MCT/histologe/pull/2839

## Ticket

#782    

## Description
Ajout d'un scan antivirus (via clamav) sur les fichiers uploadé sur le formulaire de dépot du signalement,la page de suivi usager du signalement et la page BO du signalement

## Changements apportés
* Ajout du buildpack clamav pour scalingo
* Ajout d'un conteneur docker pour le fonctionnement de clamav en local
* Ajout de l'extension php sockets pour la communication avec clamav
* Ajout du bundle sineflow/clamav pour l'utilisation sous Symfony

## Pré-requis
- [ ] Ajouter dans vos fichiers .env de dev et test : CLAMAV_STRATEGY=clamd_network
- [ ] Exécuter `make build`
- [ ] Vérifier le bon fonctionnement de clamav `make clamscan-tmp`
- [ ] Commenter le contrôle du type de fichier https://github.com/MTES-MCT/stop-punaises/blob/0c691196abbebcbc33d0e7eb51aa2f65163d3cc0/src/Service/Upload/UploadHandlerService.php#L126


## Tests
- [ ] Déposer un signalement (Dans mon logement) puis récupérer la requête via la réponse et modifiant la requête sur la pièce jointe puis soumettre la à nouveau
- [ ] Vérifier que la pièce jointe contenu un virus n'est pas présente sur la fiche

```

-----------------------------67889249634044727342552075142
Content-Disposition: form-data; name="file-upload[]"; filename="bonjour.txt"
Content-Type: text/plain

X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*

-----------------------------67889249634044727342552075142
```
![image](https://github.com/user-attachments/assets/95cde4f2-86bf-4183-b958-3d568e20242f)

- [ ] Répéter cette opération avec ERP et transport
- [ ] Déploiement OK => https://stop-punaises-staging-pr786.osc-fr1.scalingo.io/

