### PR TITLE
[Historique] Initier un système d'historisation des actions BO, et historisation des logins

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -40,6 +40,10 @@ services:
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous ones
 
+    App\EventListener\AuthentificationHistoryListener:
+        tags:
+            - { name: 'kernel.event_listener', event: 'security.interactive_login' }
+
     App\Service\Mailer\MessageFactory:
         arguments:
             $baseUrl: '%base_url%'

--- a/migrations/Version20240923083351.php
+++ b/migrations/Version20240923083351.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240923083351 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'add table HistoryEntry';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE history_entry (id INT AUTO_INCREMENT NOT NULL, user_id INT DEFAULT NULL, event VARCHAR(255) DEFAULT NULL, entity_id INT DEFAULT NULL, entity_name VARCHAR(255) NOT NULL, changes JSON DEFAULT NULL, source VARCHAR(255) DEFAULT NULL, created_at DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\', INDEX IDX_72999517A76ED395 (user_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE history_entry ADD CONSTRAINT FK_72999517A76ED395 FOREIGN KEY (user_id) REFERENCES user (id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE history_entry DROP FOREIGN KEY FK_72999517A76ED395');
+        $this->addSql('DROP TABLE history_entry');
+    }
+}

--- a/src/Dto/Command/CommandContext.php
+++ b/src/Dto/Command/CommandContext.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Dto\Command;
+
+class CommandContext
+{
+    public function __construct(private ?string $commandName = null)
+    {
+    }
+
+    public function setCommandName(string $commandName): self
+    {
+        $this->commandName = $commandName;
+
+        return $this;
+    }
+
+    public function getCommandName(): ?string
+    {
+        return $this->commandName;
+    }
+}

--- a/src/Entity/Behaviour/EntityHistoryInterface.php
+++ b/src/Entity/Behaviour/EntityHistoryInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Entity\Behaviour;
+
+interface EntityHistoryInterface
+{
+    public function getId(): ?int;
+
+    public function getHistoryRegisteredEvent(): array;
+}

--- a/src/Entity/Enum/HistoryEntryEvent.php
+++ b/src/Entity/Enum/HistoryEntryEvent.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Entity\Enum;
+
+enum HistoryEntryEvent: string
+{
+    case LOGIN = 'LOGIN';
+
+    case CREATE = 'CREATE';
+
+    case UPDATE = 'UPDATE';
+
+    case DELETE = 'DELETE';
+}

--- a/src/Entity/HistoryEntry.php
+++ b/src/Entity/HistoryEntry.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace App\Entity;
+
+use App\Entity\Enum\HistoryEntryEvent;
+use App\Repository\HistoryEntryRepository;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: HistoryEntryRepository::class)]
+class HistoryEntry
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\Column(type: 'string', nullable: true, enumType: HistoryEntryEvent::class)]
+    private ?HistoryEntryEvent $event = null;
+
+    #[ORM\Column(nullable: true)]
+    private ?int $entityId = null;
+
+    #[ORM\Column(length: 255)]
+    private ?string $entityName = null;
+
+    #[ORM\Column(nullable: true)]
+    private ?array $changes = null;
+
+    #[ORM\Column(nullable: true)]
+    private ?string $source = null;
+
+    #[ORM\Column]
+    private ?\DateTimeImmutable $createdAt = null;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(nullable: true)]
+    private ?User $user = null;
+
+    public function __construct()
+    {
+        $this->createdAt = new \DateTimeImmutable();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setId(int $id): static
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    public function getEvent(): ?HistoryEntryEvent
+    {
+        return $this->event;
+    }
+
+    public function setEvent(HistoryEntryEvent $event): static
+    {
+        $this->event = $event;
+
+        return $this;
+    }
+
+    public function getEntityId(): ?int
+    {
+        return $this->entityId;
+    }
+
+    public function setEntityId(?int $entityId): static
+    {
+        $this->entityId = $entityId;
+
+        return $this;
+    }
+
+    public function getEntityName(): ?string
+    {
+        return $this->entityName;
+    }
+
+    public function setEntityName(string $entityName): static
+    {
+        $this->entityName = $entityName;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): ?\DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(?\DateTimeImmutable $createdAt): self
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    public function getUser(): ?User
+    {
+        return $this->user;
+    }
+
+    public function setUser(?User $user): static
+    {
+        $this->user = $user;
+
+        return $this;
+    }
+
+    public function getChanges(): ?array
+    {
+        return $this->changes;
+    }
+
+    public function setChanges(?array $changes): self
+    {
+        $this->changes = $changes;
+
+        return $this;
+    }
+
+    public function getSource(): ?string
+    {
+        return $this->source;
+    }
+
+    public function setSource(?string $source): self
+    {
+        $this->source = $source;
+
+        return $this;
+    }
+}

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -3,7 +3,9 @@
 namespace App\Entity;
 
 use App\Entity\Behaviour\ActivableTrait;
