### PR TITLE
[FO - Signalement] Refonte composant autocompletion

### DIFF
--- a/assets/controllers/component_search_address.js
+++ b/assets/controllers/component_search_address.js
@@ -8,6 +8,14 @@ $(function() {
 function initSearchAddress() {
   var idTimeoutInputAddress = null;
   var ajaxObject = null;
+  var selectedSuggestionIndex = -1;
+  var isAutocompleteOpen = false;
+
+  $(document).on('click', function(event) {
+    if (!$(event.target).closest('.fr-autocomplete-list').length && isAutocompleteOpen) {
+      closeSuggestions();
+    }
+  });
 
   $('input#rechercheAdresse').on('input', function() {
     if (idTimeoutInputAddress !== null) {
@@ -17,7 +25,7 @@ function initSearchAddress() {
       ajaxObject.abort();
     }
 
-    $('#rechercheAdresseListe select').empty();
+    $('#rechercheAdresseListe').empty();
     $('#rechercheAdresseIcon .fr-icon-timer-line').show();
     $('#rechercheAdresseIcon .fr-icon-map-pin-2-line').hide();
 
@@ -30,6 +38,7 @@ function initSearchAddress() {
         ajaxObject = $.ajax({
           url: 'https://api-adresse.data.gouv.fr/search/?q=' + searchField
         }).done(function(jsonData) {
+          let ariaPosinset = 1;
           for (let feature of jsonData.features) {
             let adresseLabel = feature.properties.label;
             let adresseName = feature.properties.name;
@@ -46,7 +55,23 @@ function initSearchAddress() {
             elementData += ' data-citycode="'+adresseCityCode+'"';
             elementData += ' data-geoloclat="'+adresseGeolocLat+'"';
             elementData += ' data-geoloclng="'+adresseGeolocLng+'"';
-            $('#rechercheAdresseListe select').append( '<option '+elementData+' class="fr-mb-1v fr-p-1v">'+adresseLabel+'</option>' );
+
+            const setSize = jsonData.features.length;
+            $('#rechercheAdresseListe')
+                .append(
+                    '<li '
+                    + elementData
+                    + ' class="fr-col-12 fr-p-3v fr-text-label--blue-france fr-autocomplete-suggestion"'
+                    + ' role="option" tabindex="-1"'
+                    + ' aria-selected="false"'
+                    + ' aria-posinset="' + ariaPosinset + '"'
+                    + ' aria-setsize="' + setSize + '"'
+                    + '>'
+                    + adresseLabel
+                    + '</li>');
+
+            ++ariaPosinset;
+
             $('#rechercheAdresseListe').show();
             $('#rechercheAdresseIcon .fr-icon-timer-line').hide();
             $('#rechercheAdresseIcon .fr-icon-map-pin-2-line').show();
@@ -59,8 +84,10 @@ function initSearchAddress() {
               });
             }
 
-            $('#rechercheAdresseListe select option').on('click', function() {
-              let formPrefix = ($('#signalement_history_adresse').length > 0) ? 'signalement_history' : 'signalement_front';
+            $('#rechercheAdresseListe li').on('click', function() {
+              let formPrefix = ($('#signalement_history_adresse').length > 0)
+                  ? 'signalement_history'
+                  : 'signalement_front';
               $('#rechercheAdresse').val($(this).data('label'));
               $('#' + formPrefix + '_adresse').val($(this).data('name'));
               $('#' + formPrefix + '_codePostal').val($(this).data('postcode'));
@@ -75,20 +102,25 @@ function initSearchAddress() {
               }
             });
           }
+          isAutocompleteOpen = true;
         });
       },
       300
     );
   });
 
-  $('#rechercheAdresseListe select').on('keypress', function(e){		  
-    var code = e.keyCode || e.which;
-    if (code == 32 && $('#rechercheAdresseListe').is(':visible')) {
-      $('#rechercheAdresseListe select option:selected').trigger('click');
+
+  $('input#rechercheAdresse').on('keydown', function (event) {
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      handleDown();
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      handleUp();
+    } else if (event.key === 'Enter') {
+      event.preventDefault();
+      handleEnter();
     }
-  });
-  $('#rechercheAdresseListe select').on('change', function(e){	
-    $('#rechercheAdresseListe select option:selected').trigger('click');
   });
 
   $('#toggle-skip-search-address').on('click', function(){
@@ -113,4 +145,68 @@ function initSearchAddress() {
       $('#adresse_afficher_les_champs button').removeClass('fr-icon-eye-off-line');
     }
   });
+
+  function handleDown() {
+    const suggestions = $('.fr-autocomplete-suggestion');
+    if (selectedSuggestionIndex < suggestions.length - 1) {
+      selectedSuggestionIndex++;
+      updateSelectedSuggestion();
+    }
+  }
+
+  function handleUp() {
+    if (selectedSuggestionIndex > 0) {
+      selectedSuggestionIndex--;
+      updateSelectedSuggestion();
+    }
+  }
+
+  function updateSelectedSuggestion() {
+    const suggestions = $('.fr-autocomplete-suggestion');
+    suggestions.each(function(index, suggestion) {
+      if (index === selectedSuggestionIndex) {
+        $(suggestion)
+            .addClass('fr-autocomplete-suggestion-highlighted')
+            .attr('aria-selected', 'true');
+      } else {
+        $(suggestion)
+            .removeClass('fr-autocomplete-suggestion-highlighted')
+            .attr('aria-selected', 'false');
+      }
+    });
+  }
+
+  function handleEnter() {
+    const suggestions = $('.fr-autocomplete-suggestion');
+    if (selectedSuggestionIndex !== -1) {
+      let formPrefix = ($('#signalement_history_adresse').length > 0)
+          ? 'signalement_history'
+          : 'signalement_front';
+
+      $('#rechercheAdresse').val(suggestions.eq(selectedSuggestionIndex).data('label'));
+      $('#' + formPrefix + '_adresse').val(suggestions.eq(selectedSuggestionIndex).data('name'));
+      $('#' + formPrefix + '_codePostal').val(suggestions.eq(selectedSuggestionIndex).data('postcode'));
+      $('#' + formPrefix + '_ville').val(suggestions.eq(selectedSuggestionIndex).data('city'));
+      $('#' + formPrefix + '_codeInsee').val(suggestions.eq(selectedSuggestionIndex).data('citycode'));
+      let geoloc = suggestions.eq(selectedSuggestionIndex).data('geoloclat')
+          + '|'
+          + suggestions.eq(selectedSuggestionIndex).data('geoloclng');
+
+      $('#' + formPrefix + '_geoloc').val(geoloc);
+
+      $('#rechercheAdresseListe').hide();
+      if ($('.address-fields').length > 0) {
+        $('.address-fields').removeClass('fr-hidden');
+        $('.skip-search-address').hide();
+      }
+
+      closeSuggestions();
+    }
+  }
+
+  function closeSuggestions() {
+    $('.fr-autocomplete-list').html('');
+    selectedSuggestionIndex = -1;
+    isAutocompleteOpen = false;
+  }
 }

--- a/assets/controllers/component_search_address.js
+++ b/assets/controllers/component_search_address.js
@@ -120,7 +120,9 @@ function initSearchAddress() {
     } else if (event.key === 'Enter') {
       event.preventDefault();
       handleEnter();
-    }
+    } else if (event.key === 'Tab') {
+      closeSuggestions();
+  }
   });
 
   $('#toggle-skip-search-address').on('click', function(){

--- a/assets/controllers/form_signalement_front.js
+++ b/assets/controllers/form_signalement_front.js
@@ -59,7 +59,8 @@ class PunaisesFrontSignalementController {
     self = this;
     self.fetchTerritoireOpened();
     $('input').on('keyup', function(e){
-      if (e.which == 13) {
+      // Do not move to the next screen when pressing Enter while selecting an address
+      if (e.which == 13 && e.currentTarget.id !== 'rechercheAdresse') {
         e.preventDefault();
         $('#step-'+self.stepStr + ' .btn-next').trigger( "click" );
       }

--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -195,17 +195,21 @@ span.statut-infestation {
         z-index: 1;
         display: none;
         border: 1px solid;
-        background: #FFF;
-        min-width: 300px;
-        select {
-            width: 100%;
-            
-            option {
-                cursor: pointer;
-                &:hover {
-                    background-color: #dde5ff;
-                }
-            }
+        background-color: var(--background-alt-blue-france);
+        min-width: 100%;
+        list-style-type: none;
+
+        .fr-autocomplete-list {
+            cursor: pointer;
+        }
+        .fr-autocomplete-suggestion:hover {
+            background-color: var(--artwork-minor-blue-cumulus);
+            color: white !important;
+        }
+
+        .fr-autocomplete-suggestion-highlighted {
+            background-color: #417dc4;
+            color: white !important;
         }
     }
 }

--- a/templates/front_signalement/_partial_step_info_logement.html.twig
+++ b/templates/front_signalement/_partial_step_info_logement.html.twig
@@ -38,7 +38,7 @@
                        type="text"
                        class="fr-input"
                        autocomplete="street"
-                       aria-controls="autocomplete-street__listbox"
+                       aria-controls="rechercheAdresseListe"
                        aria-autocomplete="list"
                        role="combobox"
 

--- a/templates/front_signalement/_partial_step_info_logement.html.twig
+++ b/templates/front_signalement/_partial_step_info_logement.html.twig
@@ -34,15 +34,22 @@
                 <span class="fr-hint-text help-text">Saisissez le début de votre adresse puis sélectionnez-la dans la liste.</span>
             </label>
             <div class="fr-input-wrap fr-icon-map-pin-2-line">
-                <input id="rechercheAdresse" type="text" class="fr-input" autocomplete="street">
+                <input id="rechercheAdresse"
+                       type="text"
+                       class="fr-input"
+                       autocomplete="street"
+                       aria-controls="autocomplete-street__listbox"
+                       aria-autocomplete="list"
+                       role="combobox"
+
+                >
                 <p id="rechercheAdresse-error" class="fr-error-text fr-hidden">
                     Veuillez renseigner l'adresse de votre logement.
                 </p>
             </div>
-            <div id="rechercheAdresseListe" class="fr-mt-1v fr-py-1w">
-                <select size="5">
-                </select>
-            </div>
+            <ul id="rechercheAdresseListe"
+                class="fr-grid-row fr-background-alt--blue-france fr-text-label--blue-france fr-autocomplete-list">
+            </ul>
         </div>
                 
         <div class="fr-toggle">

--- a/templates/front_signalement/_partial_step_info_logement.html.twig
+++ b/templates/front_signalement/_partial_step_info_logement.html.twig
@@ -44,7 +44,7 @@
 
                 >
                 <p id="rechercheAdresse-error" class="fr-error-text fr-hidden">
-                    Veuillez renseigner l'adresse de votre logement.
+                    Veuillez renseigner et sélectionner l'adresse de votre logement.
                 </p>
             </div>
             <ul id="rechercheAdresseListe"

--- a/templates/signalement_create/tab-1.html.twig
+++ b/templates/signalement_create/tab-1.html.twig
@@ -30,7 +30,7 @@
                                type="text"
                                class="fr-input"
                                autocomplete="street"
-                               aria-controls="autocomplete-street__listbox"
+                               aria-controls="rechercheAdresseListe"
                                aria-autocomplete="list"
                                role="combobox"
                         >

--- a/templates/signalement_create/tab-1.html.twig
+++ b/templates/signalement_create/tab-1.html.twig
@@ -26,11 +26,17 @@
                         </span>
                     </label>
                     <div class="fr-input-wrap fr-icon-map-pin-2-line">
-                        <input id="rechercheAdresse" type="text" class="fr-input" autocomplete="street">
-                        <div id="rechercheAdresseListe" class="fr-mt-1v fr-py-1w">
-                            <select size="5">
-                            </select>
-                        </div>
+                        <input id="rechercheAdresse"
+                               type="text"
+                               class="fr-input"
+                               autocomplete="street"
+                               aria-controls="autocomplete-street__listbox"
+                               aria-autocomplete="list"
+                               role="combobox"
+                        >
+                        <ul id="rechercheAdresseListe"
+                            class="fr-grid-row fr-background-alt--blue-france fr-text-label--blue-france fr-autocomplete-list">
+                        </ul>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Review-app: https://stop-punaises-staging-pr796.osc-fr1.scalingo.io/

## Ticket

#695    

## Description

Mise à jour du composant adresse pour le rendre accessible sur mobile.

## Changements apportés
- Remplacement de l'élément `select` par une liste d'éléments (`ul` + `li`).
- Rendre cette liste navigable au clavier.
- Ajout des attributs ARIA à l'élément de saisie et aux éléments de suggestion pour améliorer l'accessibilité :
  - `aria-setsize` pour indiquer la taille totale de la liste des suggestions.
  - `aria-posinset` pour indiquer la position de chaque élément dans la liste.
  - `aria-selected` pour indiquer quel élément est actuellement sélectionné.

## Tests
- [ ] Vérifier que l'autocomplétion fonctionne avec la sélection à la souris.
- [ ] Vérifier que l'autocomplétion fonctionne avec la navigation et la sélection au clavier (touche entrée).
- [ ] Vérifiez que chacun des éléments de la liste des suggestions dispose des attributs `aria-setsize`, `aria-selected`, et `aria-posinset` et se met à jour correctement lorsqu'une suggestion est sélectionnée.

