### PR TITLE
[Sécurité] Cloisonnement des rôles

### DIFF
--- a/src/Controller/SignalementListController.php
+++ b/src/Controller/SignalementListController.php
@@ -17,7 +17,6 @@ class SignalementListController extends AbstractController
 {
     #[Route('/bo/signalements', name: 'app_signalement_list')]
     public function signalements(
-        SignalementManager $signalementManager,
         TerritoireRepository $territoireRepository,
     ): Response {
         $territoires = $territoireRepository->findAll();

--- a/src/Controller/SignalementMessageController.php
+++ b/src/Controller/SignalementMessageController.php
@@ -8,6 +8,7 @@ use App\Entity\Signalement;
 use App\Factory\MessageFactory;
 use App\Manager\MessageManager;
 use App\Manager\MessageThreadManager;
+use App\Repository\InterventionRepository;
 use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -34,7 +35,16 @@ class SignalementMessageController extends AbstractController
         MessageManager $messageManager,
         ValidatorInterface $validator,
         SerializerInterface $serializer,
+        InterventionRepository $interventionRepository,
     ): JsonResponse {
+        $entrepriseIntervention = $interventionRepository->findBySignalementAndEntreprise(
+            $signalement,
+            $entreprise
+        );
+        if (!$entrepriseIntervention || !$entrepriseIntervention->isAccepted()) {
+            return $this->json(['status' => 'denied'], Response::HTTP_FORBIDDEN);
+        }
+
         $data = $request->request->all();
         $messageThread = $messageThreadManager->createOrGet($signalement, $entreprise);
         $message = $messageFactory->createInstanceFrom(
@@ -60,7 +70,6 @@ class SignalementMessageController extends AbstractController
     public function sendMessageToEntreprise(
         Request $request,
         MessageThread $messageThread,
-        MessageThreadManager $messageThreadManager,
         MessageFactory $messageFactory,
         MessageManager $messageManager,
         ValidatorInterface $validator,

--- a/src/Controller/SignalementResolveController.php
+++ b/src/Controller/SignalementResolveController.php
@@ -10,6 +10,7 @@ use App\Form\SignalementHistoryType;
 use App\Manager\InterventionManager;
 use App\Manager\SignalementManager;
 use App\Repository\InterventionRepository;
+use App\Security\Voter\InterventionVoter;
 use App\Service\Mailer\MailerProvider;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -44,17 +45,7 @@ class SignalementResolveController extends AbstractController
                 $userEntreprise
             );
 
-            if (!$intervention
-                || $signalement->getResolvedAt()
-                || $signalement->getClosedAt()
-                || empty($signalement->getTypeIntervention())
-                || !$intervention->isAccepted()
-                || empty($intervention->getEstimationSentAt())
-                || !$intervention->isAcceptedByUsager()) {
-                $this->addFlash('error', 'Vous ne pouvez pas marquer ce signalement comme traité.');
-
-                return $this->redirect($this->generateUrl('app_signalement_view', ['uuid' => $signalement->getUuid()]));
-            }
+            $this->denyAccessUnlessGranted(InterventionVoter::RESOLVE, $intervention);
 
             $signalement->updateUuidPublic();
             $signalementManager->save($signalement);

--- a/src/Controller/SignalementResolveController.php
+++ b/src/Controller/SignalementResolveController.php
@@ -51,9 +51,9 @@ class SignalementResolveController extends AbstractController
                 || !$intervention->isAccepted()
                 || empty($intervention->getEstimationSentAt())
                 || !$intervention->isAcceptedByUsager()) {
+                $this->addFlash('error', 'Vous ne pouvez pas marquer ce signalement comme traité.');
 
-                    $this->addFlash('error', "Vous ne pouvez pas marquer ce signalement comme traité.");
-                    return $this->redirect($this->generateUrl('app_signalement_view', ['uuid' => $signalement->getUuid()]));
+                return $this->redirect($this->generateUrl('app_signalement_view', ['uuid' => $signalement->getUuid()]));
             }
 
             $signalement->updateUuidPublic();

--- a/src/Controller/SignalementViewController.php
+++ b/src/Controller/SignalementViewController.php
@@ -63,7 +63,7 @@ class SignalementViewController extends AbstractController
             if (!$user->getEntreprise()->getTerritoires()->contains($signalement->getTerritoire())) {
                 return $this->render('signalement_view/not-found.html.twig');
             }
-            
+
             $entrepriseIntervention = $interventionRepository->findBySignalementAndEntreprise(
                 $signalement,
                 $userEntreprise
@@ -141,8 +141,9 @@ class SignalementViewController extends AbstractController
             if ($signalement->getResolvedAt()
                 || $signalement->getClosedAt()
                 || \count($acceptedEstimations) > 0) {
-                    $this->addFlash('error', "Vous ne pouvez pas accepter ce signalement.");
-                    return $this->redirect($this->generateUrl('app_signalement_view', ['uuid' => $signalement->getUuid()]));
+                $this->addFlash('error', 'Vous ne pouvez pas accepter ce signalement.');
+
+                return $this->redirect($this->generateUrl('app_signalement_view', ['uuid' => $signalement->getUuid()]));
             }
 
             if (null === $intervention) {
@@ -190,8 +191,9 @@ class SignalementViewController extends AbstractController
             if ($signalement->getResolvedAt()
                 || $signalement->getClosedAt()
                 || \count($acceptedEstimations) > 0) {
-                    $this->addFlash('error', "Vous ne pouvez pas refuser ce signalement.");
-                    return $this->redirect($this->generateUrl('app_signalement_view', ['uuid' => $signalement->getUuid()]));
+                $this->addFlash('error', 'Vous ne pouvez pas refuser ce signalement.');
+
+                return $this->redirect($this->generateUrl('app_signalement_view', ['uuid' => $signalement->getUuid()]));
             }
 
             /** @var User $user */
@@ -262,8 +264,9 @@ class SignalementViewController extends AbstractController
 
                 if (!$intervention
                     || !$intervention->isAccepted()) {
-                        $this->addFlash('error', "Vous ne pouvez pas envoyer d'estimation pour ce signalement.");
-                        return $this->redirect($this->generateUrl('app_signalement_view', ['uuid' => $signalement->getUuid()]));
+                    $this->addFlash('error', "Vous ne pouvez pas envoyer d'estimation pour ce signalement.");
+
+                    return $this->redirect($this->generateUrl('app_signalement_view', ['uuid' => $signalement->getUuid()]));
                 }
 
                 $intervention->setCommentaireEstimation($request->get('commentaire'));
@@ -299,8 +302,9 @@ class SignalementViewController extends AbstractController
             if (!$this->isGranted('ROLE_ADMIN')
                 || $signalement->getResolvedAt()
                 || $signalement->getClosedAt()) {
-                    $this->addFlash('error', "Vous ne pouvez pas fermer ce signalement.");
-                    return $this->redirect($this->generateUrl('app_signalement_view', ['uuid' => $signalement->getUuid()]));
+                $this->addFlash('error', 'Vous ne pouvez pas fermer ce signalement.');
+
+                return $this->redirect($this->generateUrl('app_signalement_view', ['uuid' => $signalement->getUuid()]));
             }
 
             $this->addFlash('success', 'La procédure est terminée !');
@@ -338,32 +342,28 @@ class SignalementViewController extends AbstractController
                 || $intervention->getCanceledByEntrepriseAt()
                 || (!$intervention->getChoiceByEntrepriseAt() && !$intervention->isAcceptedByUsager())
                 || $signalement->getTypeIntervention()) {
-                    $this->addFlash('error', "Vous ne pouvez pas clôturer ce signalement.");
-                    return $this->redirect($this->generateUrl('app_signalement_view', ['uuid' => $signalement->getUuid()]));
+                $this->addFlash('error', 'Vous ne pouvez pas clôturer ce signalement.');
+
+                return $this->redirect($this->generateUrl('app_signalement_view', ['uuid' => $signalement->getUuid()]));
             }
 
             $this->addFlash('success', 'Votre procédure est terminée !');
 
-            $wasAccepted = $intervention->isAccepted();
-            if ($wasAccepted) {
-                $date = new \DateTimeImmutable();
-                $intervention->setCanceledByEntrepriseAt($date);
-            }
+            $date = new \DateTimeImmutable();
+            $intervention->setCanceledByEntrepriseAt($date);
             $intervention->setAccepted(false);
             $interventionManager->save($intervention);
 
-            if ($wasAccepted) {
-                /** @var User $user */
-                $user = $this->getUser();
-                $eventDispatcher->dispatch(
-                    new InterventionEntrepriseCanceledEvent(
-                        $intervention,
-                        $user->getId(),
-                        $date
-                    ),
-                    InterventionEntrepriseCanceledEvent::NAME
-                );
-            }
+            /** @var User $user */
+            $user = $this->getUser();
+            $eventDispatcher->dispatch(
+                new InterventionEntrepriseCanceledEvent(
+                    $intervention,
+                    $user->getId(),
+                    $date
+                ),
+                InterventionEntrepriseCanceledEvent::NAME
+            );
         }
 
         return $this->redirectToRoute('app_signalement_view', ['uuid' => $intervention->getSignalement()->getUuid()]);

--- a/src/Security/Voter/InterventionVoter.php
+++ b/src/Security/Voter/InterventionVoter.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Security\Voter;
+
+use App\Entity\Intervention;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+class InterventionVoter extends Voter
+{
+    public const SEND_ESTIMATION = 'INTERVENTION_SEND_ESTIMATION';
+    public const RESOLVE = 'INTERVENTION_RESOLVE';
+    public const STOP = 'INTERVENTION_STOP';
+
+    protected function supports(string $attribute, $subject): bool
+    {
+        return \in_array($attribute, [self::RESOLVE, self::SEND_ESTIMATION, self::STOP]) && $subject instanceof Intervention;
+    }
+
+    protected function voteOnAttribute(string $attribute, $subject, TokenInterface $token): bool
+    {
+        $user = $token->getUser();
+        if (!($user instanceof UserInterface)) {
+            return false;
+        }
+
+        if (self::RESOLVE == $attribute) {
+            return $this->canResolve($subject);
+        }
+
+        if (self::SEND_ESTIMATION == $attribute) {
+            return $this->canSendEstimation($subject);
+        }
+
+        if (self::STOP == $attribute) {
+            return $this->canStop($subject);
+        }
+
+        return false;
+    }
+
+    private function canResolve(Intervention $intervention): bool
+    {
+        $signalement = $intervention->getSignalement();
+
+        if (!$signalement->getResolvedAt()
+            && !$signalement->getClosedAt()
+            && $intervention->isAccepted()
+            && $intervention->getEstimationSentAt()
+            && !$intervention->getCanceledByEntrepriseAt()
+            && $intervention->isAcceptedByUsager()
+            && !$intervention->getResolvedByEntrepriseAt()) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private function canSendEstimation(Intervention $intervention): bool
+    {
+        if ($intervention->isAccepted()) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private function canStop(Intervention $intervention): bool
+    {
+        $signalement = $intervention->getSignalement();
+
+        if (!$signalement->getResolvedAt()
+            && !$signalement->getClosedAt()
+            && $intervention->isAccepted()
+            && $intervention->getEstimationSentAt()
+            && !$intervention->getCanceledByEntrepriseAt()
+            && ($intervention->getChoiceByEntrepriseAt() || $intervention->isAcceptedByUsager())
+            && !$signalement->getTypeIntervention()) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Security/Voter/InterventionVoter.php
+++ b/src/Security/Voter/InterventionVoter.php
@@ -3,6 +3,7 @@
 namespace App\Security\Voter;
 
 use App\Entity\Intervention;
+use App\Entity\User;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\Voter;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -34,7 +35,7 @@ class InterventionVoter extends Voter
         }
 
         if (self::STOP == $attribute) {
-            return $this->canStop($subject);
+            return $this->canStop($subject, $user);
         }
 
         return false;
@@ -66,8 +67,15 @@ class InterventionVoter extends Voter
         return false;
     }
 
-    private function canStop(Intervention $intervention): bool
+    private function canStop(Intervention $intervention, User $user): bool
     {
+        if (
+            !$user->getEntreprise()
+            || $user->getEntreprise() != $intervention->getEntreprise()
+        ) {
+            return false;
+        }
+
         $signalement = $intervention->getSignalement();
 
         if (!$signalement->getResolvedAt()

--- a/src/Security/Voter/SignalementVoter.php
+++ b/src/Security/Voter/SignalementVoter.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Security\Voter;
+
+use App\Entity\Enum\Role;
+use App\Entity\Signalement;
+use App\Repository\InterventionRepository;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+class SignalementVoter extends Voter
+{
+    public const ACCEPT = 'SIGNALEMENT_ACCEPT';
+    public const CLOSE = 'SIGNALEMENT_CLOSE';
+
+    public function __construct(
+        private Security $security,
+        private InterventionRepository $interventionRepository,
+    ) {
+    }
+
+    protected function supports(string $attribute, $subject): bool
+    {
+        return \in_array($attribute, [self::ACCEPT, self::CLOSE]) && $subject instanceof Signalement;
+    }
+
+    protected function voteOnAttribute(string $attribute, $subject, TokenInterface $token): bool
+    {
+        $user = $token->getUser();
+        if (!($user instanceof UserInterface)) {
+            return false;
+        }
+
+        if (self::ACCEPT == $attribute) {
+            return $this->canAccept($subject);
+        }
+
+        if (self::CLOSE == $attribute) {
+            return $this->canClose($subject);
+        }
+
+        return false;
+    }
+
+    private function canAccept(Signalement $signalement): bool
+    {
+        if ($this->security->isGranted(Role::ROLE_ADMIN->value)) {
+            return false;
+        }
+
+        $acceptedEstimations = $this->interventionRepository->findBy([
+            'signalement' => $signalement,
+            'acceptedByUsager' => true,
+            'canceledByEntrepriseAt' => null,
+        ]);
+        if (!$signalement->getResolvedAt()
+            && !$signalement->getClosedAt()
+            && 0 == \count($acceptedEstimations)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private function canClose(Signalement $signalement): bool
+    {
+        if ($this->security->isGranted(Role::ROLE_ADMIN->value)
+            && !$signalement->getResolvedAt()
+            && !$signalement->getClosedAt()) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/templates/signalement_view/signalement.html.twig
+++ b/templates/signalement_view/signalement.html.twig
@@ -38,26 +38,17 @@
             <div class="fr-col-12 fr-col-lg-6">
                 {% if not is_granted('ROLE_ADMIN') %}
                     {% if entrepriseIntervention and not signalement.resolvedAt and not signalement.closedAt %}
-                        {% if entrepriseIntervention.accepted and
-                            entrepriseIntervention.estimationSentAt is not null and
-                            entrepriseIntervention.acceptedByUsager and
-                            signalement.typeIntervention is null
-                        %}
+                        {% if is_granted('INTERVENTION_RESOLVE', entrepriseIntervention) %}
                             <a href="{{ path('app_signalement_treated', {'uuid': signalement.uuid }) }}" class="fr-btn fr-btn--sm fr-btn--icon-left fr-icon-check-line color-check" value="accept">Marquer comme traité</a>
                         {% endif %}
 
-                        {% if entrepriseIntervention.accepted and
-                            entrepriseIntervention.estimationSentAt is not null and
-                            not entrepriseIntervention.canceledByEntrepriseAt and
-                            (not entrepriseIntervention.choiceByUsagerAt or entrepriseIntervention.acceptedByUsager) and
-                            signalement.typeIntervention is null
-                        %}
+                        {% if is_granted('INTERVENTION_STOP', entrepriseIntervention) %}
                             <form action="{{ path('app_intervention_stop', {'id': entrepriseIntervention.id }) }}" method="POST" class="form-back-stop-intervention fr-mt-1v">
                                 <input type="hidden" name="_csrf_token" value="{{ csrf_token('intervention_stop') }}">
                                 <button type="submit" class="fr-btn fr-btn--sm fr-btn--icon-left fr-icon-close-line color-close">Clôturer le signalement</button>
                             </form>
                         {% endif %}
-                    {% elseif not signalement.resolvedAt and not signalement.closedAt and not has_other_entreprise %}
+                    {% elseif is_granted('SIGNALEMENT_ACCEPT', signalement) %}
                         <form action="{{ path('app_signalement_intervention_accept', {'uuid': signalement.uuid }) }}" method="POST">
                             <input type="hidden" name="_csrf_token" value="{{ csrf_token('signalement_intervention_accept') }}">
                             <button type="button" data-fr-opened="false" aria-controls="fr-modal-refuse-signalement" class="fr-btn fr-btn--sm fr-btn--icon-left fr-icon-close-line color-close">Refuser le signalement</button>
@@ -69,7 +60,7 @@
                     <span class="date-info">Mis à jour le <strong>{{ signalement.updatedAt.format('d/m/Y') }}</strong></span>
                 {% endif %}
 
-                {% if is_granted('ROLE_ADMIN') and not signalement.resolvedAt and not signalement.closedAt %}
+                {% if is_granted('SIGNALEMENT_CLOSE', signalement) %}
                     <form action="{{ path('app_signalement_admin_stop', {'uuid': signalement.uuid }) }}" method="POST" class="form-back-admin-close-signalement">
                         <input type="hidden" name="_csrf_token" value="{{ csrf_token('signalement_admin_stop') }}">
                         <button type="submit" class="fr-btn fr-btn--sm fr-btn--icon-left fr-icon-close-line color-close">Fermer le signalement</button>

--- a/templates/signalement_view/tab-signalement.html.twig
+++ b/templates/signalement_view/tab-signalement.html.twig
@@ -24,7 +24,7 @@
 
             {% if can_display_messages %}
                 <div class="fr-grid-row fr-grid fr-grid-row--gutters">
-                    {% if can_send_estimation %}
+                    {% if is_granted('INTERVENTION_SEND_ESTIMATION', entrepriseIntervention) %}
                         <div class="fr-col-12 fr-col-lg-6">
                             <button class="fr-btn fr-btn--icon-left fr-icon-article-line" data-fr-opened="false" aria-controls="fr-modal-send-estimation" {% if has_sent_estimation %}disabled{% endif %}>Envoyer une estimation</button>
                         </div>


### PR DESCRIPTION
## Ticket

#797    

## Description
Ajout de sécurités sur les controllers pour l'utilisation de certaines fonctionnalités

## TNR
- [ ] Entreprise : L'envoi de message aux usagers est toujours possible
- [ ] Entreprise : Il est toujours possible de marquer un signalement en cours comme traité
- [ ] Entreprise : Quand on clique sur un signalement de la liste ou historique, on peut y accéder
- [ ] Entreprise : On peut accepter un signalement
- [ ] Entreprise : On peut refuser un signalement
- [ ] Entreprise : On peut clôturer un signalement
- [ ] Admin : Quand on clique sur un signalement de la liste ou historique, on peut y accéder
- [ ] Admin : On peut fermer un signalement