+use App\Entity\Behaviour\EntityHistoryInterface;
 use App\Entity\Behaviour\TimestampableTrait;
+use App\Entity\Enum\HistoryEntryEvent;
 use App\Entity\Enum\Status;
 use App\Repository\UserRepository;
 use Doctrine\DBAL\Types\Types;
@@ -17,7 +19,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 #[ORM\Entity(repositoryClass: UserRepository::class)]
 #[ORM\HasLifecycleCallbacks()]
 #[UniqueEntity('email')]
-class User implements UserInterface, PasswordAuthenticatedUserInterface
+class User implements UserInterface, PasswordAuthenticatedUserInterface, EntityHistoryInterface
 {
     use ActivableTrait;
     use TimestampableTrait;
@@ -219,5 +221,10 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
         $this->uuid = $uuid;
 
         return $this;
+    }
+
+    public function getHistoryRegisteredEvent(): array
+    {
+        return [HistoryEntryEvent::LOGIN];
     }
 }

--- a/src/EventListener/AuthentificationHistoryListener.php
+++ b/src/EventListener/AuthentificationHistoryListener.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\EventListener;
+
+use App\Entity\Enum\HistoryEntryEvent;
+use App\Entity\User;
+use App\Manager\HistoryEntryManager;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
+
+class AuthentificationHistoryListener
+{
+    public function __construct(
+        private readonly HistoryEntryManager $historyEntryManager,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    public function onSecurityInteractiveLogin(InteractiveLoginEvent $event): void
+    {
+        /** @var User $user */
+        $user = $event->getAuthenticationToken()->getUser();
+        $this->createAuthentificationHistory(HistoryEntryEvent::LOGIN, $user);
+    }
+
+    private function createAuthentificationHistory(HistoryEntryEvent $historyEntryEvent, User $user): void
+    {
+        try {
+            $historyEntry = $this->historyEntryManager->create(
+                historyEntryEvent: $historyEntryEvent,
+                entityHistory: $user,
+                flush: false
+            );
+
+            $source = $this->historyEntryManager->getSource();
+            $historyEntry->setSource($source);
+            $this->historyEntryManager->save($historyEntry);
+
+            return;
+        } catch (\Throwable $exception) {
+            $this->logger->error(\sprintf(
+                'Failed to create login history entry (%s) on user : %d',
+                $exception->getMessage(),
+                $user->getId()
+            ));
+        }
+    }
+}

--- a/src/Factory/HistoryEntryFactory.php
+++ b/src/Factory/HistoryEntryFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Factory;
+
+use App\Entity\Behaviour\EntityHistoryInterface;
+use App\Entity\Enum\HistoryEntryEvent;
+use App\Entity\HistoryEntry;
+use Symfony\Bundle\SecurityBundle\Security;
+
+readonly class HistoryEntryFactory
+{
+    public function __construct(private Security $security)
+    {
+    }
+
+    public function createInstanceFrom(
+        HistoryEntryEvent $historyEntryEvent,
+        EntityHistoryInterface $entityHistory,
+    ): HistoryEntry {
+        return (new HistoryEntry())
+            ->setEvent($historyEntryEvent)
+            ->setEntityId($entityHistory->getId())
+            ->setEntityName(str_replace('Proxies\\__CG__\\', '', $entityHistory::class))
+            ->setUser($this->security->getUser());
+    }
+}

--- a/src/Manager/HistoryEntryManager.php
+++ b/src/Manager/HistoryEntryManager.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Manager;
+
+use App\Dto\Command\CommandContext;
+use App\Entity\Behaviour\EntityHistoryInterface;
+use App\Entity\Enum\HistoryEntryEvent;
+use App\Entity\HistoryEntry;
+use App\Factory\HistoryEntryFactory;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Serializer\Exception\ExceptionInterface;
+
+class HistoryEntryManager extends AbstractManager
+{
+    public function __construct(
+        private readonly HistoryEntryFactory $historyEntryFactory,
+        private readonly RequestStack $requestStack,
+        private readonly CommandContext $commandContext,
+        ManagerRegistry $managerRegistry,
+        string $entityName = HistoryEntry::class,
+    ) {
+        parent::__construct($managerRegistry, $entityName);
+    }
+
+    /**
+     * @throws ExceptionInterface
+     */
+    public function create(
+        HistoryEntryEvent $historyEntryEvent,
+        EntityHistoryInterface|Collection $entityHistory,
+        array $changes = [],
+        bool $flush = true,
+    ): ?HistoryEntry {
+        $historyEntry = $this->historyEntryFactory->createInstanceFrom(
+            historyEntryEvent: $historyEntryEvent,
+            entityHistory: $entityHistory,
+        );
+
+        $source = $this->getSource();
+        $historyEntry
+            ->setChanges($changes)
+            ->setSource($source);
+
+        $this->save($historyEntry, $flush);
+
+        return $historyEntry;
+    }
+
+    /**
+     * @throws ExceptionInterface
+     */
+    public function getSource(
+    ): ?string {
+        return $this->requestStack->getCurrentRequest()?->getPathInfo() ?? $this->commandContext->getCommandName();
+    }
+}

--- a/src/Repository/HistoryEntryRepository.php
+++ b/src/Repository/HistoryEntryRepository.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\HistoryEntry;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<HistoryEntry>
+ *
+ * @method HistoryEntry|null find($id, $lockMode = null, $lockVersion = null)
+ * @method HistoryEntry|null findOneBy(array $criteria, array $orderBy = null)
+ * @method HistoryEntry[]    findAll()
+ * @method HistoryEntry[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class HistoryEntryRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, HistoryEntry::class);
+    }
+}

