### PR TITLE
[QA] Data too long for column 'nom_biocide'

### DIFF
--- a/src/Controller/SignalementCreateController.php
+++ b/src/Controller/SignalementCreateController.php
@@ -31,8 +31,7 @@ class SignalementCreateController extends AbstractController
         $signalement = new Signalement();
         $form = $this->createForm(
             SignalementHistoryType::class,
-            $signalement,
-            ['validation_groups' => 'back_add_signalement_logement']
+            $signalement
         );
         $form->handleRequest($request);
 

--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -123,6 +123,7 @@ class Signalement
     private ?array $typeTraitement = null;
 
     #[ORM\Column(length: 50, nullable: true)]
+    #[Assert\Length(max: 50, maxMessage: 'Le nom du biocide doit contenir au maximum 50 caractères.')]
     private ?string $nomBiocide = null;
 
     #[ORM\Column(length: 50, nullable: true)]

--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -142,6 +142,8 @@ class Signalement
     private ?\DateTimeInterface $dateVisitePostTraitement = null;
 
     #[ORM\Column(nullable: true)]
+    #[Assert\Positive()]
+    #[Assert\Type(type: 'integer')]
     private ?int $prixFactureHT = null;
 
     #[ORM\ManyToOne(inversedBy: 'signalements')]

--- a/src/Form/SignalementHistoryType.php
+++ b/src/Form/SignalementHistoryType.php
@@ -19,7 +19,6 @@ use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\Extension\Core\Type\EnumType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
-use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\TelType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -400,7 +399,7 @@ class SignalementHistoryType extends AbstractType
                 'label' => 'Date de la visite post-traitement',
                 'required' => false,
             ])
