### PR TITLE
[BO - Carto] Fix sur un bug de calcul de statut

### DIFF
--- a/assets/controllers/weekly_slider.js
+++ b/assets/controllers/weekly_slider.js
@@ -25,7 +25,7 @@ $( function() {
     $("#weekly-slider-selection").text(selectedDateString)
     $("input[name=filter-date]").val(selectedDateString)
     if (refreshHeatMap){
-      getMarkers(0)
+      getMarkers()
     }
   }
 } );

--- a/public/js/maps.js
+++ b/public/js/maps.js
@@ -11,37 +11,72 @@ var map = L.map('map-signalements-view', {
     maxZoom: 18,
     zoom: 6
 });
+
+map.on('zoomend', async function() {
+    const zoomLevel = map.getZoom();
+    await getMarkers();
+});
+
+map.on('moveend', async function() {
+    await getMarkers();
+});
+
 L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {crossOrigin: true}).addTo(map);
+let abortController;
 var heat;
 
-async function getMarkers(offset) {
-    const response = await fetch('?load_markers=true&offset=' + offset, {
-        headers: {
-            'X-TOKEN': document.querySelector('#carto__js').getAttribute('data-token')
-        },
-        method: 'POST',
-        body: new FormData(document.querySelector('form#bo_carto_filter'))
-    });
-    const result = await response.json();
-    if (heat){
-        heat.remove();
+async function getMarkers() {
+    if (abortController) {
+        abortController.abort();
     }
-    if (result.signalements) {  
-        const heatValues = [];
-        result.signalements.forEach(signalement => {      
-            if (!isNaN(parseFloat(signalement.geoloc?.lng)) && !isNaN(parseFloat(signalement.geoloc?.lat))) {  
-                // pour l'instant on ne prend pas en compte le niveauInfestation
-                // on n'affiche pas les signalements au statut resolved
-                if ('trace' === signalement.statut){
-                    heatValues.push([signalement.geoloc.lat, signalement.geoloc.lng, 0.5]);
-                }  
-                if ('en cours' === signalement.statut){
-                    heatValues.push([signalement.geoloc.lat, signalement.geoloc.lng, 1]);
-                }         
-            }
-        })
-        heat = L.heatLayer(heatValues, {maxZoom:15}).addTo(map);
-    } else {
-        alert('Erreur lors du chargement des signalements...')
+    abortController = new AbortController();
+
+    try {
+        const bounds = map.getBounds();
+        const southWest = bounds.getSouthWest();
+        const northEast = bounds.getNorthEast();
+        const formData = new FormData(document.querySelector('form#bo_carto_filter'));
+        formData.append('swLat', southWest.lat);
+        formData.append('swLng', southWest.lng);
+        formData.append('neLat', northEast.lat);
+        formData.append('neLng', northEast.lng);
+
+        const response = await fetch('?load_markers=true', {
+            headers: {
+                'X-TOKEN': document.querySelector('#carto__js').getAttribute('data-token')
+            },
+            method: 'POST',
+            body: formData,
+            signal: abortController.signal // Passer le signal d'annulation
+        });
+        const result = await response.json();
+        if (heat){
+            heat.remove();
+        }
+        if (result.signalements) {  
+            const heatValues = [];
+            result.signalements.forEach(signalement => {     
+                const geoloc = JSON.parse(signalement.geoloc);  
+                if (!isNaN(parseFloat(geoloc?.lng)) && !isNaN(parseFloat(geoloc?.lat))) {  
+                    // pour l'instant on ne prend pas en compte le niveauInfestation
+                    // on n'affiche pas les signalements au statut resolved
+                    if ('trace' === signalement.statut){
+                        heatValues.push([geoloc.lat, geoloc.lng, 0.5]);
+                    }  
+                    if ('en cours' === signalement.statut){
+                        heatValues.push([geoloc.lat, geoloc.lng, 1]);
+                    }         
+                }
+            })
+            heat = L.heatLayer(heatValues, {maxZoom:15}).addTo(map);
+        } else {
+            alert('Erreur lors du chargement des signalements...')
+        }
+    } catch (error) {
+        if (error.name === 'AbortError') {
+            console.log('Requête annulée');
+        } else {
+            console.error('Erreur lors de l\'analyse du JSON:', error);
+        }
     }
 }

--- a/src/Controller/CartographieController.php
+++ b/src/Controller/CartographieController.php
@@ -23,9 +23,17 @@ class CartographieController extends AbstractController
             } else {
                 $date = new \DateTimeImmutable();
             }
+            $swLat = $request->get('swLat');
+            $swLng = $request->get('swLng');
+            $neLat = $request->get('neLat');
+            $neLng = $request->get('neLng');
+
             $signalements = $signalementRepository->findAllWithGeoData(
                 $date,
-                (int) $request->get('offset')
+                $swLat,
+                $swLng,
+                $neLat,
+                $neLng
             );
 
             return $this->json(

--- a/src/Controller/CartographieController.php
+++ b/src/Controller/CartographieController.php
@@ -2,6 +2,7 @@
 
 namespace App\Controller;
 
+use App\Dto\CartographieRequest;
 use App\Repository\SignalementRepository;
 use App\Service\Signalement\CartoStatutCalculator;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -23,18 +24,15 @@ class CartographieController extends AbstractController
             } else {
                 $date = new \DateTimeImmutable();
             }
-            $swLat = $request->get('swLat');
-            $swLng = $request->get('swLng');
-            $neLat = $request->get('neLat');
-            $neLng = $request->get('neLng');
-
-            $signalements = $signalementRepository->findAllWithGeoData(
+            $cartoRequest = new CartographieRequest(
+                $request->get('swLat'),
+                $request->get('swLng'),
+                $request->get('neLat'),
+                $request->get('neLng'),
                 $date,
-                $swLat,
-                $swLng,
-                $neLat,
-                $neLng
             );
+
+            $signalements = $signalementRepository->findAllWithGeoData($cartoRequest);
 
             return $this->json(
                 [

--- a/src/Dto/CartographieRequest.php
+++ b/src/Dto/CartographieRequest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Dto;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+class CartographieRequest
+{
+    #[Assert\NotBlank]
+    public readonly \DateTimeImmutable $date;
+
+    #[Assert\NotBlank]
+    public readonly float $swLat;
+
+    #[Assert\NotBlank]
+    public readonly float $swLng;
+
+    #[Assert\NotBlank]
+    public readonly float $neLat;
+
+    #[Assert\NotBlank]
+    public readonly float $neLng;
+
+    public function __construct(
+        float $swLat,
+        float $swLng,
+        float $neLat,
+        float $neLng,
+        \DateTimeImmutable $date,
+    ) {
+        $this->swLat = $swLat;
+        $this->swLng = $swLng;
+        $this->neLat = $neLat;
+        $this->neLng = $neLng;
+        $this->date = $date;
+    }
+
+    public function getDate(): string
+    {
+        return $this->date->format('Y-m-d H:i:s');
+    }
+
+    public function getSwLat(): float
+    {
+        return $this->swLat;
+    }
+
+    public function getSwLng(): float
+    {
+        return $this->swLng;
+    }
+
+    public function getNeLat(): float
+    {
+        return $this->neLat;
+    }
+
+    public function getNeLng(): float
+    {
+        return $this->neLng;
+    }
+}

--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -2,6 +2,7 @@
 
 namespace App\Repository;
 
+use App\Dto\CartographieRequest;
 use App\Dto\SignalementOccupantDataTableFilters;
 use App\Entity\Entreprise;
 use App\Entity\Enum\Declarant;
@@ -25,7 +26,7 @@ class SignalementRepository extends ServiceEntityRepository
 {
     private const NB_DAYS_BEFORE_NOTIFYING = 45;
     private const NB_DAYS_BEFORE_CLOSING_AUTOTRAITEMENT = 45;
-    public const MARKERS_PAGE_SIZE = 6000; // @todo: is high cause duplicate result, the query findAllWithGeoData should be reviewed
+    public const MARKERS_PAGE_SIZE = 5000;
 
     public function __construct(ManagerRegistry $registry)
     {
@@ -472,11 +473,7 @@ class SignalementRepository extends ServiceEntityRepository
     }
 
     public function findAllWithGeoData(
-        \DateTimeImmutable $date,
-        float $swLat,
-        float $swLng,
-        float $neLat,
-        float $neLng,
+        CartographieRequest $cartoRequest,
     ): array {
         $conn = $this->getEntityManager()->getConnection();
         $limit = self::MARKERS_PAGE_SIZE;
@@ -493,11 +490,11 @@ class SignalementRepository extends ServiceEntityRepository
         ";
 
         $resultSet = $conn->executeQuery($sql, [
-            'date' => $date->format('Y-m-d H:i:s'),
-            'swLat' => $swLat,
-            'neLat' => $neLat,
-            'swLng' => $swLng,
-            'neLng' => $neLng,
+            'date' => $cartoRequest->getDate(),
+            'swLat' => $cartoRequest->getSwLat(),
+            'neLat' => $cartoRequest->getNeLat(),
+            'swLng' => $cartoRequest->getSwLng(),
+            'neLng' => $cartoRequest->getNeLng(),
         ]);
 
         return $resultSet->fetchAllAssociative();

--- a/src/Service/Signalement/CartoStatutCalculator.php
+++ b/src/Service/Signalement/CartoStatutCalculator.php
@@ -13,17 +13,19 @@ class CartoStatutCalculator
         $signalementsStatues = [];
         foreach ($signalements as $signalement) {
             $date4monthsAgo = $date->modify('-4 month');
-            if (null !== $signalement['resolvedAt'] && $signalement['resolvedAt'] < $date) {
+            $dateResolvedAt = new \DateTimeImmutable($signalement['resolved_at']);
+            $dateClosedAt = new \DateTimeImmutable($signalement['closed_at']);
+            $dateCreatedAt = new \DateTimeImmutable($signalement['created_at']);
+            if (null !== $dateResolvedAt && $dateResolvedAt < $date) {
                 $statut = 'resolved';
-            } elseif (null !== $signalement['closedAt'] && $signalement['closedAt'] < $date4monthsAgo) {
+            } elseif (null !== $dateClosedAt && $dateClosedAt < $date4monthsAgo) {
                 $statut = 'resolved';
-            } elseif (false === $signalement['active'] && $signalement['createdAt'] < $date4monthsAgo) {
+            } elseif ($dateCreatedAt < $date4monthsAgo) {
                 $statut = 'resolved';
-            } elseif (null !== $signalement['closedAt']
-                    && $signalement['closedAt'] > $date4monthsAgo && $signalement['closedAt'] < $date) {
+            } elseif (null !== $dateClosedAt
+                    && $dateClosedAt > $date4monthsAgo && $dateClosedAt < $date) {
                 $statut = 'trace';
-            } elseif (false === $signalement['active']
-                    && $signalement['createdAt'] > $date4monthsAgo && $signalement['createdAt'] < $date) {
+            } elseif ($dateCreatedAt > $date4monthsAgo && $dateCreatedAt < $date) {
                 $statut = 'trace';
             } else {
                 $statut = 'en cours';


### PR DESCRIPTION
## Ticket

#810   

## Description
Il y avait un bug sur le calcul du statut resolved pour les signalements créés il y a plus de 4 mois, le statut n'était calculé que pour les signalements de territoires fermés, or il n'y a plus de territoires fermés
Mais pour identifier la cause du bug, j'ai fait une refacto pour ne charger les signalements que pour la zone de la carte affichée à l'écran (et pas pour les 9000 max signalements)

## Changements apportés
* Appel de la requête à chaque changement de visialisation de la carte (zoom ou déplacement)
* Annulation d'une éventuelle requêete non-finie précédente
* Modification de la requête pour calculer la geoloc
* Modification du calcul du statut pour ne plus prendre en compte l'ouverture du territoire

## Pré-requis
`npm run build`

## Tests
- [ ] Bosser sur une base de prod pour mieux voir
- [ ] Vérifier que les points s'affichent, et se rechargent à chaque zoom / déplacement / slide du curseur
- [ ] Vérifier que les requêtes annulent les précédentes en cours (mais c'est long quand même)
- [ ] Se placer sur Nice et bouger le slider temporel
- [ ] Vérifier que passé le 15 octobre il n'y a plus beaucoup de signalements (car presque tous créés le 15 juin)