--- a/tests/Functional/Manager/HistoryEntryManagerTest.php
+++ b/tests/Functional/Manager/HistoryEntryManagerTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Tests\Functional\Manager;
+
+use App\Dto\Command\CommandContext;
+use App\Entity\Enum\HistoryEntryEvent;
+use App\Entity\HistoryEntry;
+use App\Entity\User;
+use App\Factory\HistoryEntryFactory;
+use App\Manager\HistoryEntryManager;
+use App\Repository\UserRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class HistoryEntryManagerTest extends KernelTestCase
+{
+    private EntityManagerInterface $entityManager;
+    private RequestStack $requestStack;
+    private CommandContext $commandContext;
+    private HistoryEntryFactory $historyEntryFactory;
+    private HistoryEntryManager $historyEntryManager;
+
+    protected ManagerRegistry $managerRegistry;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+
+        $this->managerRegistry = static::getContainer()->get(ManagerRegistry::class);
+        $this->historyEntryFactory = static::getContainer()->get(HistoryEntryFactory::class);
+        $this->requestStack = static::getContainer()->get(RequestStack::class);
+        $this->commandContext = static::getContainer()->get(CommandContext::class);
+        $this->entityManager = $kernel->getContainer()->get('doctrine')->getManager();
+        $this->historyEntryManager = new HistoryEntryManager(
+            $this->historyEntryFactory,
+            $this->requestStack,
+            $this->commandContext,
+            $this->managerRegistry,
+            HistoryEntry::class,
+        );
+    }
+
+    public function testCreateHistoryEntry()
+    {
+        /** @var UserRepository $userRepository */
+        $userRepository = $this->entityManager->getRepository(User::class);
+        $user = $userRepository->findOneBy(['email' => 'company-01@punaises.fr']);
+
+        $historyEntry = $this->historyEntryManager->create(
+            historyEntryEvent: HistoryEntryEvent::LOGIN,
+            entityHistory: $user,
+        );
+
+        $this->assertInstanceOf(HistoryEntry::class, $historyEntry);
+        $this->assertEquals(HistoryEntryEvent::LOGIN, $historyEntry->getEvent());
+    }
+}


### PR DESCRIPTION
## Ticket

#791 
#792 

## Description
Historisation de l'ensemble des accès à la plateforme, tout en ayant mis en place les colonnes `source` et `changes` 
* `source` : origine de la modification (une url ou une commande)
* `changes` : changement qui ont été apportés sur la ressource notamment lors de la modification

## Changements apportés
* Création d'une table HistoryEntry qui stocke l'ensemble des logins au SI
* A terme, elle permettra de stocker l'ensemble des événements de modification du site
* Ajout de l'interface `EntityHistoryInterface` utilisée pour s'assurer qu'une entité supporte l'historisation.

## Pré-requis
`make execute-migration name=Version20240923083351 direction=up`

## Tests
- [ ] Se logger avec différents utilisateurs et vérifier qu'une ligne s'ajoute dans la table `history_entry`
