### PR TITLE
[FO] Validation bloquante sur auto-traitement parc public

### DIFF
--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -84,7 +84,7 @@ class Signalement
 
     #[ORM\Column(length: 20, nullable: true)]
     #[Assert\When(
-        expression: 'this.isAutotraitement() == false',
+        expression: 'this.isAutotraitement() == false and this.isLogementSocial() == false',
         constraints: [
             new Assert\NotBlank(
                 message: 'Veuillez renseigner votre numéro de téléphone.'

--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -83,13 +83,18 @@ class Signalement
     private ?string $prenomOccupant = null;
 
     #[ORM\Column(length: 20, nullable: true)]
-    #[Assert\Regex(
-        pattern: '/^(?:0|\(?\+33\)?\s?|0033\s?)[1-9](?:[\.\-\s]?\d\d){4}$/',
-        match: true,
-        message: 'Merci de saisir le numéro de téléphone au bon format'
-    )]
-    #[Assert\NotBlank(
-        message: 'Veuillez renseigner votre numéro de téléphone.',
+    #[Assert\When(
+        expression: 'this.isAutotraitement() == false',
+        constraints: [
+            new Assert\NotBlank(
+                message: 'Veuillez renseigner votre numéro de téléphone.'
+            ),
+            new Assert\Regex(
+                pattern: '/^(?:0|\(?\+33\)?\s?|0033\s?)[1-9](?:[\.\-\s]?\d\d){4}$/',
+                message: 'Merci de saisir le numéro de téléphone au bon format',
+                match: true
+            ),
+        ],
         groups: ['front_add_signalement_logement']
     )]
     private ?string $telephoneOccupant = null;
@@ -107,14 +112,18 @@ class Signalement
     private ?\DateTimeInterface $dateIntervention = null;
 
     #[ORM\Column(type: Types::SMALLINT, nullable: true)]
-    #[Assert\Range(
-        min: 0,
-        max: 4,
-        notInRangeMessage: 'Le niveau d\'infestation doit être compris entre 1 et 4.',
-        groups: ['front_add_signalement_logement']
-    )]
-    #[Assert\NotBlank(
-        message: 'Veuillez renseigner un niveau d\'infestation.',
+    #[Assert\When(
+        expression: 'this.isAutotraitement() == false',
+        constraints: [
+            new Assert\Range(
+                notInRangeMessage: 'Le niveau d\'infestation doit être compris entre 1 et 4.',
+                min: 0,
+                max: 4
+            ),
+            new Assert\NotBlank(
+                message: 'Veuillez renseigner un niveau d\'infestation.'
+            ),
+        ],
         groups: ['front_add_signalement_logement']
     )]
     private ?int $niveauInfestation = null;


### PR DESCRIPTION
## Ticket

#863    

## Description
Validation appliqué sur le niveau infestation et le téléphone occupant lors d'une soumission avec auto-traitement
Pour info le téléphone occupant n'est pas demandé.

## Changements apportés
* Ajout de contrainte conditionnelle sur téléphoneOccupant (pas demandé dans le formulaire) et niveau d'infestation 

## Pré-requis

## Tests
- [ ] Soumette un signalement parc public et valider l'auto-traitement
### TNR
- [ ] Soumettre un signalement et valider que les différentes soumission fonctionne en fin de parcours