### PR TITLE
[Cartographier] Bug d'affichage

### DIFF
--- a/templates/base-back.html.twig
+++ b/templates/base-back.html.twig
@@ -30,8 +30,9 @@
             <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/leaflet.css"/>
             <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/leaflet.js"></script>
             <script src="https://cdn.jsdelivr.net/npm/leaflet.heat@0.2.0/dist/leaflet-heat.min.js"></script>
+        {% else %}
+            <script src="{{ asset('build/dsfr/dsfr.module.min.js') }}"></script>
         {% endif %}
-        <script src="{{ asset('build/dsfr/dsfr.module.min.js') }}"></script>
         {% include 'common/analytics.html.twig' %}
     </head>
     <body>


### PR DESCRIPTION
## Ticket

#807

## Description
Suppression du DSFR.js de la page map duquel on a pas besoin et qui provoque un conflit avec leaflet

## Pré-requis
`make npm-build`

## Tests
- [ ] S'assurer que l'affichage de la map fonctionne
