### PR TITLE
[BO- Signalement] Validation intervention impossible

### DIFF
--- a/assets/controllers/form_signalement.js
+++ b/assets/controllers/form_signalement.js
@@ -160,10 +160,6 @@ function checkSignalementFirstStep() {
     'Le format de l\'adresse email est incorrect.',
     false
   ) && buffer;
-
-  if (buffer && $('input#signalement_history_codeInsee').val() == '') {
-    $('input#signalement_history_codeInsee').val(0);
-  }
   
   return buffer;
 }

--- a/migrations/Version20241011145806.php
+++ b/migrations/Version20241011145806.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20241011145806 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Set code_insee to NULL when it is 0';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("UPDATE `signalement` SET `code_insee` = NULL WHERE `code_insee` = '0'");
+    }
+
+    public function down(Schema $schema): void
+    {
+    }
+}


### PR DESCRIPTION
## Ticket

#811

## Description
Suppression d'une transformation de code insee vide en "0" pour éviter erreur de validation 
Migration pour que les code insee a "0" passe a null

## Pré-requis
`make execute-migration name=Version20241011145806 direction=up`
`make npm-build`

## Tests
- [ ] Se connecter en tant qu'entreprise et marquer un signalement (sur lequel vous aurez au préalable passer le code insee a null) comme traiter. Soumettre le formulaire de traitement du signalement et vérifier qu'aucune erreur concernant le code insee n'apparait 
