### PR TITLE
[BO - Cartographie] Ajout d'un referrer pour leaflet

### DIFF
--- a/public/js/maps.js
+++ b/public/js/maps.js
@@ -16,7 +16,7 @@ map.on('moveend', async function() {
     await getMarkers();
 });
 
-L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {crossOrigin: true}).addTo(map);
+L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {crossOrigin: true, referrerPolicy: "origin"}).addTo(map);
 let abortController;
 var heat;
 


### PR DESCRIPTION
## Ticket

#872   

## Description
Ajout de l'option `referrerPolicy: "origin"` sur la carte afin d'éviter l'erreur "Refrer is required"

## Pré-requis
`make npm-watch`

## Tests
- [ ] Tester l'affichage de la carte de l'application
