### PR TITLE
[Technique] Vérifier (et corriger) les vulnérabilités détectées par Nuclei 

### DIFF
--- a/.scalingo/nginx/server.location
+++ b/.scalingo/nginx/server.location
@@ -1,6 +1,17 @@
 add_header X-Frame-Options "deny";
-add_header X-Content-Type-Options nosniff;
+add_header X-Content-Type-Options "nosniff";
 add_header X-XSS-Protection "1; mode=block";
+add_header Permissions-Policy "geolocation=(), camera=(), microphone=(), payment=(), accelerometer=(), ambient-light-sensor=(), gyroscope=(), magnetometer=(), usb=(), vibrate=()";
+add_header X-Permitted-Cross-Domain-Policies "none";
+add_header Referrer-Policy "no-referrer";
+add_header Cross-Origin-Embedder-Policy "unsafe-none";  # Temporarily disable COEP for matomo.js
+add_header Cross-Origin-Opener-Policy "same-origin";
+add_header Cross-Origin-Resource-Policy "cross-origin";
+add_header Upgrade-Insecure-Requests "1";
+add_header X-Powered-By "none";
+add_header Access-Control-Allow-Origin "*";
+add_header Access-Control-Allow-Methods "GET, POST, OPTIONS";
+add_header Access-Control-Allow-Headers "Content-Type, Authorization";
 
 location ~* ^/bo/historique/.*\/supprimer-photo$ {
     try_files $uri /index.php$is_args$args;

--- a/public/js/maps.js
+++ b/public/js/maps.js
@@ -11,7 +11,7 @@ var map = L.map('map-signalements-view', {
     maxZoom: 18,
     zoom: 6
 });
-L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {}).addTo(map);
+L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {crossOrigin: true}).addTo(map);
 var heat;
 
 async function getMarkers(offset) {


### PR DESCRIPTION
## Ticket

#773    

## Description
J'ai fait le tour des scans initiés sur mozilla observatory https://observatory.mozilla.org/analyze/stop-punaises.gouv.fr
Il y a beaucoup moins de choses que sur Histologe, donc pas grand-chose à faire.
http://dashlord.mte.incubateur.net/url/stop-punaises-beta-gouv-fr/securite/

On a 5 points de moins sur on va sur stop-punaises.beta.gouv.fr à cause de la redirection vers stop-punaises.gouv.fr.
Donc je me suis contentée d'ajouter les mêmes headers de sécurité qu'on avait ajouté sur histologe (la CSP ayant été renforcée dans un autre ticket)

## Changements apportés
* Modification des entêtes

## Pré-requis
`make down && make run`

## Tests
- [ ] Vérifier à l'aide d'une requête CURL la présence des nouvelles en-têtes
```bash
curl -I http://localhost:8090
````
- [ ] Vérifier qu'il n'y a pas d'erreurs dans la console
- [ ] Vérifier qu'il n'y a pas de nouveaux avertissements dans la console
- [ ] Tester avec différents type de navigateurs (Chrome, Firefox, Edge)