-            ->add('prixFactureHT', NumberType::class, [
+            ->add('prixFactureHT', IntegerType::class, [
                 'attr' => [
                     'class' => 'fr-input',
                     'maxlength' => '100',
@@ -409,7 +408,7 @@ class SignalementHistoryType extends AbstractType
                     'class' => 'fr-label',
                 ],
                 'label' => 'Prix facturé (en €)',
-                'help' => 'Le prix facturé doit être un nombre supérieur à 0.',
+                'help' => 'Le prix facturé doit être un nombre entier supérieur à 0.',
                 'help_attr' => [
                     'class' => 'fr-hint-text',
                 ],
@@ -420,6 +419,9 @@ class SignalementHistoryType extends AbstractType
                     new Assert\Positive(
                         message: 'Le prix facturé doit être un nombre supérieur à 0.'
                     ),
+                    new Assert\Type(
+                        type: 'integer',
+                        message: 'Le prix facturé {{ value }} n\'est pas un entier valide.', ),
                 ],
             ])
         ;

--- a/src/Form/SignalementHistoryType.php
+++ b/src/Form/SignalementHistoryType.php
@@ -311,12 +311,16 @@ class SignalementHistoryType extends AbstractType
             ->add('nomBiocide', TextType::class, [
                 'attr' => [
                     'class' => 'fr-input',
-                    'maxlength' => '100',
+                    'maxlength' => '50',
                 ],
                 'label_attr' => [
                     'class' => 'fr-label',
                 ],
                 'label' => 'Nom du biocide',
+                'help' => 'Format attendu : 50 caractères maximum',
+                'help_attr' => [
+                    'class' => 'fr-hint-text',
+                ],
                 'required' => false,
             ])
             ->add('typeDiagnostic', ChoiceType::class, [

--- a/templates/common/components/macro-forms.html.twig
+++ b/templates/common/components/macro-forms.html.twig
@@ -1,103 +1,80 @@
 
 {% macro input(form_view, error_text, help = false) %}
-    {% if form_errors(form_view) %}
-        <div class="fr-input-group fr-input-group--error">
-            {{ form_label(form_view) }}
-            {{ form_widget(form_view, { 'attr': {
-                'aria-describedby': form_view.vars.id ~ '-error',
-                'title': error_text,
-                'data-error': error_text,
-                'data-error-id': form_view.vars.id ~ '-error'
-            } }) }}
-            <div id="{{ form_view.vars.id }}-error" class="fr-error-text fr-mt-1v">
-                {{ form_errors(form_view) }}
-            </div>
+    {% set has_error = form_errors(form_view) %}
+    <div class="fr-input-group{% if has_error %} fr-input-group--error{% endif %}">
+        {{ form_label(form_view) }}
+        
+        {% if help %}
+            {{ form_help(form_view) }}
+        {% endif %}
+        
+        {{ form_widget(form_view, { 'attr': {
+            'aria-describedby': has_error ? (form_view.vars.id ~ '-error') : null,
+            'title': error_text,
+            'data-error': error_text,
+            'data-error-id': form_view.vars.id ~ '-error'
+        } }) }}
+        
+        <div id="{{ form_view.vars.id }}-error" class="fr-error-text{% if has_error %} fr-mt-1v{% else %} fr-hidden{% endif %}">
+            {{ has_error ? form_errors(form_view) : error_text }}
         </div>
-    {% else %}
-        <div class="fr-input-group">
-            {{ form_label(form_view) }}
-            {{ form_widget(form_view, { 'attr': {
-                'title': error_text,
-                'data-error': error_text,
-                'data-error-id': form_view.vars.id ~ '-error'
-            } }) }}
-            <p id="{{ form_view.vars.id }}-error" class="fr-error-text fr-hidden">
-                {{ error_text}}
-            </p>
-        </div>
-    {% endif %}
+    </div>
 {% endmacro %}
 
 {% macro select(form_view, error_text, help = false) %}
-    {% if form_errors(form_view) %}
-        <div class="fr-select-group fr-select-group--error">
-            {{ form_label(form_view) }}
-            {{ form_widget(form_view, { 'attr': {
-                'aria-describedby': form_view.vars.id ~ '-error',
-                'title': error_text,
-                'data-error': error_text,
-                'data-error-id': form_view.vars.id ~ '-error'
-            } }) }}
-            <div id="{{ form_view.vars.id }}-error" class="fr-error-text fr-mt-1v">
-                {{ form_errors(form_view) }}
-            </div>
+    {% set has_error = form_errors(form_view) %}
+    <div class="fr-select-group{% if has_error %}  fr-select-group--error{% endif %}">
+        {{ form_label(form_view) }}
+        {% if help %}
+            {{ form_help(form_view) }}                
+        {% endif %}
+        {{ form_widget(form_view, { 'attr': {
+            'aria-describedby': has_error ? (form_view.vars.id ~ '-error') : null,
+            'title': error_text,
+            'data-error': error_text,
+            'data-error-id': form_view.vars.id ~ '-error'
+        } }) }}
+        
+        <div id="{{ form_view.vars.id }}-error" class="fr-error-text{% if has_error %} fr-mt-1v{% else %} fr-hidden{% endif %}">
+            {{ has_error ? form_errors(form_view) : error_text }}
         </div>
-    {% else %}
-        <div class="fr-select-group">
-            {{ form_label(form_view) }}
-            {{ form_widget(form_view, { 'attr': {
-                'title': error_text,
-                'data-error': error_text,
-                'data-error-id': form_view.vars.id ~ '-error'
-            } }) }}
-            <p id="{{ form_view.vars.id }}-error" class="fr-error-text fr-hidden">
-                {{ error_text}}
-            </p>
-        </div>
-    {% endif %}
+    </div>
 {% endmacro %}
 
 
 {% macro radio_choice(form_view, error_text, help = false, displayLabel = true) %}
-    {% if form_errors(form_view) %}
-        <fieldset class="fr-fieldset fr-fieldset--error" role="group" id="{{ form_view.vars.id }}" aria-labelledby="{{ form_view.vars.id }}_legend">
+    {% set has_error = form_errors(form_view) %}
+        <fieldset 
+            class="fr-fieldset{% if has_error %} fr-fieldset--error{% endif %}" 
+            role="group" id="{{ form_view.vars.id }}"
+            aria-labelledby="{{ form_view.vars.id }}_legend"
+        >
             <legend class="fr-fieldset__legend fr-fieldset__legend--regular" id="{{ form_view.vars.id }}_legend">
                 {% if displayLabel %}
                     {{ form_label(form_view) }}
                 {% endif %}
             </legend>
+            {% if help %}
+                {{ form_help(form_view) }}                
+            {% endif %}
             {% for key, choice in form_view.children %}
                 <div class="fr-fieldset__element">
                     <div class="fr-radio-group">
                         {{ form_widget(choice, { 'attr': {
-                            'aria-describedby': form_view.vars.id ~ '-error'
+                            'aria-describedby': has_error ? (form_view.vars.id ~ '-error') : null
                         } }) }}
                         {{ form_label(choice) }}
                     </div>
                 </div>
             {% endfor %}
+            {% if has_error %}
                 <div id="{{ form_view.vars.id }}-error" class="fr-messages-group fr-error-text fr-mt-1v">
                     {{ form_errors(form_view) }}
                 </div>
-        </fieldset>
-    {% else %}
-        <fieldset class="fr-fieldset" role="group" id="{{ form_view.vars.id }}" aria-labelledby="{{ form_view.vars.id }}_legend">
-            <legend class="fr-fieldset__legend fr-fieldset__legend--regular"  id="{{ form_view.vars.id }}_legend">
-                {% if displayLabel %}
-                    {{ form_label(form_view) }}
-                {% endif %}
-            </legend>
-            {% for key, choice in form_view.children %}
-                <div class="fr-fieldset__element">
-                    <div class="fr-radio-group">
-                        {{ form_widget(choice) }}
-                        {{ form_label(choice) }}
-                    </div>
-                </div>
-            {% endfor %}
+            {% else %}
                 <p id="{{ form_view.vars.id }}-error" class="fr-error-text fr-hidden">
                     {{ error_text}}
                 </p>
+            {% endif %}
         </fieldset>
-    {% endif %}
 {% endmacro %}

--- a/templates/common/components/macro-forms.html.twig
+++ b/templates/common/components/macro-forms.html.twig
@@ -4,10 +4,6 @@
     <div class="fr-input-group{% if has_error %} fr-input-group--error{% endif %}">
         {{ form_label(form_view) }}
         
-        {% if help %}
-            {{ form_help(form_view) }}
-        {% endif %}
-        
         {{ form_widget(form_view, { 'attr': {
             'aria-describedby': has_error ? (form_view.vars.id ~ '-error') : null,
             'title': error_text,
@@ -25,9 +21,7 @@
     {% set has_error = form_errors(form_view) %}
     <div class="fr-select-group{% if has_error %}  fr-select-group--error{% endif %}">
         {{ form_label(form_view) }}
-        {% if help %}
-            {{ form_help(form_view) }}                
-        {% endif %}
+
         {{ form_widget(form_view, { 'attr': {
             'aria-describedby': has_error ? (form_view.vars.id ~ '-error') : null,
             'title': error_text,
@@ -54,9 +48,7 @@
                     {{ form_label(form_view) }}
                 {% endif %}
             </legend>
-            {% if help %}
-                {{ form_help(form_view) }}                
-            {% endif %}
+
             {% for key, choice in form_view.children %}
                 <div class="fr-fieldset__element">
                     <div class="fr-radio-group">

--- a/templates/entreprise_list/modal-create-entreprise.html.twig
+++ b/templates/entreprise_list/modal-create-entreprise.html.twig
@@ -10,6 +10,8 @@
                         <h1 id="fr-modal-title-modal-create-entreprise" class="fr-modal__title"><span class="fr-fi-arrow-right-line fr-fi--lg"></span>Créer une entreprise</h1>
                         <p>Remplissez le formulaire ci-dessous pour ajouter une entreprise.</p>
                         {% import "common/components/macro-forms.html.twig" as forms %}
+                        {% use 'common/form/custom_theme.html.twig' %}
+                        {% form_theme form 'common/form/custom_theme.html.twig' %}
 
                         <form action="{{ path('app_entreprise_list') }}" method="POST" class="fr-my-5w">
                             {{ form_row(form._token) }}

--- a/templates/entreprise_view/modal-create-employe.html.twig
+++ b/templates/entreprise_view/modal-create-employe.html.twig
@@ -10,6 +10,8 @@
                         <h1 id="fr-modal-title-modal-create-employe" class="fr-modal__title"><span class="fr-fi-arrow-right-line fr-fi--lg"></span>Ajouter un employé</h1>
                         <p>Remplissez le formulaire ci-dessous pour ajouter un employé.</p>
                         {% import "common/components/macro-forms.html.twig" as forms %}
+                        {% use 'common/form/custom_theme.html.twig' %}
+                        {% form_theme formCreateEmploye 'common/form/custom_theme.html.twig' %}
 
                         <form action="{{ path('app_entreprise_view',{uuid:entreprise.uuid}) }}" method="POST" class="fr-my-5w">
                             {{ form_row(formCreateEmploye._token) }}

--- a/templates/front/contact.html.twig
+++ b/templates/front/contact.html.twig
@@ -4,6 +4,8 @@
 
 {% block body %}
     {% import "common/components/macro-forms.html.twig" as forms %}
+    {% use 'common/form/custom_theme.html.twig' %}
+    {% form_theme form 'common/form/custom_theme.html.twig' %}
     <div id="contact-container" class="fr-container--fluid fr-py-5w fr-py-md-10w">
     
         {% for label, messages in app.flashes %}

--- a/templates/front_signalement/_partial_step_info_locataire.html.twig
+++ b/templates/front_signalement/_partial_step_info_locataire.html.twig
@@ -2,6 +2,8 @@
 
 {% block content %}
     {% import "common/components/macro-forms.html.twig" as forms %}
+    {% use 'common/form/custom_theme.html.twig' %}
+    {% form_theme form 'common/form/custom_theme.html.twig' %}
     <div class="fr-stepper">
         <h1 class="fr-stepper__title fr-h2">
             Informations du logement
@@ -16,7 +18,7 @@
     {{ forms.radio_choice(form.locataire, 'Veuillez renseigner si vous êtes propriétaire ou locataire.') }}
 
     <div id="form-group-nomProprietaire" class="fr-form-group">
-        {{ forms.input(form.nomProprietaire, 'Veuillez renseigner le nom du bailleur / propriétaire..') }}
+        {{ forms.input(form.nomProprietaire, 'Veuillez renseigner le nom du bailleur / propriétaire.') }}
     </div>
 
     {{ forms.radio_choice(form.logementSocial, 'Veuillez renseigner si vous vivez dans un logement social.') }}

--- a/templates/front_signalement/_partial_step_info_logement.html.twig
+++ b/templates/front_signalement/_partial_step_info_logement.html.twig
@@ -35,13 +35,12 @@
             </label>
             <div class="fr-input-wrap fr-icon-map-pin-2-line">
                 <input id="rechercheAdresse"
-                       type="text"
-                       class="fr-input"
-                       autocomplete="street"
-                       aria-controls="rechercheAdresseListe"
-                       aria-autocomplete="list"
-                       role="combobox"
-
+                    type="text"
+                    class="fr-input"
+                    autocomplete="street"
+                    aria-controls="rechercheAdresseListe"
+                    aria-autocomplete="list"
+                    role="combobox"
                 >
                 <p id="rechercheAdresse-error" class="fr-error-text fr-hidden">
                     Veuillez renseigner et sélectionner l'adresse de votre logement.

--- a/templates/front_signalement/_partial_step_info_problemes.html.twig
+++ b/templates/front_signalement/_partial_step_info_problemes.html.twig
@@ -2,6 +2,8 @@
 
 {% block content %}
     {% import "common/components/macro-forms.html.twig" as forms %}
+    {% use 'common/form/custom_theme.html.twig' %}
+    {% form_theme form 'common/form/custom_theme.html.twig' %}
     <div class="fr-stepper">
         <h1 class="fr-stepper__title fr-h2">
             Durée de l'infestation

--- a/templates/front_signalement/_partial_step_info_usager.html.twig
+++ b/templates/front_signalement/_partial_step_info_usager.html.twig
@@ -2,6 +2,8 @@
 
 {% block content %}
     {% import "common/components/macro-forms.html.twig" as forms %}
+    {% use 'common/form/custom_theme.html.twig' %}
+    {% form_theme form 'common/form/custom_theme.html.twig' %}
     <div class="if-territory-open">
         <div class="fr-stepper">
             <h1 class="fr-stepper__title fr-h2">
@@ -25,7 +27,7 @@
         {{ form_widget(form.niveauInfestation) }}
     </div>
 
-    <div class="if-territory-not-open">
+    <div class="if-territory-not-open">Renseignez vos coordonnées
         <h1 class="fr-h2">Stop punaises</h1>
 
         <p>

--- a/templates/front_signalement/_partial_step_traces_punaises_piqures.html.twig
+++ b/templates/front_signalement/_partial_step_traces_punaises_piqures.html.twig
@@ -2,6 +2,8 @@
 
 {% block content %}
     {% import "common/components/macro-forms.html.twig" as forms %}
+    {% use 'common/form/custom_theme.html.twig' %}
+    {% form_theme form 'common/form/custom_theme.html.twig' %}
     <div class="fr-stepper">
         <h1 class="fr-stepper__title fr-h2">
             Les traces de punaises

--- a/templates/front_signalement_erp/index.html.twig
+++ b/templates/front_signalement_erp/index.html.twig
@@ -4,6 +4,8 @@
 
 {% block body %}
 {% import "common/components/macro-forms.html.twig" as forms %}
+{% use 'common/form/custom_theme.html.twig' %}
+{% form_theme form 'common/form/custom_theme.html.twig' %}
 
     <div class="signalement-punaises fr-grid-row fr-grid-row--center">
         <div class="fr-col-12 fr-col-md-8 fr-col-md-6">

--- a/templates/front_signalement_transport/index.html.twig
+++ b/templates/front_signalement_transport/index.html.twig
@@ -4,6 +4,8 @@
 
 {% block body %}
 {% import "common/components/macro-forms.html.twig" as forms %}
+{% use 'common/form/custom_theme.html.twig' %}
+{% form_theme form 'common/form/custom_theme.html.twig' %}
 
     <div class="signalement-punaises fr-grid-row fr-grid-row--center">
         <div class="fr-col-12 fr-col-md-8 fr-col-md-6">

--- a/templates/signalement_create/tab-1.html.twig
+++ b/templates/signalement_create/tab-1.html.twig
@@ -1,4 +1,6 @@
 {% import "common/components/macro-forms.html.twig" as forms %}
+{% use 'common/form/custom_theme.html.twig' %}
+{% form_theme form 'common/form/custom_theme.html.twig' %}
 
 <div class="fr-stepper">
     <h2 class="fr-stepper__title fr-h2">

--- a/templates/signalement_create/tab-2.html.twig
+++ b/templates/signalement_create/tab-2.html.twig
@@ -44,7 +44,7 @@
         </div>
 
         <div class="fr-form-group display-if-traitement display-if-biocide fr-mt-3v">
-            {{ forms.input(form.nomBiocide, 'Veuillez renseigner le nom du Biocide.') }}
+            {{ forms.input(form.nomBiocide, 'Veuillez renseigner le nom du Biocide.', true) }}
         </div>
 
         <div class="fr-form-group display-if-diagnostic fr-mt-3v">

--- a/templates/signalement_create/tab-2.html.twig
+++ b/templates/signalement_create/tab-2.html.twig
@@ -70,7 +70,7 @@
         </div>
 
         <div class="fr-form-group display-if-diagnostic display-if-traitement fr-mt-3v">
-            {{ forms.input(form.prixFactureHT, 'Veuillez renseigner le prix facturé.') }}
+            {{ forms.input(form.prixFactureHT, 'Veuillez renseigner le prix facturé.', true) }}
         </div>
     </div>
 </div>

--- a/templates/signalement_create/tab-2.html.twig
+++ b/templates/signalement_create/tab-2.html.twig
@@ -1,4 +1,6 @@
 {% import "common/components/macro-forms.html.twig" as forms %}
+{% use 'common/form/custom_theme.html.twig' %}
+{% form_theme form 'common/form/custom_theme.html.twig' %}
 
 <div class="fr-stepper">
     <h2 class="fr-stepper__title fr-h2">

--- a/tests/Functional/Controller/SignalementControllerTest.php
+++ b/tests/Functional/Controller/SignalementControllerTest.php
@@ -45,7 +45,7 @@ class SignalementControllerTest extends WebTestCase
                 'nombrePiecesTraitees' => '',
                 'delaiEntreInterventions' => '',
                 'dateVisitePostTraitement' => '',
-                'prixFactureHT' => '555',
+                'prixFactureHT' => 555,
             ],
         ];
 


### PR DESCRIPTION
## Ticket

#816    
#813 

## Description
Ajout d'une contrainte de longueur sur le nom du biocide, et sur le nombre entier du prix facturé

## Changements apportés
* Suppression des validation_groups dans SignalementCreateController (car écrase celui du FormType)
* Ajout d'une contrainte de longueur sur le nom du biocide dans l'entité
* Changement de la longueur dans le nom du biocide dans le formType et ajout d'un texte d'aide
* Changement du type dans le formType pour prix facturé
* modification du twig de la macro :  factorisation du code
* utilisation de `common/form/custom_theme.html.twig` là où on utilise la macro pour afficher les textes d'aide (cf commit https://github.com/MTES-MCT/stop-punaises/commit/4ea951c9455370ae7843a834f15e64895b76fcdd)

## Pré-requis

## Tests
- [ ] Créer un signalement historique, et vérifier qu'on ne peut pas mettre un nom de biocide supérieur à 50 caractères, ni de float pour le prix facturé
- [ ] TNR : Créer un signalement historique dans le BO, vérifier l'affichage des textes d'aide
- [ ] TNR : Créer une entreprise dans le BO, vérifier l'affichage des textes d'aide
- [ ] TNR : Créer un utilisateur dans une entreprise dans le BO, vérifier l'affichage des textes d'aide
- [ ] TNR : Utiliser le formulaire de contact dans le FO, vérifier l'affichage des textes d'aide
- [ ] TNR : Déposer un signalement dans le FO, vérifier l'affichage des textes d'aide
- [ ] TNR : Déposer un signalement ERP dans le FO, vérifier l'affichage des textes d'aide
- [ ] TNR : Déposer un signalement TRANSPORT dans le FO, vérifier l'affichage des textes d'aide
